### PR TITLE
chore: release 0.2.1 (default exports + minified dist)

### DIFF
--- a/.changeset/stackblitz-default-export.md
+++ b/.changeset/stackblitz-default-export.md
@@ -1,0 +1,10 @@
+---
+"@microcharts/react": patch
+---
+
+Fix subpath resolution on StackBlitz and some CDNs. Every export now includes a
+`default` condition alongside `import`, so imports like
+`@microcharts/react/sparkline/interactive` resolve on loose resolvers that don't
+request the `import` condition (they previously failed with "file does not
+exist"). Also ship a **minified** dist — smaller install, and correct bytes for
+consumers that import the ESM directly (Deno, CDNs). No API changes.


### PR DESCRIPTION
Adds the changeset that cuts **0.2.1** — publishing the fixes already merged to main to npm.

**0.2.1 (patch):**
- **Fix** subpath resolution on StackBlitz / some CDNs — every export now has a `default` condition (#18).
- **Minified** dist — smaller install, correct bytes for no-bundler consumers (Deno/CDN).
- Ships the new README hero + honest size figures on the npm page.

No API changes.

On merge, the changesets bot opens a **Version Packages** PR (0.2.0 → 0.2.1); merging that publishes to npm over OIDC. Then the StackBlitz repro works with `@0.2.1`.