### PR TITLE
feat: add examples visual harness suite

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,8 @@
+# examples are an independent, manual visual-test harness — never commit installed deps or builds
+**/node_modules/
+**/dist/
+**/.next/
+**/out/
+**/.vite/
+**/package-lock.json
+*.log

--- a/examples/DEPLOY.md
+++ b/examples/DEPLOY.md
@@ -1,0 +1,79 @@
+# Deploy the examples to Cloudflare Pages
+
+Each of the 7 apps ships as **static assets** (no server runtime), one **Cloudflare Pages project per app**, so each
+gets its own URL. The 6 Vite apps build to `dist/`; the Next app (`pulse-analytics`) uses `output: "export"` and builds
+to `out/` — its Server Components still render at build time, so the charts are baked into the HTML as pure SVG (the
+RSC/static-first story) with zero server runtime.
+
+## One-time setup
+
+1. A Cloudflare account.
+2. Authenticate wrangler **one** of these ways:
+   - Interactive: `npx wrangler login`
+   - Token (CI): `export CLOUDFLARE_API_TOKEN=…` (scope **Cloudflare Pages: Edit**) and `export CLOUDFLARE_ACCOUNT_ID=…`
+
+Nothing else to install — the deploy script uses `npx wrangler@4`.
+
+## Deploy
+
+From `examples/`:
+
+```bash
+./deploy-cloudflare.sh            # build + deploy all 7
+./deploy-cloudflare.sh cortex-ai  # build + deploy just one
+MC_PAGES_PREFIX=acme ./deploy-cloudflare.sh   # change the project-name prefix
+```
+
+For each app the script: installs deps if missing → `npm run build` → ensures the Pages project exists →
+`wrangler pages deploy <out|dist>`. Re-running redeploys to the **same** URL.
+
+## URLs (default prefix `microcharts`)
+
+| App                | Project                | URL                                    |
+| ------------------ | ---------------------- | -------------------------------------- |
+| pulse-analytics    | `microcharts-pulse`    | https://microcharts-pulse.pages.dev    |
+| ledger-finance     | `microcharts-ledger`   | https://microcharts-ledger.pages.dev   |
+| vitals-health      | `microcharts-vitals`   | https://microcharts-vitals.pages.dev   |
+| shipyard-devops    | `microcharts-shipyard` | https://microcharts-shipyard.pages.dev |
+| dispatch-editorial | `microcharts-dispatch` | https://microcharts-dispatch.pages.dev |
+| atlas-realestate   | `microcharts-atlas`    | https://microcharts-atlas.pages.dev    |
+| cortex-ai          | `microcharts-cortex`   | https://microcharts-cortex.pages.dev   |
+
+(`*.pages.dev` subdomains are first-come; if one is taken, set `MC_PAGES_PREFIX` and re-run.)
+
+## Web analytics (how many people visit)
+
+Two layers, both free:
+
+1. **Pages built-in metrics** — automatic, zero setup. Dashboard → the Pages project → _Metrics_: requests, bandwidth,
+   status codes, top paths. Always on once deployed. `wrangler` has no toggle for this; it's inherent to Pages.
+
+2. **Cloudflare Web Analytics** — privacy-first, cookieless _visits + page views_. Two ways:
+   - **Easiest (recommended, zero code):** Dashboard → the Pages project → _Web Analytics_ → **Enable**. Cloudflare
+     auto-injects the beacon on every response. Nothing to set in the repo. Do this per project.
+   - **Token in build (already wired in code):** create a Web Analytics site (Dashboard → _Web Analytics_ → _Add a site_
+     → hostname = the project's `*.pages.dev` or your custom domain → copy the **token**), then set the env var
+     **before** building/deploying that app:
+     - Vite apps: `export VITE_CF_BEACON_TOKEN=<token>`
+     - Next app (pulse): `export NEXT_PUBLIC_CF_BEACON_TOKEN=<token>` The apps already contain the beacon wiring
+       (`src/analytics.ts` / the Next `layout.tsx`) — it injects only when the token is set, and is a no-op otherwise.
+       **One token per hostname**, so if you use the beacon path, set a different token per app (the dashboard toggle
+       avoids this bookkeeping).
+
+> Note: there is no `wrangler` command to switch Web Analytics on for Pages — it's the dashboard toggle or the beacon
+> token above. `wrangler` only ships the assets.
+
+## Notes
+
+- **No SEO by design.** Every app ships `noindex, nofollow` plus a `robots.txt` that disallows all crawlers. These are a
+  visual harness / shareable demos — ranking and AI surfaces (`llms.txt`, sitemaps, OG campaigns) live on
+  `microcharts.dev` only. Do not add them here.
+- **One URL each** is the point — 7 independent projects. To instead host all under one domain at subpaths, each app
+  would need a matching `base` (Vite) / `basePath` (Next) — not set here; separate projects are simpler.
+- **Custom domains:** add in the Cloudflare dashboard (Pages → project → Custom domains) or
+  `npx wrangler pages deployment … ` — e.g. `pulse.example.com` per project.
+- **Testing a release candidate:** bump `@microcharts/react` in each app's `package.json` to the RC / target version,
+  `npm install`, then re-run the deploy — same as the local suite.
+- **CI option:** the same `wrangler pages deploy` calls run in GitHub Actions with the token env vars above, if you
+  later want push-to-deploy.
+- Build outputs (`dist/`, `out/`, `.next/`) are git-ignored; the script rebuilds fresh each run.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,88 @@
+# microcharts examples — visual test suite
+
+Seven **independent** real-world apps that each install `@microcharts/react` **from npm** (`0.8.0`) and integrate it via
+the [quickstart agent prompt](https://microcharts.dev/docs/quickstart). They are a **manual** visual harness: before
+shipping a major change, bump the dependency to the target version (or RC), reinstall, launch all seven, and eyeball
+that rendering, theming, interactivity, and the RSC/static path still behave — then take it live.
+
+Between them the seven apps exercise **every one of the 106 chart types** in the catalog, in believable product contexts
+(not a gallery) — so a rendering or API regression on any chart surfaces here.
+
+Not part of CI. Not part of the pnpm workspace (`pnpm-workspace.yaml` globs are `.`, `apps/*`, `fixtures/*` —
+`examples/` is excluded on purpose). Each app has its own `package.json` and its own `node_modules`; lockfiles are
+gitignored so installs stay local to the machine. Public deploys are **`noindex`** (see [DEPLOY.md](DEPLOY.md)) — SEO /
+`llms.txt` stay on the docs site.
+
+## The apps
+
+| #   | App                    | Stack                 | Port | What it stress-tests                                                                                                                 |
+| --- | ---------------------- | --------------------- | ---- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| 1   | **pulse-analytics**    | Next.js 15 App Router | 4001 | Product analytics — interactive by default on every route; `/live` is the streaming ops island                                       |
+| 2   | **ledger-finance**     | Vite + React 19       | 4002 | Interactive (hover/keyboard) + `animate` + **dark** preset, OHLC candlesticks                                                        |
+| 3   | **vitals-health**      | Vite + React 19       | 4003 | Categorical `colors[]` — progress rings, macro donut, sleep hypnogram; inline stats                                                  |
+| 4   | **shipyard-devops**    | Vite + React 19       | 4004 | **mono** preset, status semantics, bullet / error-budget / burn-chart, dense tables                                                  |
+| 5   | **dispatch-editorial** | Vite + React 19       | 4005 | **editorial** preset, static prose-inline marks, interactive figures, `--mc-font` serif-body trap, annotations                       |
+| 6   | **atlas-realestate**   | Vite + React 19       | 4006 | **vivid** preset, histogram / quadrant-dot / dumbbell / slope / percentile-ladder, dense tables                                      |
+| 7   | **cortex-ai**          | Vite + React 19       | 4007 | LLM/agent eval + observability — token-confidence, calibration-strip, confusion-grid, rubric-strip, trace-fold, waveform, star-spoke |
+
+Together they cover: **all 106 chart types**, static vs interactive entries, all five theme presets + dark +
+**print/eink**, categorical palettes, inline-in-text and inline-in-table, annotations (`Threshold` / `Marker` /
+`TargetZone` / `Callout`), `animate`, `format`/`domain` scaling, **picker callbacks** (`onActive` / `onSelect` /
+`selectedIndex`), **`readout={false}` + `datum.formatted`**, **`SparkGroup`**, **`defineTheme` + `MicroProvider`**, and
+responsive reflow (tested at 375 / 768 / 1280). Each app is a multi-section product with light+dark support.
+
+## Feature matrix (0.8.0 coverage)
+
+| Surface                         | pulse                        | ledger | vitals  | shipyard | dispatch             | atlas     | cortex |
+| ------------------------------- | ---------------------------- | ------ | ------- | -------- | -------------------- | --------- | ------ |
+| Interactive + `animate`         | ● all routes                 | ●      | ●       | ●        | ● figures            | ●         | ●      |
+| Static (intentional)            |                              |        | △ prose |          | ● prose inline       |           |        |
+| `onActive` / `onSelect` / pin   | ●                            | ●      | ●       | ●        | △                    | ●         | ●      |
+| `readout={false}` + `formatted` | `/live` KPI wiring           | ●      | ●       | ●        | △                    | ●         | ●      |
+| Inline `.mc-inline`             | tables                       | ●      | ●       |          | ●                    |           |        |
+| Annotations                     | Threshold+TargetZone+Callout |        |         |          | ●                    |           |        |
+| `SparkGroup`                    | engagement                   |        |         |          |                      | compare   |        |
+| `defineTheme` / `MicroProvider` |                              | dark   |         | mono     |                      | vivid+ink | cobalt |
+| Theme presets                   | modern                       | dark   | modern  | mono     | editorial+print+eink | vivid     | modern |
+| Categorical `colors[]`          | ●                            | ●      | ●       |          | ●                    | ●         | ●      |
+| `onWindowChange` (minimap)      |                              |        |         | ●        |                      |           |        |
+
+● primary · △ present but not the stress story
+
+## Run
+
+```bash
+cd examples/<app>
+npm install                                        # resolves @microcharts/react@0.8.0 from npm
+npm run dev                                        # fixed port — see table
+```
+
+Or launch any of them from the editor via the `ex-*` entries in `.claude/launch.json`.
+
+To point the suite at a newer release or RC, bump `@microcharts/react` in each app's `package.json` (e.g. `"0.8.1"` or
+`"0.9.0-rc.1"`) and re-run `npm install`.
+
+## Deploy (Cloudflare Pages — one URL per app)
+
+All 7 build to static assets (Vite → `dist/`, Next `output: "export"` → `out/`), so each deploys as its own Cloudflare
+Pages project with its own `*.pages.dev` URL. After `npx wrangler login` (or a `CLOUDFLARE_API_TOKEN`), from
+`examples/`:
+
+```bash
+./deploy-cloudflare.sh            # build + deploy all 7
+./deploy-cloudflare.sh cortex-ai  # or just one
+```
+
+See [DEPLOY.md](DEPLOY.md) for prerequisites, the URL map, and custom-domain notes.
+
+## Endpoints (once servers are up)
+
+- pulse-analytics → http://localhost:4001 (`/`, `/revenue`, `/engagement`, `/experiments`, `/accounts`, `/live`)
+- ledger-finance → http://localhost:4002
+- vitals-health → http://localhost:4003
+- shipyard-devops → http://localhost:4004
+- dispatch-editorial → http://localhost:4005
+- atlas-realestate → http://localhost:4006
+- cortex-ai → http://localhost:4007
+
+Every one of the 106 chart types appears in at least one app.

--- a/examples/atlas-realestate/index.html
+++ b/examples/atlas-realestate/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <meta name="theme-color" content="#f3f0ea" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#1c1e26" media="(prefers-color-scheme: dark)" />
+    <title>Atlas · Real-estate market intelligence</title>
+    <link rel="preconnect" href="https://api.fontshare.com" crossorigin />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://api.fontshare.com/v2/css?f[]=zodiak@500,600,700&f[]=supreme@400,500,600,700&display=swap"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Spline+Sans+Mono:wght@400;500;600&display=swap"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/atlas-realestate/package.json
+++ b/examples/atlas-realestate/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "example-atlas-realestate",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite --port 4006 --strictPort",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview --port 4006 --strictPort"
+  },
+  "dependencies": {
+    "@microcharts/react": "^0.8.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^5.0.0",
+    "typescript": "^5.7.0",
+    "vite": "^7.0.0"
+  }
+}

--- a/examples/atlas-realestate/public/robots.txt
+++ b/examples/atlas-realestate/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/examples/atlas-realestate/src/App.tsx
+++ b/examples/atlas-realestate/src/App.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useState } from "react";
+import { MarketView } from "./components/MarketView";
+import { ListingsView } from "./components/ListingsView";
+import { CompareView } from "./components/CompareView";
+
+type Tab = "market" | "listings" | "compare";
+
+const TABS: { id: Tab; label: string }[] = [
+  { id: "market", label: "Market" },
+  { id: "listings", label: "Listings" },
+  { id: "compare", label: "Compare" },
+];
+
+/** Reveal `.reveal` blocks as they scroll in. Re-scans whenever the view changes. */
+function useReveal(key: string) {
+  useEffect(() => {
+    const reduce = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    const els = Array.from(document.querySelectorAll<HTMLElement>(".reveal:not(.in)"));
+    if (reduce || !("IntersectionObserver" in window)) {
+      els.forEach((el) => el.classList.add("in"));
+      return;
+    }
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const e of entries) {
+          if (e.isIntersecting) {
+            e.target.classList.add("in");
+            io.unobserve(e.target);
+          }
+        }
+      },
+      { rootMargin: "0px 0px -8% 0px", threshold: 0.08 },
+    );
+    els.forEach((el) => io.observe(el));
+    return () => io.disconnect();
+  }, [key]);
+}
+
+export function App() {
+  const [tab, setTab] = useState<Tab>("market");
+  useReveal(tab);
+
+  return (
+    <div className="atlas">
+      <header className="topbar">
+        <a className="brand" href="#" aria-label="Atlas home">
+          <span className="brand-mark" aria-hidden="true">
+            <svg viewBox="0 0 24 24" width="17" height="17" fill="none" aria-hidden="true">
+              <path
+                d="M4 20 L12 4 L20 20"
+                stroke="currentColor"
+                strokeWidth="2.4"
+                strokeLinejoin="round"
+                strokeLinecap="round"
+              />
+              <path
+                d="M8 20 L12 12 L16 20"
+                stroke="currentColor"
+                strokeWidth="2.4"
+                strokeLinejoin="round"
+                strokeLinecap="round"
+                opacity="0.5"
+              />
+            </svg>
+          </span>
+          <span className="brand-word">
+            <b>Atlas</b>
+            <small>Market Intelligence</small>
+          </span>
+        </a>
+        <nav className="tabs" aria-label="Views">
+          {TABS.map((t) => (
+            <button
+              key={t.id}
+              className="tab"
+              aria-current={tab === t.id}
+              onClick={() => setTab(t.id)}
+            >
+              {t.label}
+            </button>
+          ))}
+        </nav>
+        <div className="topbar-spacer" />
+        <label className="search">
+          <svg viewBox="0 0 16 16" width="14" height="14" fill="none" aria-hidden="true">
+            <circle cx="7" cy="7" r="4.5" stroke="currentColor" strokeWidth="1.6" />
+            <path d="M11 11 L14 14" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+          </svg>
+          <span>Search neighborhoods, MLS #…</span>
+          <kbd>/</kbd>
+        </label>
+        <div className="avatar" aria-hidden="true">
+          AV
+        </div>
+      </header>
+
+      <main key={tab} className="view-swap">
+        {tab === "market" && <MarketView />}
+        {tab === "listings" && <ListingsView />}
+        {tab === "compare" && <CompareView />}
+      </main>
+    </div>
+  );
+}

--- a/examples/atlas-realestate/src/analytics.ts
+++ b/examples/atlas-realestate/src/analytics.ts
@@ -1,0 +1,14 @@
+// Cloudflare Web Analytics — privacy-first, cookieless page-view/visit beacon.
+// Injected only when VITE_CF_BEACON_TOKEN is set at build time; otherwise a no-op.
+// Get a token: Cloudflare dashboard → Web Analytics → Add a site → copy the token
+// (or just enable Web Analytics on the Pages project, which auto-injects instead). See DEPLOY.md.
+const token = (import.meta as unknown as { env?: Record<string, string | undefined> }).env
+  ?.VITE_CF_BEACON_TOKEN;
+if (token) {
+  const s = document.createElement("script");
+  s.defer = true;
+  s.src = "https://static.cloudflareinsights.com/beacon.min.js";
+  s.setAttribute("data-cf-beacon", JSON.stringify({ token }));
+  document.head.appendChild(s);
+}
+export {};

--- a/examples/atlas-realestate/src/app.css
+++ b/examples/atlas-realestate/src/app.css
@@ -1,0 +1,1230 @@
+/* Atlas — real-estate market intelligence.
+   Aesthetic: an architectural survey rendered on warm limestone paper, drawn
+   in cool Prussian ink. Editorial serif masthead (Zodiak), humanist grotesk
+   body (Supreme), and a drafting-instrument mono (Spline Sans Mono) on every
+   figure. Topographic contour plates stand in for photography.
+
+   FONT TRAP: --mc-font must stay a SANS stack or microcharts SVG labels render
+   in the display serif. Numerals ride --mc-font-numeric (mono) for the
+   instrument feel. Dark mode is a warm ink charcoal; both OS schemes are tuned
+   so chart strokes never go invisible. */
+
+:root {
+  --font-display: "Zodiak", "Iowan Old Style", Georgia, "Times New Roman", serif;
+  --font-sans: "Supreme", ui-sans-serif, system-ui, "Segoe UI", sans-serif;
+  --font-mono: "Spline Sans Mono", ui-monospace, "SF Mono", Menlo, monospace;
+}
+
+body {
+  font-family: var(--font-sans);
+  margin: 0;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+/* ------------------------------------------------------------------ tokens */
+/* OKLCH: warm limestone neutrals (hue ~85) against one cool ink accent
+   (hue ~252). Chroma drops as lightness climbs so nothing goes garish. */
+
+:root {
+  --paper: oklch(0.968 0.006 84);
+  --surface: oklch(0.992 0.004 86);
+  --surface-2: oklch(0.958 0.007 83);
+  --ink: oklch(0.255 0.021 262);
+  --ink-soft: oklch(0.455 0.019 258);
+  --ink-faint: oklch(0.605 0.016 252);
+  --line: oklch(0.895 0.011 80);
+  --line-soft: oklch(0.928 0.008 82);
+  --grid: color-mix(in oklab, var(--ink) 4%, transparent);
+
+  --accent: oklch(0.45 0.101 252);
+  --accent-strong: oklch(0.4 0.112 255);
+  --accent-soft: oklch(0.93 0.03 250);
+  --bronze: oklch(0.58 0.104 62);
+
+  --radius: 14px;
+  --radius-sm: 9px;
+  --radius-tag: 5px;
+
+  --shadow-sm: 0 1px 2px oklch(0.3 0.03 260 / 0.06);
+  --shadow: 0 1px 2px oklch(0.3 0.03 260 / 0.05), 0 14px 34px oklch(0.3 0.04 260 / 0.08);
+  --shadow-lg: 0 2px 6px oklch(0.3 0.03 260 / 0.07), 0 30px 60px oklch(0.3 0.05 260 / 0.13);
+  --topbar-bg: color-mix(in oklab, var(--paper) 82%, transparent);
+
+  /* microcharts — accent + materials categorical palette (steel / brass /
+     patina / plum). Valence hues (positive green, negative vermillion) are
+     never touched. */
+  --mc-accent: oklch(0.45 0.101 252);
+  --mc-cat-1: oklch(0.46 0.092 250);
+  --mc-cat-2: oklch(0.68 0.102 78);
+  --mc-cat-3: oklch(0.56 0.056 205);
+  --mc-cat-4: oklch(0.48 0.082 330);
+  --mc-font: var(--font-sans);
+  --mc-font-numeric: var(--font-mono);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --paper: oklch(0.203 0.012 264);
+    --surface: oklch(0.238 0.014 264);
+    --surface-2: oklch(0.278 0.015 264);
+    --ink: oklch(0.945 0.008 86);
+    --ink-soft: oklch(0.74 0.012 82);
+    --ink-faint: oklch(0.585 0.014 258);
+    --line: oklch(0.328 0.015 264);
+    --line-soft: oklch(0.288 0.013 264);
+    --grid: color-mix(in oklab, oklch(0.8 0.05 250) 6%, transparent);
+
+    --accent: oklch(0.72 0.108 250);
+    --accent-strong: oklch(0.78 0.11 250);
+    --accent-soft: oklch(0.32 0.05 255);
+    --bronze: oklch(0.74 0.1 74);
+
+    --shadow-sm: 0 1px 2px oklch(0 0 0 / 0.4);
+    --shadow: 0 1px 2px oklch(0 0 0 / 0.4), 0 14px 34px oklch(0 0 0 / 0.5);
+    --shadow-lg: 0 2px 6px oklch(0 0 0 / 0.45), 0 30px 60px oklch(0 0 0 / 0.6);
+    --topbar-bg: color-mix(in oklab, var(--paper) 78%, transparent);
+
+    --mc-accent: oklch(0.72 0.108 250);
+    --mc-cat-1: oklch(0.7 0.1 250);
+    --mc-cat-2: oklch(0.76 0.1 80);
+    --mc-cat-3: oklch(0.68 0.06 205);
+    --mc-cat-4: oklch(0.66 0.09 330);
+  }
+}
+
+/* ------------------------------------------------------------------ shell */
+
+.atlas {
+  position: relative;
+  min-height: 100vh;
+  background:
+    linear-gradient(180deg, color-mix(in oklab, var(--accent) 6%, transparent), transparent 240px),
+    var(--paper);
+  color: var(--ink);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+/* Faint survey grid — architectural texture that cards sit clean on top of. */
+.atlas::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background-image:
+    repeating-linear-gradient(0deg, transparent 0 39px, var(--grid) 39px 40px),
+    repeating-linear-gradient(90deg, transparent 0 39px, var(--grid) 39px 40px);
+  -webkit-mask-image: radial-gradient(120% 90% at 50% 0%, #000 30%, transparent 78%);
+  mask-image: radial-gradient(120% 90% at 50% 0%, #000 30%, transparent 78%);
+}
+
+.atlas > * {
+  position: relative;
+  z-index: 1;
+}
+
+/* ---------------------------------------------------------------- top bar */
+
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  gap: clamp(14px, 2.4vw, 26px);
+  padding: 0 clamp(16px, 4vw, 40px);
+  height: 66px;
+  background: var(--topbar-bg);
+  backdrop-filter: saturate(1.4) blur(16px);
+  -webkit-backdrop-filter: saturate(1.4) blur(16px);
+  border-bottom: 1px solid var(--line);
+}
+
+main,
+.view,
+.panel {
+  scroll-margin-top: 72px;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  color: var(--ink);
+  text-decoration: none;
+  border-radius: 8px;
+  transition: opacity 0.16s ease;
+}
+
+.brand:hover {
+  opacity: 0.78;
+}
+
+.brand:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+}
+
+.brand-mark {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  background: var(--accent-strong);
+  color: oklch(0.98 0.01 86);
+  box-shadow:
+    inset 0 0 0 1px oklch(1 0 0 / 0.12),
+    0 2px 8px color-mix(in oklab, var(--accent) 40%, transparent);
+}
+
+.brand-word {
+  display: flex;
+  flex-direction: column;
+  line-height: 1;
+}
+
+.brand-word b {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 21px;
+  letter-spacing: -0.01em;
+}
+
+.brand-word small {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  font-weight: 500;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin-top: 3px;
+}
+
+.tabs {
+  display: flex;
+  gap: 4px;
+  margin-left: 10px;
+}
+
+.tab {
+  appearance: none;
+  position: relative;
+  border: 0;
+  background: transparent;
+  color: var(--ink-soft);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  padding: 8px 6px;
+  min-height: 40px;
+  cursor: pointer;
+  transition: color 0.18s ease;
+}
+
+.tab::after {
+  content: "";
+  position: absolute;
+  left: 6px;
+  right: 6px;
+  bottom: 10px;
+  height: 2px;
+  background: var(--accent);
+  border-radius: 2px;
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.22s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.tab:hover {
+  color: var(--ink);
+}
+
+.tab:hover::after {
+  transform: scaleX(0.4);
+}
+
+.tab:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+
+.tab[aria-current="true"] {
+  color: var(--ink);
+  font-weight: 600;
+}
+
+.tab[aria-current="true"]::after {
+  transform: scaleX(1);
+}
+
+.topbar-spacer {
+  flex: 1;
+}
+
+.search {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  height: 38px;
+  padding: 0 10px 0 13px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line);
+  background: var(--surface);
+  color: var(--ink-faint);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: -0.01em;
+  min-width: 236px;
+  cursor: text;
+  transition:
+    border-color 0.16s ease,
+    box-shadow 0.16s ease;
+}
+
+.search:hover {
+  border-color: color-mix(in oklab, var(--accent) 45%, var(--line));
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+.search kbd {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--ink-soft);
+  background: var(--surface-2);
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  padding: 1px 6px;
+}
+
+.avatar {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  flex: none;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  color: var(--ink-soft);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+/* ------------------------------------------------------------------ layout */
+
+.page {
+  max-width: 1220px;
+  margin: 0 auto;
+  padding: clamp(24px, 4vw, 44px) clamp(16px, 4vw, 40px) 96px;
+}
+
+.page-head {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 20px;
+  padding-bottom: 22px;
+  margin-bottom: 28px;
+  border-bottom: 1px solid var(--line);
+}
+
+.eyebrow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 14px;
+}
+
+.eyebrow::before {
+  content: "";
+  width: 22px;
+  height: 1px;
+  background: currentColor;
+  opacity: 0.55;
+}
+
+.page-head h1 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(29px, 4.4vw, 44px);
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  line-height: 1.04;
+}
+
+.page-head p {
+  margin: 12px 0 0;
+  color: var(--ink-soft);
+  font-size: 14.5px;
+  line-height: 1.5;
+  max-width: 58ch;
+}
+
+.pill {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 6px 13px;
+  white-space: nowrap;
+}
+
+.pill-live::before {
+  content: "";
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--mc-positive, #0e7a5f);
+  box-shadow: 0 0 0 0 color-mix(in oklab, #0e7a5f 60%, transparent);
+}
+
+.pill-hot {
+  color: oklch(0.99 0.01 80);
+  background: var(--bronze);
+  border-color: transparent;
+  box-shadow: 0 2px 10px color-mix(in oklab, var(--bronze) 40%, transparent);
+}
+
+/* --------------------------------------------------------------- cards */
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-sm);
+}
+
+.card-pad {
+  padding: clamp(18px, 3vw, 26px);
+}
+
+.card-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 14px;
+  margin-bottom: 18px;
+}
+
+.card-head h2 {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+}
+
+.card-head .sub {
+  color: var(--ink-faint);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  letter-spacing: -0.01em;
+  text-align: right;
+}
+
+/* Drafting sheet numbers on the plotted charts (01, 02, …). */
+.market-grid,
+.compare-grid {
+  counter-reset: plate;
+}
+
+.chart-block {
+  counter-increment: plate;
+}
+
+.chart-block .card-head h2::before {
+  content: counter(plate, decimal-leading-zero);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--accent);
+  margin-right: 10px;
+  letter-spacing: 0;
+}
+
+/* --------------------------------------------------------- ledger (KPIs) */
+/* A single ruled title-block, not four repeated cards. The 1px grid gap
+   paints the hairline dividers so it re-rules cleanly at every breakpoint. */
+
+.stat-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1px;
+  background: var(--line);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  overflow: hidden;
+  margin-bottom: 24px;
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: clamp(16px, 2.4vw, 22px);
+  background: var(--surface);
+  transition: background 0.2s ease;
+}
+
+.stat.card {
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.stat:hover {
+  background: var(--surface-2);
+}
+
+.stat-label {
+  color: var(--ink-soft);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.stat-value {
+  font-family: var(--font-mono);
+  font-size: clamp(23px, 2.8vw, 31px);
+  font-weight: 500;
+  letter-spacing: -0.03em;
+  line-height: 1;
+  color: var(--ink);
+}
+
+.stat-foot {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--ink-faint);
+}
+
+/* ------------------------------------------------------------ market grid */
+
+.market-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 18px;
+}
+
+.market-grid .full {
+  grid-column: 1 / -1;
+}
+
+.chart-block {
+  display: flex;
+  flex-direction: column;
+  transition:
+    box-shadow 0.24s ease,
+    border-color 0.24s ease,
+    transform 0.24s ease;
+}
+
+.card.chart-block:hover {
+  box-shadow: var(--shadow);
+  border-color: color-mix(in oklab, var(--accent) 20%, var(--line));
+}
+
+.chart-frame {
+  margin-top: 4px;
+}
+
+.chart-frame-center {
+  display: grid;
+  place-items: center;
+  padding: 10px 0;
+}
+
+/* ---------------------------------------------------------- heat matrix */
+
+.heat-matrix {
+  display: grid;
+  gap: 5px;
+  align-items: center;
+  width: max-content;
+  max-width: 100%;
+}
+
+.heat-corner {
+  min-height: 24px;
+}
+
+.heat-col {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  text-align: center;
+  padding-bottom: 6px;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.heat-name {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--ink);
+  padding-right: 12px;
+  white-space: nowrap;
+}
+
+.heat-cell-wrap {
+  border-radius: 4px;
+  transition:
+    transform 0.16s ease,
+    box-shadow 0.16s ease;
+}
+
+.heat-cell-wrap:hover {
+  transform: scale(1.09);
+  box-shadow: var(--shadow-sm);
+  z-index: 2;
+}
+
+/* --------------------------------------------------------------- table */
+
+.table-scroll {
+  overflow-x: auto;
+}
+
+.data-table {
+  width: 100%;
+  min-width: 580px;
+  border-collapse: collapse;
+  font-size: 13.5px;
+}
+
+.data-table thead th {
+  text-align: left;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  padding: 4px 16px 12px;
+  border-bottom: 1px solid var(--line);
+}
+
+.data-table th.num,
+.data-table td.num {
+  text-align: right;
+  font-family: var(--font-mono);
+  letter-spacing: -0.01em;
+}
+
+.data-table tbody td {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--line-soft);
+}
+
+.data-table tbody tr {
+  transition: background 0.14s ease;
+}
+
+.data-table tbody tr:hover {
+  background: var(--surface-2);
+}
+
+.data-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.td-name {
+  font-weight: 600;
+}
+
+.mix-col {
+  width: 150px;
+}
+
+.mix-col .mc-inline {
+  width: 130px;
+}
+
+/* ------------------------------------------------------- listing spotlight */
+
+.spotlight {
+  display: grid;
+  grid-template-columns: minmax(0, 280px) 1fr;
+  overflow: hidden;
+}
+
+.spotlight-mast,
+.listing-mast {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  gap: 6px;
+  padding: 22px 20px 20px;
+  background:
+    linear-gradient(165deg, var(--surface-2), var(--surface)),
+    repeating-linear-gradient(
+      0deg,
+      transparent 0 14px,
+      color-mix(in oklab, var(--ink) 4%, transparent) 14px 15px
+    );
+  border-right: 1px solid var(--line-soft);
+}
+
+.spotlight-mast {
+  min-height: 100%;
+  gap: 8px;
+}
+
+.spotlight-mast .pill-hot {
+  position: absolute;
+  top: 16px;
+  left: 16px;
+}
+
+.spotlight-meta {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  color: var(--ink-faint);
+  margin-top: 8px;
+}
+
+.spotlight-addr {
+  font-family: var(--font-display);
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  color: var(--ink);
+  line-height: 1.15;
+  margin-top: 28px;
+}
+
+.spotlight-hood {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+
+.listing-mast {
+  min-height: 96px;
+  border-right: 0;
+  border-bottom: 1px solid var(--line-soft);
+}
+
+.listing-mast .listing-badge {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  left: auto;
+}
+
+.spotlight-body {
+  padding: clamp(20px, 3vw, 30px);
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+
+.spotlight-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+
+.spotlight-price {
+  font-family: var(--font-mono);
+  font-size: clamp(28px, 4vw, 38px);
+  font-weight: 500;
+  letter-spacing: -0.035em;
+  line-height: 1.02;
+  margin: 4px 0 6px;
+  color: var(--ink);
+}
+
+.spotlight-facts {
+  display: flex;
+  gap: 22px;
+  flex-wrap: wrap;
+}
+
+.fact {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.fact-lbl {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+.fact-val {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+}
+
+.spotlight-charts {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px 26px;
+  padding-top: 20px;
+  border-top: 1px solid var(--line-soft);
+}
+
+.mini-block {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  min-width: 0;
+}
+
+.mini-block.wide {
+  grid-column: 1 / -1;
+}
+
+.mini-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.mini-head .lbl {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.mini-head .sub {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--ink-faint);
+  letter-spacing: -0.01em;
+  text-align: right;
+}
+
+/* --------------------------------------------------------------- listings */
+
+.listing-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(272px, 1fr));
+  gap: 18px;
+}
+
+.listing {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  transition:
+    box-shadow 0.24s ease,
+    transform 0.24s ease,
+    border-color 0.24s ease;
+}
+
+.listing:hover {
+  box-shadow: var(--shadow);
+  transform: translateY(-3px);
+  border-color: color-mix(in oklab, var(--accent) 22%, var(--line));
+}
+
+.listing-badge {
+  position: absolute;
+  top: 11px;
+  left: 11px;
+  z-index: 1;
+  padding: 4px 10px;
+  border-radius: var(--radius-tag);
+  background: color-mix(in oklab, var(--surface) 88%, transparent);
+  backdrop-filter: blur(4px);
+  border: 1px solid var(--line);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  color: var(--ink);
+}
+
+.listing-body {
+  padding: 16px 18px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 13px;
+}
+
+.listing-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.listing-addr {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 16px;
+  letter-spacing: -0.01em;
+  line-height: 1.15;
+}
+
+.listing-hood {
+  color: var(--ink-faint);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin-top: 4px;
+}
+
+.listing-price {
+  font-family: var(--font-mono);
+  font-size: 17px;
+  font-weight: 500;
+  letter-spacing: -0.03em;
+  white-space: nowrap;
+}
+
+.listing-meta {
+  display: flex;
+  gap: 14px;
+  color: var(--ink-soft);
+  font-size: 12.5px;
+}
+
+.listing-meta span {
+  font-family: var(--font-mono);
+  letter-spacing: -0.01em;
+}
+
+.spark-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--line-soft);
+}
+
+.spark-row .lbl,
+.bullet-row .lbl {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+.bullet-row {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+/* ---------------------------------------------------------------- compare */
+
+.compare-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 18px;
+}
+
+.compare-grid .full {
+  grid-column: 1 / -1;
+}
+
+.bench-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  align-items: center;
+}
+
+.bench-labels {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  margin-top: 8px;
+}
+
+.bench-labels span {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.01em;
+  color: var(--ink-faint);
+  text-align: center;
+}
+
+.paired-frame {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 12px;
+  align-items: stretch;
+}
+
+.paired-labels {
+  display: grid;
+  grid-auto-rows: 1fr;
+  align-items: center;
+  padding: 2px 0;
+}
+
+.paired-labels span {
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--ink);
+  white-space: nowrap;
+  line-height: 1.1;
+}
+
+/* ------------------------------------------------------- scrub readout */
+/* Limestone chip on ink hairline — the compact "you're hovering here"
+   line under a scrubbable chart. Dims until a bin is active. */
+.picker-readout {
+  margin: 10px 0 0;
+  padding: 5px 10px;
+  display: inline-flex;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--surface-2);
+  color: var(--ink-faint);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: -0.01em;
+  transition:
+    color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.picker-readout.is-active {
+  color: var(--ink);
+  border-color: color-mix(in oklab, var(--accent) 32%, var(--line));
+}
+
+/* ------------------------------------------------------------------- misc */
+
+.mc-inline {
+  display: inline-flex;
+  vertical-align: middle;
+}
+
+.legend {
+  display: flex;
+  gap: 8px 18px;
+  flex-wrap: wrap;
+  margin-top: 16px;
+}
+
+.legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12.5px;
+  color: var(--ink-soft);
+}
+
+.legend i {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  display: inline-block;
+  flex: none;
+}
+
+.note {
+  margin: 16px 0 0;
+  font-size: 13px;
+  color: var(--ink-soft);
+  line-height: 1.6;
+  max-width: 60ch;
+}
+
+/* ------------------------------------------------------------------ motion */
+
+@media (prefers-reduced-motion: no-preference) {
+  .reveal {
+    opacity: 0;
+    transform: translateY(16px);
+    transition:
+      opacity 0.55s cubic-bezier(0.22, 1, 0.36, 1),
+      transform 0.55s cubic-bezier(0.22, 1, 0.36, 1);
+  }
+  .reveal.in {
+    opacity: 1;
+    transform: none;
+  }
+
+  .stat-row.reveal {
+    opacity: 1;
+    transform: none;
+  }
+  .stat-row.reveal .stat {
+    opacity: 0;
+  }
+  .stat-row.reveal.in .stat {
+    animation: stat-rise 0.55s cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+  .stat-row.reveal.in .stat:nth-child(2) {
+    animation-delay: 0.07s;
+  }
+  .stat-row.reveal.in .stat:nth-child(3) {
+    animation-delay: 0.14s;
+  }
+  .stat-row.reveal.in .stat:nth-child(4) {
+    animation-delay: 0.21s;
+  }
+  @keyframes stat-rise {
+    from {
+      opacity: 0;
+      transform: translateY(10px);
+    }
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
+  .view-swap {
+    animation: view-in 0.34s cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+  @keyframes view-in {
+    from {
+      opacity: 0;
+      transform: translateY(7px);
+    }
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
+  .pill-live::before {
+    animation: live-pulse 2.4s ease-out infinite;
+  }
+  @keyframes live-pulse {
+    0% {
+      box-shadow: 0 0 0 0 color-mix(in oklab, #0e7a5f 55%, transparent);
+    }
+    70%,
+    100% {
+      box-shadow: 0 0 0 6px transparent;
+    }
+  }
+}
+
+/* ------------------------------------------------------------- responsive */
+
+@media (max-width: 960px) {
+  .market-grid,
+  .compare-grid {
+    grid-template-columns: 1fr;
+  }
+  .stat-row {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  /* keep the third cell's stagger sane on two columns */
+  .stat-row.reveal.in .stat:nth-child(3) {
+    animation-delay: 0.07s;
+  }
+  .stat-row.reveal.in .stat:nth-child(4) {
+    animation-delay: 0.14s;
+  }
+  .spotlight {
+    grid-template-columns: 1fr;
+  }
+  .spotlight-mast {
+    border-right: 0;
+    border-bottom: 1px solid var(--line-soft);
+    min-height: 0;
+  }
+}
+
+@media (max-width: 620px) {
+  .topbar {
+    gap: 12px;
+    height: 60px;
+  }
+  .search {
+    display: none;
+  }
+  .tabs {
+    margin-left: 2px;
+    flex: 1;
+    min-width: 0;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+  .tabs::-webkit-scrollbar {
+    display: none;
+  }
+  .tab {
+    padding: 8px 4px;
+    font-size: 13.5px;
+    white-space: nowrap;
+  }
+  .heat-matrix {
+    min-width: 0;
+  }
+  .brand-word small {
+    display: none;
+  }
+  .page-head {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .spotlight-charts {
+    grid-template-columns: 1fr;
+  }
+  .stat-row {
+    grid-template-columns: 1fr;
+  }
+  .bench-row,
+  .bench-labels {
+    grid-template-columns: 1fr;
+  }
+  .card-head {
+    flex-direction: column;
+    gap: 3px;
+  }
+  .card-head .sub {
+    text-align: left;
+  }
+}
+
+@media (max-width: 400px) {
+  .brand-word small {
+    display: none;
+  }
+}

--- a/examples/atlas-realestate/src/components/CompareView.tsx
+++ b/examples/atlas-realestate/src/components/CompareView.tsx
@@ -1,0 +1,254 @@
+import { SparkGroup } from "@microcharts/react";
+import { Dumbbell } from "@microcharts/react/dumbbell/interactive";
+import { Slope } from "@microcharts/react/slope/interactive";
+import { StackedArea } from "@microcharts/react/stacked-area/interactive";
+import { PairedBars } from "@microcharts/react/paired-bars/interactive";
+import { VolumeProfile } from "@microcharts/react/volume-profile/interactive";
+import { BenchmarkStrip } from "@microcharts/react/benchmark-strip/interactive";
+import { PartitionStrip } from "@microcharts/react/partition-strip/interactive";
+import {
+  listToSale,
+  yearOverYear,
+  salesMix,
+  listVsSale,
+  typeComposition,
+  salesByPrice,
+  benchmarks,
+  usd,
+  usdSqft,
+} from "../data";
+
+// Materials categorical palette — driven by Atlas --mc-cat-* so dark mode flips.
+const mixColors = ["var(--mc-cat-1)", "var(--mc-cat-2)", "var(--mc-cat-3)"];
+const typeColors = ["var(--mc-cat-1)", "var(--mc-cat-2)", "var(--mc-cat-3)", "var(--mc-cat-4)"];
+
+export function CompareView() {
+  return (
+    <div className="page">
+      <div className="page-head">
+        <div>
+          <div className="eyebrow">Comparison · 6 regions</div>
+          <h1>Neighborhood against neighborhood</h1>
+          <p>
+            List-to-sale spread, appreciation, buyer mix, and where the money is quietly moving.
+          </p>
+        </div>
+        <span className="pill">6 regions</span>
+      </div>
+
+      <div className="compare-grid">
+        {/* List → sale ------------------------------------------------- */}
+        <section className="card card-pad chart-block reveal">
+          <div className="card-head">
+            <h2>List price to sale price</h2>
+            <span className="sub">median, by neighborhood</span>
+          </div>
+          <div className="chart-frame">
+            <Dumbbell
+              data={listToSale}
+              positive="up"
+              label="value"
+              highlight="Lakeside"
+              format={usd}
+              width={420}
+              height={220}
+              title="List price versus sale price by neighborhood"
+              style={{ width: "100%", height: "auto" }}
+            />
+          </div>
+          <p className="note">
+            Lakeside homes clear well over asking; Sunset Terrace is the lone segment settling below
+            list.
+          </p>
+        </section>
+
+        {/* Year over year ---------------------------------------------- */}
+        <section className="card card-pad chart-block reveal">
+          <div className="card-head">
+            <h2>Median price, YoY</h2>
+            <span className="sub">last year → this year</span>
+          </div>
+          <div className="chart-frame">
+            <Slope
+              data={yearOverYear}
+              positive="up"
+              label="value"
+              highlight="Lakeside"
+              format={(n) => "$" + Math.round(n / 1000) + "k"}
+              width={420}
+              height={240}
+              title="Median price last year versus this year by neighborhood"
+              style={{ width: "100%", height: "auto" }}
+              animate
+            />
+          </div>
+          <div className="legend">
+            {yearOverYear.map((d) => {
+              const hi = d.label === "Lakeside";
+              const swatch = hi
+                ? "var(--mc-accent)"
+                : d.to > d.from
+                  ? "var(--mc-positive)"
+                  : d.to < d.from
+                    ? "var(--mc-negative)"
+                    : "var(--mc-neutral)";
+              return (
+                <span
+                  key={d.label}
+                  style={hi ? { color: "var(--ink)", fontWeight: 600 } : undefined}
+                >
+                  <i style={{ background: swatch }} />
+                  {d.label}
+                </span>
+              );
+            })}
+          </div>
+          <p className="note">
+            Lakeside led appreciation at +14%, while Cedar Park cooled slightly against last year.
+          </p>
+        </section>
+
+        {/* Paired bars: list vs sale ----------------------------------- */}
+        <section className="card card-pad chart-block reveal">
+          <div className="card-head">
+            <h2>List vs. sale by region</h2>
+            <span className="sub">sale bar, list reference</span>
+          </div>
+          <div className="chart-frame paired-frame">
+            <div className="paired-labels" aria-hidden>
+              {listVsSale.map((d) => (
+                <span key={d.label}>{d.label}</span>
+              ))}
+            </div>
+            <PairedBars
+              data={listVsSale}
+              mode="grouped"
+              orientation="horizontal"
+              positive="up"
+              format={usd}
+              width={320}
+              height={240}
+              title="Median list price versus sale price by region"
+              style={{ width: "100%", height: "auto" }}
+              animate
+            />
+          </div>
+          <p className="note">
+            Five of six regions close above their list reference; only Sunset Terrace prints a
+            shortfall.
+          </p>
+        </section>
+
+        {/* Benchmark: three homes vs their own comp sets, one shared scale */}
+        <section className="card card-pad chart-block reveal">
+          <div className="card-head">
+            <h2>Home vs. comp set</h2>
+            <span className="sub">3 flagged listings · $/sqft</span>
+          </div>
+          <SparkGroup domain="shared" width={150} height={48} className="bench-row">
+            {benchmarks.map((b) => (
+              <BenchmarkStrip
+                key={b.name}
+                data={b.cohort}
+                value={b.value}
+                range="p5p95"
+                label="value"
+                format={usdSqft}
+                title={`${b.name} at $${b.value} per foot against its comparable set`}
+                style={{ width: "100%", height: "auto" }}
+              />
+            ))}
+          </SparkGroup>
+          <div className="bench-labels">
+            {benchmarks.map((b) => (
+              <span key={b.name}>{b.name}</span>
+            ))}
+          </div>
+          <p className="note">
+            Marlowe prices in the upper third of its comp set; Harborview and Lakeside have more
+            room to negotiate — all three read off the same metro $/sqft scale.
+          </p>
+        </section>
+
+        {/* Partition: type composition --------------------------------- */}
+        <section className="card card-pad chart-block reveal">
+          <div className="card-head">
+            <h2>Inventory composition</h2>
+            <span className="sub">type → subtype, all active listings</span>
+          </div>
+          <div className="chart-frame">
+            <PartitionStrip
+              data={typeComposition}
+              colors={typeColors}
+              labels
+              width={420}
+              height={96}
+              title="Active inventory by property type and subtype"
+              style={{ width: "100%", height: "auto" }}
+            />
+          </div>
+          <div className="legend">
+            {typeComposition.map((d, i) => (
+              <span key={d.label}>
+                <i style={{ background: typeColors[i] }} />
+                {d.label}
+              </span>
+            ))}
+          </div>
+        </section>
+
+        {/* Volume profile: sales by price level ------------------------ */}
+        <section className="card card-pad chart-block reveal">
+          <div className="card-head">
+            <h2>Sales by price level</h2>
+            <span className="sub">closed sales · shaded value area</span>
+          </div>
+          <div className="chart-frame">
+            <VolumeProfile
+              data={salesByPrice}
+              align="left"
+              format={usd}
+              width={420}
+              height={240}
+              title="Closed sales volume by price level"
+              style={{ width: "100%", height: "auto" }}
+              animate
+            />
+          </div>
+          <p className="note">
+            The market’s center of gravity sits in the $500K–$575K band — where the most deals
+            actually close.
+          </p>
+        </section>
+
+        {/* Sales mix over time ----------------------------------------- */}
+        <section className="card card-pad chart-block full reveal">
+          <div className="card-head">
+            <h2>Sales mix over time</h2>
+            <span className="sub">units closed by buyer segment · trailing 12 months</span>
+          </div>
+          <div className="chart-frame">
+            <StackedArea
+              data={salesMix}
+              colors={mixColors}
+              label="last"
+              width={720}
+              height={220}
+              title="Monthly closed sales by buyer segment"
+              style={{ width: "100%", height: "auto" }}
+              animate
+            />
+          </div>
+          <div className="legend">
+            {salesMix.map((s, i) => (
+              <span key={s.label}>
+                <i style={{ background: mixColors[i] }} />
+                {s.label} buyers
+              </span>
+            ))}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/examples/atlas-realestate/src/components/ListingsView.tsx
+++ b/examples/atlas-realestate/src/components/ListingsView.tsx
@@ -1,0 +1,298 @@
+import { Sparkline } from "@microcharts/react/sparkline/interactive";
+import { Delta } from "@microcharts/react/delta/interactive";
+import { Bullet } from "@microcharts/react/bullet/interactive";
+import { EventTimeline } from "@microcharts/react/event-timeline/interactive";
+import { MiniBar } from "@microcharts/react/mini-bar/interactive";
+import { MicroBox } from "@microcharts/react/micro-box/interactive";
+import { Thermometer } from "@microcharts/react/thermometer/interactive";
+import { PictogramRow } from "@microcharts/react/pictogram-row/interactive";
+import { CalendarStrip } from "@microcharts/react/calendar-strip/interactive";
+import {
+  listings,
+  featured,
+  lifecycle,
+  timelineDomain,
+  today,
+  closings,
+  usd,
+  money,
+  type Listing,
+} from "../data";
+
+function FeaturedSpotlight() {
+  const f = featured;
+  const compLo = Math.min(...f.comps);
+  const compHi = Math.max(...f.comps);
+  // Adjustments are signed moves off list — MiniBar (shared baseline) so each
+  // bump's size reads; list → offer lives in the caption (list would dwarf a
+  // waterfall domain that includes zero).
+  const wfOpen = f.adjustments[0]!.value;
+  const wfSteps = f.adjustments.slice(1);
+  const wfNet = wfSteps.reduce((s, d) => s + d.value, 0);
+  const wfEnd = wfOpen + wfNet;
+
+  return (
+    <section className="card spotlight reveal">
+      <div className="spotlight-mast">
+        <span className="pill pill-hot">Bidding war · 5% over ask</span>
+        <div className="spotlight-addr">{f.address}</div>
+        <div className="spotlight-hood">{f.neighborhood}</div>
+        <div className="spotlight-meta">
+          {f.beds} bd · {f.baths} ba · {f.sqft.toLocaleString()} sqft · {f.dom} days on market
+        </div>
+      </div>
+
+      <div className="spotlight-body">
+        <div className="spotlight-top">
+          <div>
+            <div className="stat-label">Accepted offer</div>
+            <div className="spotlight-price">{money(f.offer)}</div>
+            <div className="stat-foot">
+              <Delta
+                value={f.offer}
+                from={f.list}
+                positive="up"
+                format={{ style: "percent", maximumFractionDigits: 1 }}
+                summary={false}
+              />
+              <span>over ${money(f.list).replace("$", "")} list</span>
+            </div>
+          </div>
+          <div className="spotlight-facts">
+            <div className="fact">
+              <span className="fact-lbl">Beds</span>
+              <span className="mc-inline">
+                <PictogramRow
+                  value={f.beds}
+                  total={5}
+                  shape="square"
+                  width={78}
+                  height={16}
+                  summary={false}
+                />
+              </span>
+            </div>
+            <div className="fact">
+              <span className="fact-lbl">Baths</span>
+              <span className="mc-inline">
+                <PictogramRow
+                  value={f.baths}
+                  total={5}
+                  shape="square"
+                  width={78}
+                  height={16}
+                  summary={false}
+                />
+              </span>
+            </div>
+            <div className="fact">
+              <span className="fact-lbl">Size</span>
+              <span className="fact-val">{f.sqft.toLocaleString()} sqft</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="spotlight-charts">
+          <div className="mini-block">
+            <div className="mini-head">
+              <span className="lbl">List vs. estimate</span>
+              <span className="sub">
+                {money(f.list)} list · {money(f.estimate)} est.
+              </span>
+            </div>
+            <Thermometer
+              value={f.list}
+              target={f.estimate}
+              domain={[compLo, compHi]}
+              orientation="horizontal"
+              bulb={false}
+              label="value"
+              format={usd}
+              width={300}
+              height={44}
+              title={`List price ${money(f.list)} against estimate ${money(f.estimate)}`}
+              style={{ width: "100%", height: "auto" }}
+            />
+          </div>
+
+          <div className="mini-block">
+            <div className="mini-head">
+              <span className="lbl">Comparable sales</span>
+              <span className="sub">{f.comps.length} recent · $/spread</span>
+            </div>
+            <MicroBox
+              data={f.comps}
+              format={usd}
+              width={300}
+              height={44}
+              title="Comparable recent sale prices near this home"
+              style={{ width: "100%", height: "auto" }}
+            />
+          </div>
+
+          <div className="mini-block wide">
+            <div className="mini-head">
+              <span className="lbl">Listing lifecycle</span>
+              <span className="sub">listed → pending in {f.dom} days</span>
+            </div>
+            <EventTimeline
+              data={lifecycle}
+              now={today}
+              domain={timelineDomain}
+              label="spans"
+              width={520}
+              height={52}
+              title="Lifecycle of the featured listing"
+              style={{ width: "100%", height: "auto" }}
+              animate
+            />
+          </div>
+
+          <div className="mini-block wide">
+            <div className="mini-head">
+              <span className="lbl">Price adjustments</span>
+              <span className="sub">
+                {money(wfOpen)} list → {money(wfEnd)} offer · net {wfNet >= 0 ? "+" : "−"}
+                {money(Math.abs(wfNet)).replace("$", "")}
+              </span>
+            </div>
+            <MiniBar
+              data={wfSteps}
+              positive="up"
+              color={wfSteps.every((s) => s.value >= 0) ? "var(--mc-positive)" : undefined}
+              format={usd}
+              width={520}
+              height={72}
+              title={`Price moves from ${money(wfOpen)} list to ${money(wfEnd)} offer`}
+              style={{ width: "100%", height: "auto" }}
+              animate
+            />
+            <div className="legend" style={{ marginTop: 8 }}>
+              {wfSteps.map((s) => (
+                <span key={s.label}>
+                  <i
+                    style={{
+                      background: s.value >= 0 ? "var(--mc-positive)" : "var(--mc-negative)",
+                    }}
+                  />
+                  {s.label} · {s.value >= 0 ? "+" : "−"}
+                  {money(Math.abs(s.value)).replace("$", "")}
+                </span>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ListingCard({ item }: { item: Listing }) {
+  const lo = Math.min(item.list, item.offer, item.estimate) * 0.97;
+  const hi = Math.max(item.list, item.offer, item.estimate) * 1.03;
+  return (
+    <article className="card listing reveal">
+      <div className="listing-mast">
+        <div className="listing-addr">{item.address}</div>
+        <div className="listing-hood">{item.neighborhood}</div>
+        <span className="listing-badge">{item.dom} days on market</span>
+      </div>
+      <div className="listing-body">
+        <div className="listing-top">
+          <div className="listing-meta">
+            <span>{item.beds} bd</span>
+            <span>{item.baths} ba</span>
+            <span>{item.sqft.toLocaleString()} sqft</span>
+          </div>
+          <div className="listing-price">{money(item.list)}</div>
+        </div>
+
+        <div className="spark-row">
+          <span className="lbl">8-week price</span>
+          <span className="mc-inline">
+            <Sparkline
+              data={item.history}
+              width={110}
+              height={28}
+              dots="auto"
+              curve="smooth"
+              summary={false}
+            />
+          </span>
+          <Delta
+            value={item.offer}
+            from={item.list}
+            positive="up"
+            format={{ style: "percent", maximumFractionDigits: 1 }}
+            summary={false}
+          />
+        </div>
+
+        <div className="bullet-row">
+          <span className="lbl">Offer vs. asking vs. estimate</span>
+          <Bullet
+            value={item.offer}
+            target={item.list}
+            bands={[item.estimate]}
+            domain={[lo, hi]}
+            format={usd}
+            width={240}
+            height={30}
+            title={`Offer ${money(item.offer)} against list ${money(item.list)} and estimate ${money(item.estimate)}`}
+            style={{ width: "100%", height: "auto" }}
+          />
+        </div>
+      </div>
+    </article>
+  );
+}
+
+export function ListingsView() {
+  return (
+    <div className="page">
+      <div className="page-head">
+        <div>
+          <div className="eyebrow">Portfolio · {listings.length} plots</div>
+          <h1>Homes on the record</h1>
+          <p>
+            Every active listing with its price history, offer strength, and estimate spread — read
+            at a glance.
+          </p>
+        </div>
+        <span className="pill">Sorted by momentum</span>
+      </div>
+
+      <FeaturedSpotlight />
+
+      <section className="card card-pad reveal" style={{ margin: "18px 0" }}>
+        <div className="card-head">
+          <h2>Closings calendar</h2>
+          <span className="sub">homes closing per day · last 6 weeks</span>
+        </div>
+        <div className="chart-frame chart-frame-center">
+          <CalendarStrip
+            data={closings}
+            weeks={6}
+            end="2026-07-18"
+            weekStart={1}
+            shape="round"
+            cell={10}
+            gap={2}
+            title="Homes closing per day over the last six weeks"
+            style={{ width: "100%", height: "auto", maxWidth: 460 }}
+          />
+        </div>
+        <p className="note">
+          Closings bunch mid-week and spike at month-end as contracts race to fund before the
+          cutoff.
+        </p>
+      </section>
+
+      <div className="listing-grid">
+        {listings.map((item) => (
+          <ListingCard key={item.id} item={item} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/examples/atlas-realestate/src/components/MarketView.tsx
+++ b/examples/atlas-realestate/src/components/MarketView.tsx
@@ -1,0 +1,394 @@
+import { useState } from "react";
+import { HistogramStrip } from "@microcharts/react/histogram-strip/interactive";
+import { QuadrantDot } from "@microcharts/react/quadrant-dot/interactive";
+import { RateVolume } from "@microcharts/react/rate-volume/interactive";
+import { NetFlow } from "@microcharts/react/net-flow/interactive";
+import { DotPlot } from "@microcharts/react/dot-plot/interactive";
+import { SegmentedBar } from "@microcharts/react/segmented-bar/interactive";
+import { PercentileLadder } from "@microcharts/react/percentile-ladder/interactive";
+import { HeatCell } from "@microcharts/react/heat-cell/interactive";
+import { RugStrip } from "@microcharts/react/rug-strip/interactive";
+import { MiniBar } from "@microcharts/react/mini-bar/interactive";
+import { Delta } from "@microcharts/react/delta/interactive";
+import {
+  priceObservations,
+  medianPrice,
+  listingScatter,
+  focalListing,
+  inventoryByType,
+  daysOnMarket,
+  marketStats,
+  neighborhoods,
+  heatMetrics,
+  heatMatrix,
+  heatDomain,
+  ppsfLeaderboard,
+  ppsfObservations,
+  metroPpsf,
+  absorption,
+  inventoryFlow,
+  usd,
+  usdSqft,
+  pct,
+  money,
+} from "../data";
+
+// Materials categorical palette (steel / brass / patina / plum) — CSS vars so dark flips.
+export const typeColors = [
+  "var(--mc-cat-1)",
+  "var(--mc-cat-2)",
+  "var(--mc-cat-3)",
+  "var(--mc-cat-4)",
+];
+
+function statValue(s: (typeof marketStats)[number]): string {
+  return new Intl.NumberFormat("en-US", s.format).format(s.value);
+}
+
+type BinDatum = { index: number; value: number | null; label?: string; formatted?: string } | null;
+
+export function MarketView() {
+  const [priceBin, setPriceBin] = useState<BinDatum>(null);
+
+  return (
+    <div className="page">
+      <div className="page-head">
+        <div>
+          <div className="eyebrow">Survey 001 · Q3 2026</div>
+          <h1>The metro, measured</h1>
+          <p>
+            Median sale price, inventory, and pace across all tracked neighborhoods — one quarter of
+            the record.
+          </p>
+        </div>
+        <span className="pill pill-live">Live · updated 9m ago</span>
+      </div>
+
+      {/* KPI cards -------------------------------------------------------- */}
+      <div className="stat-row reveal">
+        {marketStats.map((s) => (
+          <div key={s.label} className="card card-pad stat">
+            <div className="stat-label">{s.label}</div>
+            <div className="stat-value">{statValue(s)}</div>
+            <div className="stat-foot">
+              <Delta value={s.value} from={s.from} positive={s.positive} summary={false} />
+              <span>vs. last quarter</span>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Signature: neighborhood heat matrix ----------------------------- */}
+      <section className="card card-pad reveal" style={{ marginBottom: 18 }}>
+        <div className="card-head">
+          <h2>Neighborhood heat map</h2>
+          <span className="sub">market intensity · 0–100 per metric</span>
+        </div>
+        <div
+          className="heat-matrix"
+          style={{
+            gridTemplateColumns: `max-content repeat(${heatMetrics.length}, 72px)`,
+          }}
+          role="table"
+          aria-label="Market intensity by neighborhood and metric"
+        >
+          <div className="heat-corner" role="columnheader" />
+          {heatMetrics.map((m) => (
+            <div key={m} className="heat-col" role="columnheader">
+              {m}
+            </div>
+          ))}
+          {heatMatrix.map((row) => (
+            <HeatRow key={row.name} name={row.name} values={row.values} />
+          ))}
+        </div>
+        <p className="note">
+          Lakeside runs hot on every axis; Sunset Terrace and Cedar Park are the metro’s cooler,
+          buyer-friendlier corners. Brighter cells mean stronger pressure.
+        </p>
+      </section>
+
+      <div className="market-grid">
+        {/* Price distribution ------------------------------------------- */}
+        <section className="card card-pad chart-block reveal">
+          <div className="card-head">
+            <h2>Price distribution</h2>
+            <span className="sub">accent bin = metro median</span>
+          </div>
+          <div className="chart-frame">
+            <HistogramStrip
+              data={priceObservations}
+              markValue={medianPrice}
+              format={usd}
+              width={420}
+              height={120}
+              title="Sale price distribution across the metro"
+              style={{ width: "100%", height: "auto" }}
+              animate
+              readout={false}
+              onActive={setPriceBin}
+            />
+          </div>
+          <p className={`picker-readout${priceBin ? " is-active" : ""}`}>
+            {priceBin
+              ? (priceBin.formatted ?? `${priceBin.label} — ${priceBin.value ?? 0} sales`)
+              : "Scrub the strip — value lives here, chip stays off"}
+          </p>
+          <p className="note">
+            Most homes clear between $440K and $620K; the long right tail is the Lakeside and
+            Harborview luxury segment.
+          </p>
+        </section>
+
+        {/* Inventory by type -------------------------------------------- */}
+        <section className="card card-pad chart-block reveal">
+          <div className="card-head">
+            <h2>Inventory by type</h2>
+            <span className="sub">1,040 active</span>
+          </div>
+          <div className="chart-frame">
+            <SegmentedBar
+              data={inventoryByType}
+              colors={typeColors}
+              label="percent"
+              width={420}
+              height={54}
+              title="Active inventory by property type"
+              style={{ width: "100%", height: "auto" }}
+            />
+          </div>
+          <div className="legend">
+            {inventoryByType.map((d, i) => (
+              <span key={d.label}>
+                <i style={{ background: typeColors[i] }} />
+                {d.label}
+              </span>
+            ))}
+          </div>
+        </section>
+
+        {/* Price vs size ------------------------------------------------ */}
+        <section className="card card-pad chart-block reveal">
+          <div className="card-head">
+            <h2>Price vs. living area</h2>
+            <span className="sub">each dot = one listing</span>
+          </div>
+          <div className="chart-frame">
+            <QuadrantDot
+              data={focalListing}
+              field={listingScatter}
+              xLabel="living area"
+              yLabel="list price"
+              xDomain={[1000, 2600]}
+              domain={[360000, 760000]}
+              format={usd}
+              width={380}
+              height={300}
+              title="List price versus living area, one dot per listing"
+              style={{ width: "100%", height: "auto" }}
+              animate
+            />
+          </div>
+          <p className="note">
+            The highlighted listing sits above the price/size trend: premium finish for its
+            footprint.
+          </p>
+        </section>
+
+        {/* Days on market ----------------------------------------------- */}
+        <section className="card card-pad chart-block reveal">
+          <div className="card-head">
+            <h2>Days on market</h2>
+            <span className="sub">P50 · P90 · P99</span>
+          </div>
+          <div className="chart-frame">
+            <PercentileLadder
+              data={daysOnMarket}
+              ps={[50, 90, 99]}
+              label="both"
+              width={380}
+              height={120}
+              title="Days-on-market percentiles"
+              style={{ width: "100%", height: "auto" }}
+            />
+          </div>
+          <p className="note">
+            Half of homes go under contract within two weeks; the slowest 10% linger past a month.
+          </p>
+        </section>
+
+        {/* Absorption: rate vs volume ----------------------------------- */}
+        <section className="card card-pad chart-block reveal">
+          <div className="card-head">
+            <h2>Absorption rate</h2>
+            <span className="sub">share of inventory sold vs sales volume</span>
+          </div>
+          <div className="chart-frame">
+            <RateVolume
+              data={absorption}
+              format={pct}
+              volumeFormat={{ maximumFractionDigits: 0 }}
+              unit="sales"
+              width={420}
+              height={130}
+              title="Monthly absorption rate over sales volume"
+              style={{ width: "100%", height: "auto" }}
+              animate
+            />
+          </div>
+          <p className="note">
+            The market is tightening: a rising share of active inventory clears each month even as
+            volume holds steady.
+          </p>
+        </section>
+
+        {/* Inventory flow: net ------------------------------------------ */}
+        <section className="card card-pad chart-block reveal">
+          <div className="card-head">
+            <h2>Inventory flow</h2>
+            <span className="sub">new listings vs homes sold</span>
+          </div>
+          <div className="chart-frame">
+            <NetFlow
+              data={inventoryFlow}
+              label="last"
+              width={420}
+              height={130}
+              title="Listings added versus homes sold, by month"
+              style={{ width: "100%", height: "auto" }}
+              animate
+            />
+          </div>
+          <p className="note">
+            Homes are now leaving the market faster than new listings arrive — the net line has
+            dipped below zero for three straight months.
+          </p>
+        </section>
+
+        {/* $/sqft leaderboard ------------------------------------------- */}
+        <section className="card card-pad chart-block reveal">
+          <div className="card-head">
+            <h2>Price per square foot</h2>
+            <span className="sub">median, by neighborhood</span>
+          </div>
+          <div className="chart-frame">
+            <DotPlot
+              data={ppsfLeaderboard}
+              highlight="Lakeside"
+              format={usdSqft}
+              width={380}
+              height={200}
+              title="Median price per square foot by neighborhood"
+              style={{ width: "100%", height: "auto" }}
+              animate
+            />
+          </div>
+          <p className="note">
+            Lakeside commands the top per-foot premium; Sunset Terrace anchors the value end at
+            nearly $90 less.
+          </p>
+        </section>
+
+        {/* Rug: you are here -------------------------------------------- */}
+        <section className="card card-pad chart-block reveal">
+          <div className="card-head">
+            <h2>Where the metro sits</h2>
+            <span className="sub">$/sqft · neighborhood field, metro marked</span>
+          </div>
+          <div className="chart-frame chart-frame-center">
+            <RugStrip
+              data={ppsfObservations}
+              markValue={metroPpsf}
+              format={usdSqft}
+              width={420}
+              height={56}
+              title="Metro median price per square foot against every neighborhood"
+              style={{ width: "100%", height: "auto" }}
+            />
+          </div>
+          <p className="note">
+            The metro median of ${metroPpsf} per foot lands just above the middle of the
+            neighborhood spread.
+          </p>
+        </section>
+      </div>
+
+      {/* Neighborhood table with per-row inventory mix ------------------- */}
+      <section className="card reveal" style={{ marginTop: 18 }}>
+        <div className="card-pad card-head" style={{ marginBottom: 0 }}>
+          <h2>Neighborhood detail</h2>
+          <span className="sub">{neighborhoods.length} tracked · sortable in the full report</span>
+        </div>
+        <div className="table-scroll">
+          <table className="data-table">
+            <thead>
+              <tr>
+                <th>Neighborhood</th>
+                <th className="num">Median</th>
+                <th className="num">$/sqft</th>
+                <th className="num">DOM</th>
+                <th className="num">YoY</th>
+                <th className="mix-col">Inventory mix</th>
+              </tr>
+            </thead>
+            <tbody>
+              {neighborhoods.map((n) => (
+                <tr key={n.name}>
+                  <td className="td-name">{n.name}</td>
+                  <td className="num">{money(n.median)}</td>
+                  <td className="num">${n.ppsf}</td>
+                  <td className="num">{n.dom}</td>
+                  <td className="num">
+                    <Delta
+                      value={n.median * (1 + n.yoy)}
+                      from={n.median}
+                      positive="up"
+                      summary={false}
+                    />
+                  </td>
+                  <td className="mix-col">
+                    <span className="mc-inline">
+                      <MiniBar
+                        data={[
+                          { label: "Single-family", value: n.mix.sf },
+                          { label: "Condo", value: n.mix.condo },
+                          { label: "Townhouse", value: n.mix.town },
+                        ]}
+                        width={130}
+                        height={20}
+                        summary={false}
+                      />
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function HeatRow({ name, values }: { name: string; values: number[] }) {
+  return (
+    <>
+      <div className="heat-name" role="rowheader">
+        {name}
+      </div>
+      {values.map((v, i) => (
+        <div key={i} className="heat-cell-wrap">
+          <HeatCell
+            value={v}
+            domain={heatDomain}
+            steps={5}
+            shape="square"
+            label="none"
+            title={`${name} ${heatMetrics[i]}: ${v} of 100`}
+            style={{ width: "100%", height: "auto", display: "block" }}
+          />
+        </div>
+      ))}
+    </>
+  );
+}

--- a/examples/atlas-realestate/src/data.ts
+++ b/examples/atlas-realestate/src/data.ts
@@ -1,0 +1,597 @@
+// Atlas — mock real-estate market data. Believable, deterministic, seeded.
+// Everything here is computed once at module load; views useMemo over these.
+
+/* ------------------------------------------------------------------ formats */
+
+export const usd = {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0,
+} as const;
+
+export const usdSqft = {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0,
+} as const;
+
+export const pct = {
+  style: "percent",
+  maximumFractionDigits: 1,
+} as const;
+
+export const pct0 = {
+  style: "percent",
+  maximumFractionDigits: 0,
+} as const;
+
+export function money(n: number): string {
+  return new Intl.NumberFormat("en-US", usd).format(n);
+}
+
+/* --------------------------------------------------------------------- prng */
+// mulberry32 — tiny deterministic PRNG so every render is byte-identical.
+
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const rand = mulberry32(0x0a71a5);
+
+/** Gentle random walk around a base, rounded to a step. */
+function walk(base: number, points: number, drift: number, jitter: number, step: number): number[] {
+  const out: number[] = [];
+  let v = base;
+  for (let i = 0; i < points; i++) {
+    v += drift + (rand() - 0.5) * jitter;
+    out.push(Math.round(v / step) * step);
+  }
+  return out;
+}
+
+/* ------------------------------------------------------------- neighborhoods */
+
+export interface Neighborhood {
+  name: string;
+  /** Median sale price ($). */
+  median: number;
+  /** Median price per square foot ($). */
+  ppsf: number;
+  /** Median days on market. */
+  dom: number;
+  /** Active inventory (listings). */
+  inventory: number;
+  /** Year-over-year median-price appreciation (fraction). */
+  yoy: number;
+  /** Sale-to-list ratio (fraction, e.g. 1.03 = 3% over asking). */
+  saleToList: number;
+  /** Inventory mix — units of each property type currently listed. */
+  mix: { sf: number; condo: number; town: number };
+}
+
+export const neighborhoods: Neighborhood[] = [
+  {
+    name: "Lakeside",
+    median: 698000,
+    ppsf: 331,
+    dom: 6,
+    inventory: 142,
+    yoy: 0.141,
+    saleToList: 1.049,
+    mix: { sf: 88, condo: 24, town: 30 },
+  },
+  {
+    name: "Harborview",
+    median: 731000,
+    ppsf: 318,
+    dom: 19,
+    inventory: 96,
+    yoy: 0.082,
+    saleToList: 0.979,
+    mix: { sf: 41, condo: 44, town: 11 },
+  },
+  {
+    name: "Mission Hills",
+    median: 592000,
+    ppsf: 297,
+    dom: 9,
+    inventory: 168,
+    yoy: 0.08,
+    saleToList: 1.03,
+    mix: { sf: 104, condo: 32, town: 32 },
+  },
+  {
+    name: "Grove District",
+    median: 559000,
+    ppsf: 289,
+    dom: 7,
+    inventory: 131,
+    yoy: 0.053,
+    saleToList: 1.033,
+    mix: { sf: 76, condo: 28, town: 27 },
+  },
+  {
+    name: "Riverside",
+    median: 655000,
+    ppsf: 276,
+    dom: 16,
+    inventory: 118,
+    yoy: 0.071,
+    saleToList: 0.988,
+    mix: { sf: 63, condo: 40, town: 15 },
+  },
+  {
+    name: "Oakridge",
+    median: 508000,
+    ppsf: 271,
+    dom: 12,
+    inventory: 154,
+    yoy: 0.02,
+    saleToList: 1.006,
+    mix: { sf: 92, condo: 34, town: 28 },
+  },
+  {
+    name: "Cedar Park",
+    median: 411000,
+    ppsf: 258,
+    dom: 5,
+    inventory: 97,
+    yoy: -0.024,
+    saleToList: 1.032,
+    mix: { sf: 55, condo: 26, town: 16 },
+  },
+  {
+    name: "Sunset Terrace",
+    median: 421000,
+    ppsf: 244,
+    dom: 28,
+    inventory: 134,
+    yoy: 0.011,
+    saleToList: 0.979,
+    mix: { sf: 61, condo: 42, town: 31 },
+  },
+];
+
+/* --------------------------------------------------------------- market view */
+
+/** Raw sale prices across the metro (full dollars). */
+export const priceObservations: number[] = [
+  412000, 445000, 398000, 520000, 610000, 475000, 388000, 542000, 690000, 455000, 505000, 468000,
+  720000, 435000, 580000, 495000, 640000, 410000, 560000, 485000, 530000, 615000, 448000, 705000,
+  492000, 575000, 428000, 660000, 512000, 590000, 462000, 538000, 685000, 405000, 555000, 478000,
+  625000, 442000, 598000, 508000, 672000, 458000, 522000, 645000, 415000, 568000, 488000, 635000,
+  425000, 585000,
+];
+
+export const medianPrice = 512000;
+
+/** Each dot is a listing: price ($) vs. living area (sqft). */
+export const listingScatter: { x: number; y: number }[] = [
+  { x: 1180, y: 398000 },
+  { x: 1420, y: 445000 },
+  { x: 1650, y: 512000 },
+  { x: 1890, y: 560000 },
+  { x: 2100, y: 615000 },
+  { x: 2340, y: 690000 },
+  { x: 1520, y: 468000 },
+  { x: 1760, y: 535000 },
+  { x: 2010, y: 588000 },
+  { x: 2480, y: 720000 },
+  { x: 1340, y: 428000 },
+  { x: 1620, y: 495000 },
+  { x: 1980, y: 572000 },
+  { x: 2260, y: 648000 },
+  { x: 1440, y: 455000 },
+  { x: 2150, y: 605000 },
+];
+/** The listing currently being previewed — the focal dot. */
+export const focalListing = { x: 2100, y: 615000 };
+
+/** Active inventory by property type (metro-wide). */
+export const inventoryByType: { label: string; value: number }[] = [
+  { label: "Single-family", value: 486 },
+  { label: "Condo", value: 312 },
+  { label: "Townhouse", value: 168 },
+  { label: "Multi-family", value: 74 },
+];
+
+/** Days-on-market across active + recently-sold listings. */
+export const daysOnMarket: number[] = [
+  4, 7, 9, 11, 6, 14, 8, 21, 12, 17, 5, 9, 28, 13, 10, 34, 7, 16, 11, 24, 8, 19, 6, 12, 41, 9, 15,
+  22, 7, 13, 18, 10, 31, 8, 14, 26, 11, 9, 37, 12,
+];
+
+export const marketStats = [
+  { label: "Median price", value: 512000, from: 486000, format: usd, positive: "up" as const },
+  {
+    label: "Active inventory",
+    value: 1040,
+    from: 1180,
+    format: { maximumFractionDigits: 0 },
+    positive: "down" as const,
+  },
+  { label: "Price / sqft", value: 289, from: 271, format: usdSqft, positive: "up" as const },
+  { label: "Sale-to-list", value: 1.012, from: 0.997, format: pct, positive: "up" as const },
+];
+
+/* --- heat-cell matrix: neighborhood × metric intensity (shared 0–100 scale) */
+
+export const heatMetrics = ["Demand", "Apprec.", "$/sqft", "Liquid.", "Compet."] as const;
+
+/** One 0–100 intensity per (neighborhood, metric). Shared domain across all cells. */
+export const heatMatrix: { name: string; values: number[] }[] = neighborhoods.map((n) => {
+  const demand = 100 - Math.min(100, n.dom * 2.6); // faster market = hotter
+  const appreciation = Math.max(0, Math.min(100, (n.yoy + 0.03) * 560));
+  const ppsf = Math.max(0, Math.min(100, (n.ppsf - 235) * 1.05));
+  const liquidity = Math.max(0, Math.min(100, 120 - n.inventory * 0.42));
+  const competition = Math.max(0, Math.min(100, (n.saleToList - 0.95) * 850));
+  return {
+    name: n.name,
+    values: [demand, appreciation, ppsf, liquidity, competition].map((v) => Math.round(v)),
+  };
+});
+export const heatDomain: [number, number] = [0, 100];
+
+/** $/sqft leaderboard — dot-plot on a common scale. */
+export const ppsfLeaderboard: { label: string; value: number }[] = neighborhoods
+  .map((n) => ({ label: n.name, value: n.ppsf }))
+  .sort((a, b) => b.value - a.value);
+
+/** $/sqft observations across neighborhoods — denser than one tick per name so
+ *  the metro mark reads against a real field, not eight lonely ticks. */
+export const ppsfObservations: number[] = neighborhoods.flatMap((n) => {
+  const spread = [0.92, 0.96, 1, 1.03, 1.07];
+  return spread.map((s) => Math.round(n.ppsf * s));
+});
+export const metroPpsf = 289;
+
+/** 12-month absorption: sale rate (% of active inventory sold) vs sales volume. */
+const salesVolume = walk(96, 12, 3.5, 26, 1);
+export const absorption: { rate: number; volume: number }[] = salesVolume.map((vol, i) => ({
+  rate: Math.max(0.04, Math.min(0.16, 0.062 + i * 0.004 + (rand() - 0.5) * 0.02)),
+  volume: Math.max(40, vol),
+}));
+
+/** 12-month inventory flow: new listings in vs homes sold out. */
+const inFlow = walk(128, 12, -1.5, 30, 1);
+const outFlow = walk(104, 12, 2, 26, 1);
+export const inventoryFlow: { in: number; out: number }[] = inFlow.map((v, i) => ({
+  in: Math.max(30, v),
+  out: Math.max(30, outFlow[i]!),
+}));
+
+/* ------------------------------------------------------------- listings view */
+
+export interface Listing {
+  id: string;
+  address: string;
+  neighborhood: string;
+  beds: number;
+  baths: number;
+  sqft: number;
+  list: number;
+  offer: number;
+  estimate: number;
+  dom: number;
+  /** 8-point weekly price history ($). */
+  history: number[];
+  /** Comparable recent sale prices near this home ($). */
+  comps: number[];
+  /** Signed list-price adjustments over the marketing window ($). */
+  adjustments: { label: string; value: number }[];
+}
+
+export const listings: Listing[] = [
+  {
+    id: "1",
+    address: "418 Marlowe St",
+    neighborhood: "Mission Hills",
+    beds: 3,
+    baths: 2,
+    sqft: 1780,
+    list: 585000,
+    offer: 602000,
+    estimate: 578000,
+    dom: 9,
+    history: [592000, 590000, 589000, 585000, 585000, 585000, 598000, 602000],
+    comps: [548000, 561000, 566000, 572000, 578000, 583000, 590000, 604000, 612000],
+    adjustments: [
+      { label: "List", value: 592000 },
+      { label: "Wk 2", value: -7000 },
+      { label: "Wk 4", value: 0 },
+      { label: "Offer", value: 17000 },
+    ],
+  },
+  {
+    id: "2",
+    address: "12 Harborview Ct",
+    neighborhood: "Harborview",
+    beds: 4,
+    baths: 3,
+    sqft: 2340,
+    list: 720000,
+    offer: 705000,
+    estimate: 731000,
+    dom: 21,
+    history: [745000, 740000, 735000, 728000, 720000, 720000, 712000, 705000],
+    comps: [688000, 702000, 715000, 724000, 731000, 738000, 745000, 758000],
+    adjustments: [
+      { label: "List", value: 745000 },
+      { label: "Wk 3", value: -17000 },
+      { label: "Wk 5", value: -8000 },
+      { label: "Offer", value: -15000 },
+    ],
+  },
+  {
+    id: "3",
+    address: "907 Cedar Park Dr",
+    neighborhood: "Cedar Park",
+    beds: 2,
+    baths: 2,
+    sqft: 1180,
+    list: 398000,
+    offer: 415000,
+    estimate: 402000,
+    dom: 5,
+    history: [389000, 392000, 395000, 398000, 398000, 405000, 410000, 415000],
+    comps: [372000, 384000, 391000, 398000, 402000, 408000, 414000, 421000],
+    adjustments: [
+      { label: "List", value: 389000 },
+      { label: "Wk 1", value: 9000 },
+      { label: "Offer", value: 17000 },
+    ],
+  },
+  {
+    id: "4",
+    address: "233 Oakridge Ln",
+    neighborhood: "Oakridge",
+    beds: 3,
+    baths: 2,
+    sqft: 1650,
+    list: 512000,
+    offer: 512000,
+    estimate: 508000,
+    dom: 12,
+    history: [518000, 516000, 514000, 512000, 512000, 512000, 512000, 512000],
+    comps: [488000, 496000, 502000, 508000, 512000, 516000, 522000, 531000],
+    adjustments: [
+      { label: "List", value: 518000 },
+      { label: "Wk 2", value: -6000 },
+      { label: "Offer", value: 0 },
+    ],
+  },
+  {
+    id: "5",
+    address: "55 Lakeside Ave",
+    neighborhood: "Lakeside",
+    beds: 4,
+    baths: 3,
+    sqft: 2480,
+    list: 690000,
+    offer: 724000,
+    estimate: 701000,
+    dom: 3,
+    history: [672000, 678000, 685000, 690000, 690000, 705000, 718000, 724000],
+    comps: [656000, 672000, 685000, 694000, 701000, 710000, 720000, 736000],
+    adjustments: [
+      { label: "List", value: 672000 },
+      { label: "Wk 1", value: 18000 },
+      { label: "Offer", value: 34000 },
+    ],
+  },
+  {
+    id: "6",
+    address: "1408 Sunset Terrace",
+    neighborhood: "Sunset Terrace",
+    beds: 2,
+    baths: 1,
+    sqft: 1340,
+    list: 428000,
+    offer: 419000,
+    estimate: 434000,
+    dom: 28,
+    history: [448000, 444000, 440000, 435000, 428000, 428000, 422000, 419000],
+    comps: [408000, 418000, 425000, 431000, 434000, 440000, 447000, 455000],
+    adjustments: [
+      { label: "List", value: 448000 },
+      { label: "Wk 2", value: -13000 },
+      { label: "Wk 4", value: -7000 },
+      { label: "Offer", value: -9000 },
+    ],
+  },
+  {
+    id: "7",
+    address: "76 Grove District Pl",
+    neighborhood: "Grove District",
+    beds: 3,
+    baths: 2,
+    sqft: 1890,
+    list: 560000,
+    offer: 578000,
+    estimate: 566000,
+    dom: 7,
+    history: [552000, 555000, 558000, 560000, 560000, 568000, 574000, 578000],
+    comps: [532000, 544000, 552000, 559000, 566000, 573000, 581000, 592000],
+    adjustments: [
+      { label: "List", value: 552000 },
+      { label: "Wk 2", value: 8000 },
+      { label: "Offer", value: 18000 },
+    ],
+  },
+  {
+    id: "8",
+    address: "340 Riverside Blvd",
+    neighborhood: "Riverside",
+    beds: 5,
+    baths: 4,
+    sqft: 2260,
+    list: 648000,
+    offer: 640000,
+    estimate: 655000,
+    dom: 16,
+    history: [662000, 658000, 654000, 650000, 648000, 648000, 644000, 640000],
+    comps: [618000, 632000, 644000, 651000, 655000, 662000, 671000, 684000],
+    adjustments: [
+      { label: "List", value: 662000 },
+      { label: "Wk 3", value: -14000 },
+      { label: "Offer", value: -8000 },
+    ],
+  },
+];
+
+/** The listing spotlighted at the top of the Listings view. */
+export const featured = listings[4]!; // 55 Lakeside Ave — the bidding-war story
+
+/**
+ * Featured listing lifecycle for the event-timeline. Point events + one span.
+ * A fixed reference "today" keeps the render deterministic (no Date.now()).
+ */
+export const today = new Date("2026-07-16T00:00:00Z");
+const day = 86400000;
+export const lifecycle: {
+  start: Date;
+  end?: Date;
+  label?: string;
+  kind?: "neutral" | "positive" | "negative" | "accent";
+}[] = [
+  { start: new Date(today.getTime() - 24 * day), label: "Listed", kind: "accent" },
+  {
+    start: new Date(today.getTime() - 22 * day),
+    end: new Date(today.getTime() - 15 * day),
+    label: "Showings",
+    kind: "neutral",
+  },
+  { start: new Date(today.getTime() - 21 * day), label: "Open house", kind: "neutral" },
+  { start: new Date(today.getTime() - 14 * day), label: "First offer", kind: "positive" },
+  { start: new Date(today.getTime() - 12 * day), label: "Under contract", kind: "positive" },
+  { start: new Date(today.getTime() - 3 * day), label: "Pending", kind: "accent" },
+];
+export const timelineDomain: [Date, Date] = [
+  new Date(today.getTime() - 26 * day),
+  new Date(today.getTime() + 4 * day),
+];
+
+/** Recent + upcoming closings, calendar-strip (value = homes closing that day). */
+export const closings: { date: string; value: number }[] = (() => {
+  const out: { date: string; value: number }[] = [];
+  const end = new Date("2026-07-18T00:00:00Z");
+  for (let i = 0; i < 42; i++) {
+    const d = new Date(end.getTime() - i * day);
+    const dow = d.getUTCDay();
+    // Closings cluster on weekdays, end-of-month; sparse on weekends.
+    let base = dow === 0 || dow === 6 ? 0 : 1 + Math.floor(rand() * 3);
+    if (d.getUTCDate() >= 27) base += Math.floor(rand() * 3);
+    if (rand() < 0.18) base = 0;
+    out.push({ date: d.toISOString().slice(0, 10), value: base });
+  }
+  return out.reverse();
+})();
+
+/* -------------------------------------------------------------- compare view */
+
+/** List price → sale price by neighborhood (median, $). */
+export const listToSale: { label: string; from: number; to: number }[] = [
+  { label: "Lakeside", from: 665000, to: 698000 },
+  { label: "Mission Hills", from: 575000, to: 592000 },
+  { label: "Grove District", from: 548000, to: 559000 },
+  { label: "Oakridge", from: 505000, to: 508000 },
+  { label: "Cedar Park", from: 402000, to: 411000 },
+  { label: "Sunset Terrace", from: 435000, to: 421000 },
+];
+
+/** Median price last year → this year by neighborhood ($). */
+export const yearOverYear: { label: string; from: number; to: number }[] = [
+  { label: "Lakeside", from: 612000, to: 698000 },
+  { label: "Mission Hills", from: 548000, to: 592000 },
+  { label: "Grove District", from: 531000, to: 559000 },
+  { label: "Oakridge", from: 498000, to: 508000 },
+  { label: "Cedar Park", from: 421000, to: 411000 },
+];
+
+/** Sales mix over 12 months — three buyer segments (unit counts). */
+export const salesMix: { label: string; values: number[] }[] = [
+  { label: "First-time", values: [82, 78, 91, 104, 118, 132, 141, 128, 116, 98, 88, 94] },
+  { label: "Move-up", values: [64, 68, 72, 79, 88, 96, 102, 95, 84, 76, 70, 73] },
+  { label: "Investor", values: [38, 42, 45, 41, 48, 52, 56, 61, 54, 47, 43, 46] },
+];
+
+/** List vs sale (median $) by region — paired bars. */
+export const listVsSale: { label: string; value: number; ref: number }[] = listToSale.map((d) => ({
+  label: d.label,
+  value: d.to, // sale
+  ref: d.from, // list
+}));
+
+/** Property type → subtype composition (units listed metro-wide) — partition. */
+export const typeComposition: { label: string; children: { label: string; value: number }[] }[] = [
+  {
+    label: "Single-family",
+    children: [
+      { label: "Detached", value: 342 },
+      { label: "Ranch", value: 96 },
+      { label: "Estate", value: 48 },
+    ],
+  },
+  {
+    label: "Condo",
+    children: [
+      { label: "High-rise", value: 148 },
+      { label: "Low-rise", value: 118 },
+      { label: "Loft", value: 46 },
+    ],
+  },
+  {
+    label: "Townhouse",
+    children: [
+      { label: "Interior", value: 104 },
+      { label: "End-unit", value: 64 },
+    ],
+  },
+  {
+    label: "Multi-family",
+    children: [
+      { label: "Duplex", value: 44 },
+      { label: "Triplex", value: 30 },
+    ],
+  },
+];
+
+/** Closed sales by price level ($ bucket → count) — volume profile. */
+export const salesByPrice: { level: number; weight: number }[] = [
+  { level: 375000, weight: 38 },
+  { level: 425000, weight: 71 },
+  { level: 475000, weight: 118 },
+  { level: 525000, weight: 156 },
+  { level: 575000, weight: 141 },
+  { level: 625000, weight: 98 },
+  { level: 675000, weight: 62 },
+  { level: 725000, weight: 34 },
+  { level: 775000, weight: 15 },
+];
+
+/** Three flagged listings benchmarked against their own comp set ($/sqft) —
+ * a small-multiples row, drawn to one shared scale via SparkGroup. */
+export const benchmarks: { name: string; value: number; cohort: number[] }[] = [
+  {
+    name: "418 Marlowe St",
+    value: 329,
+    cohort: [278, 291, 297, 302, 308, 314, 319, 326, 333, 341, 352],
+  },
+  {
+    name: "12 Harborview Ct",
+    value: 301,
+    cohort: [275, 288, 296, 304, 312, 319, 327, 335, 344, 353, 363],
+  },
+  {
+    name: "55 Lakeside Ave",
+    value: 292,
+    cohort: [255, 268, 275, 282, 289, 296, 303, 310, 318, 327, 337],
+  },
+];

--- a/examples/atlas-realestate/src/main.tsx
+++ b/examples/atlas-realestate/src/main.tsx
@@ -1,0 +1,37 @@
+import { StrictMode, useEffect, useState } from "react";
+import { createRoot } from "react-dom/client";
+import "@microcharts/react/styles.css";
+import "@microcharts/react/motion";
+import "./app.css";
+import "./analytics";
+import { MicroProvider } from "@microcharts/react";
+import { App } from "./App";
+import { atlasTheme } from "./theme";
+
+function usePrefersDark(): boolean {
+  const [dark, setDark] = useState(
+    () => typeof matchMedia !== "undefined" && matchMedia("(prefers-color-scheme: dark)").matches,
+  );
+  useEffect(() => {
+    const mq = matchMedia("(prefers-color-scheme: dark)");
+    const onChange = () => setDark(mq.matches);
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
+  return dark;
+}
+
+function Root() {
+  const dark = usePrefersDark();
+  return (
+    <MicroProvider style={dark ? atlasTheme.darkVars : atlasTheme.vars}>
+      <App />
+    </MicroProvider>
+  );
+}
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <Root />
+  </StrictMode>,
+);

--- a/examples/atlas-realestate/src/theme.ts
+++ b/examples/atlas-realestate/src/theme.ts
@@ -1,0 +1,14 @@
+import { defineTheme } from "@microcharts/react/theme";
+
+// Prussian ink on limestone in light; on dark surfaces the auto-twin of
+// `#1a3a5c` collapses to near-white and HeatCell's accent→band ramp washes
+// out — pin a chromatic steel blue so intensity steps stay readable.
+export const atlasTheme = defineTheme({
+  extends: "vivid",
+  accent: "#1a3a5c",
+  strokeWidth: 1.25,
+  density: 1,
+  dark: {
+    accent: "#6ba3d4",
+  },
+});

--- a/examples/atlas-realestate/tsconfig.json
+++ b/examples/atlas-realestate/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "moduleDetection": "force",
+    "isolatedModules": true
+  },
+  "include": ["src"]
+}

--- a/examples/atlas-realestate/vite.config.ts
+++ b/examples/atlas-realestate/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: { port: 4006, strictPort: true, host: true },
+});

--- a/examples/cortex-ai/index.html
+++ b/examples/cortex-ai/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <meta name="color-scheme" content="dark light" />
+    <meta name="theme-color" content="#17150f" media="(prefers-color-scheme: dark)" />
+    <meta name="theme-color" content="#f6f4ef" media="(prefers-color-scheme: light)" />
+    <meta
+      name="description"
+      content="Cortex — an eval & observability instrument for model quality and agent runs, built with microcharts."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;500;600;700&family=Spectral:ital,wght@0,500;0,600;1,500&family=Spline+Sans+Mono:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <title>Cortex — eval &amp; observability instrument</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/cortex-ai/package.json
+++ b/examples/cortex-ai/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "example-cortex-ai",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite --port 4007 --strictPort",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview --port 4007 --strictPort"
+  },
+  "dependencies": {
+    "@microcharts/react": "^0.8.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^5.0.0",
+    "typescript": "^5.7.0",
+    "vite": "^7.0.0"
+  }
+}

--- a/examples/cortex-ai/public/robots.txt
+++ b/examples/cortex-ai/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/examples/cortex-ai/src/App.tsx
+++ b/examples/cortex-ai/src/App.tsx
@@ -1,0 +1,110 @@
+import { useState } from "react";
+import { HeartbeatBlip } from "@microcharts/react/heartbeat-blip/interactive";
+import { StatusDot } from "@microcharts/react/status-dot/interactive";
+import { LiveView } from "./components/LiveView";
+import { TranscriptsView } from "./components/TranscriptsView";
+import { EvalsView } from "./components/EvalsView";
+import { TracesView } from "./components/TracesView";
+import * as d from "./data";
+
+type Tab = "live" | "transcripts" | "evals" | "traces";
+
+const TABS: { id: Tab; label: string; count?: string }[] = [
+  { id: "live", label: "Live", count: "4" },
+  { id: "transcripts", label: "Transcripts", count: "1.2k" },
+  { id: "evals", label: "Evals", count: "312" },
+  { id: "traces", label: "Traces", count: "9f2c" },
+];
+
+function BrandMark() {
+  // A tiny constellation — nodes wired into a "cortex".
+  return (
+    <span className="brand-mark" aria-hidden="true">
+      <svg width="22" height="22" viewBox="0 0 18 18" fill="none">
+        <path
+          d="M4 5 L9 3 L14 6 M4 5 L6 11 M9 3 L11 9 M14 6 L11 9 M6 11 L11 9 M6 11 L9 15 L11 9"
+          stroke="currentColor"
+          strokeWidth="1.1"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          opacity="0.85"
+        />
+        <circle cx="4" cy="5" r="1.5" fill="currentColor" />
+        <circle cx="9" cy="3" r="1.5" fill="currentColor" />
+        <circle cx="14" cy="6" r="1.5" fill="currentColor" />
+        <circle cx="6" cy="11" r="1.5" fill="currentColor" />
+        <circle cx="11" cy="9" r="1.8" fill="currentColor" />
+        <circle cx="9" cy="15" r="1.5" fill="currentColor" />
+      </svg>
+    </span>
+  );
+}
+
+export function App() {
+  const [tab, setTab] = useState<Tab>("live");
+
+  return (
+    <div className="app">
+      <header className="topbar">
+        <div className="brand">
+          <BrandMark />
+          <div>
+            <div className="brand-name">Cortex</div>
+            <div className="brand-sub">
+              eval &amp; observability <b>· prod</b>
+            </div>
+          </div>
+        </div>
+
+        <div className="topbar-spacer" />
+
+        <div className="live-cluster">
+          <span className="live-chip hide-sm" title="Requests, last 60s">
+            <HeartbeatBlip
+              events={d.headerPulse.events}
+              now={d.headerPulse.now}
+              window={d.headerPulse.window}
+              width={72}
+              height={22}
+              summary={false}
+            />
+            <span className="num">142</span> rps
+          </span>
+          <span className="live-chip">
+            <StatusDot status="ok" pulse />
+            <span className="num">4</span>&nbsp;healthy
+          </span>
+        </div>
+      </header>
+
+      <nav className="tabs" role="tablist" aria-label="Console sections">
+        {TABS.map((t) => (
+          <button
+            key={t.id}
+            role="tab"
+            aria-selected={tab === t.id}
+            className="tab"
+            onClick={() => setTab(t.id)}
+          >
+            {t.label}
+            {t.count && <span className="tab-count num">{t.count}</span>}
+          </button>
+        ))}
+      </nav>
+
+      <main>
+        <div className="container">
+          {tab === "live" && <LiveView />}
+          {tab === "transcripts" && <TranscriptsView />}
+          {tab === "evals" && <EvalsView />}
+          {tab === "traces" && <TracesView />}
+        </div>
+      </main>
+
+      <footer className="foot">
+        <span className="mono">cortex · eval &amp; observability instrument</span>
+        <span className="mono">build r24.7 · us-east-2 · instrumented by microcharts</span>
+      </footer>
+    </div>
+  );
+}

--- a/examples/cortex-ai/src/analytics.ts
+++ b/examples/cortex-ai/src/analytics.ts
@@ -1,0 +1,14 @@
+// Cloudflare Web Analytics — privacy-first, cookieless page-view/visit beacon.
+// Injected only when VITE_CF_BEACON_TOKEN is set at build time; otherwise a no-op.
+// Get a token: Cloudflare dashboard → Web Analytics → Add a site → copy the token
+// (or just enable Web Analytics on the Pages project, which auto-injects instead). See DEPLOY.md.
+const token = (import.meta as unknown as { env?: Record<string, string | undefined> }).env
+  ?.VITE_CF_BEACON_TOKEN;
+if (token) {
+  const s = document.createElement("script");
+  s.defer = true;
+  s.src = "https://static.cloudflareinsights.com/beacon.min.js";
+  s.setAttribute("data-cf-beacon", JSON.stringify({ token }));
+  document.head.appendChild(s);
+}
+export {};

--- a/examples/cortex-ai/src/app.css
+++ b/examples/cortex-ai/src/app.css
@@ -1,0 +1,1118 @@
+/* ============================================================================
+   CORTEX — eval & observability instrument.
+
+   Aesthetic: a refined scientific instrument. Warm-graphite near-black,
+   one exacting blueprint-cobalt signal, three typographic voices —
+   Spectral (editorial headlines), Hanken Grotesk (interface & reading),
+   Spline Sans Mono (machine readout). Nothing glows for glow's sake.
+
+   Light tokens live in :root; a hand-tuned dark block sits at the END so it
+   wins the cascade against microcharts' zero-specificity prefers-color-scheme.
+   ========================================================================== */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+html {
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}
+body {
+  margin: 0;
+}
+
+:root {
+  /* ── three typographic voices ─────────────────────────────────────────── */
+  /* Editorial serif — the human headline voice. */
+  --display: "Spectral", "Iowan Old Style", Georgia, "Times New Roman", serif;
+  /* Interface + reading grotesque. Also --mc-font, so SVG chart text stays a
+     clean sans and never inherits a display/serif face. */
+  --ui:
+    "Hanken Grotesk", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Helvetica, Arial,
+    sans-serif;
+  /* Machine readout — every figure, every spec label. */
+  --mono: "Spline Sans Mono", ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+
+  /* fixed rem scale for a product UI — ratio ~1.28 through the heads */
+  --fs-eyebrow: 0.6875rem; /* 11 */
+  --fs-cap: 0.75rem; /* 12 */
+  --fs-label: 0.8125rem; /* 13 */
+  --fs-body: 0.9375rem; /* 15 */
+  --fs-lg: 1.0625rem; /* 17 */
+  --fs-h3: 1.1875rem; /* 19 */
+  --fs-h2: clamp(1.35rem, 1.15rem + 0.9vw, 1.75rem);
+  --fs-h1: clamp(1.9rem, 1.4rem + 2.4vw, 2.9rem);
+
+  /* 4pt spatial scale */
+  --s1: 0.25rem;
+  --s2: 0.5rem;
+  --s3: 0.75rem;
+  --s4: 1rem;
+  --s5: 1.5rem;
+  --s6: 2rem;
+  --s7: 3rem;
+  --s8: 4.5rem;
+
+  --r-sm: 7px;
+  --r: 11px;
+  --r-lg: 16px;
+  --r-pill: 999px;
+
+  /* ── neutrals — warm graphite, tinted toward the ink (hue ~78) ─────────── */
+  --bg: oklch(0.975 0.004 82);
+  --bg-grid: oklch(0.93 0.006 82);
+  --panel: oklch(0.995 0.002 82);
+  --panel-2: oklch(0.968 0.004 82);
+  --panel-inset: oklch(0.945 0.006 80);
+  --ink: oklch(0.245 0.012 74);
+  --ink-2: oklch(0.43 0.012 74);
+  --ink-3: oklch(0.56 0.01 76);
+  --ink-4: oklch(0.68 0.008 78);
+  --line: oklch(0.9 0.006 80);
+  --line-2: oklch(0.938 0.005 82);
+
+  /* ── the one signal: blueprint cobalt (hue ~252, steely, never purple) ─── */
+  --accent: oklch(0.5 0.16 252);
+  --accent-ink: oklch(0.46 0.16 252);
+  --accent-soft: oklch(0.5 0.16 252 / 0.08);
+  --accent-line: oklch(0.5 0.16 252 / 0.24);
+
+  --shadow-sm: 0 1px 2px oklch(0.245 0.012 74 / 0.06);
+  --shadow:
+    0 2px 6px -2px oklch(0.245 0.012 74 / 0.08), 0 14px 30px -18px oklch(0.245 0.012 74 / 0.18);
+  --shadow-lg:
+    0 4px 12px -4px oklch(0.245 0.012 74 / 0.1), 0 28px 60px -26px oklch(0.245 0.012 74 / 0.24);
+
+  /* microcharts contract — share the identity, never touch valence hues */
+  --mc-font: var(--ui);
+  --mc-font-numeric: var(--mono);
+  --mc-accent: var(--accent);
+
+  color-scheme: light dark;
+}
+
+body {
+  font-family: var(--ui);
+  font-size: var(--fs-body);
+  line-height: 1.55;
+  color: var(--ink);
+  background: var(--bg);
+  /* a faint engineering grid — registration, not decoration */
+  background-image:
+    linear-gradient(to right, var(--bg-grid) 1px, transparent 1px),
+    linear-gradient(to bottom, var(--bg-grid) 1px, transparent 1px);
+  background-size: 96px 96px;
+  background-position: -1px -1px;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  font-variant-ligatures: none;
+}
+
+/* ── primitives ───────────────────────────────────────────────────────────── */
+.num,
+.mono {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum" 1;
+  letter-spacing: -0.01em;
+}
+.eyebrow {
+  font-family: var(--mono);
+  font-size: var(--fs-eyebrow);
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+}
+.muted {
+  color: var(--ink-3);
+}
+h1,
+h2,
+h3,
+h4 {
+  margin: 0;
+  font-weight: 620;
+  letter-spacing: -0.014em;
+  line-height: 1.14;
+}
+p {
+  margin: 0;
+}
+a {
+  color: inherit;
+}
+
+/* ── app shell ──────────────────────────────────────────────────────────── */
+.app {
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+}
+
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  gap: var(--s4);
+  padding: var(--s3) clamp(var(--s4), 4vw, var(--s7));
+  background: color-mix(in oklab, var(--panel) 92%, transparent);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  border-bottom: 1px solid var(--line);
+}
+.brand {
+  display: flex;
+  align-items: center;
+  gap: var(--s3);
+  min-width: 0;
+}
+.brand-mark {
+  width: 26px;
+  height: 26px;
+  flex: none;
+  display: grid;
+  place-items: center;
+  color: var(--accent);
+}
+.brand-mark svg {
+  display: block;
+}
+.brand-name {
+  font-family: var(--mono);
+  font-weight: 600;
+  font-size: 0.9rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  line-height: 1;
+  color: var(--ink);
+}
+.brand-sub {
+  font-family: var(--mono);
+  font-size: var(--fs-eyebrow);
+  color: var(--ink-3);
+  letter-spacing: 0.03em;
+  margin-top: 4px;
+}
+.brand-sub b {
+  color: var(--accent-ink);
+  font-weight: 600;
+}
+
+.topbar-spacer {
+  flex: 1 1 auto;
+}
+.live-cluster {
+  display: flex;
+  align-items: center;
+  gap: var(--s3);
+}
+.live-chip {
+  display: flex;
+  align-items: center;
+  gap: var(--s2);
+  padding: 5px var(--s3);
+  border: 1px solid var(--line);
+  border-radius: var(--r-sm);
+  background: var(--panel-2);
+  font-family: var(--mono);
+  font-size: var(--fs-cap);
+  color: var(--ink-3);
+  white-space: nowrap;
+}
+.live-chip .num {
+  color: var(--ink);
+  font-weight: 600;
+}
+.live-chip svg {
+  display: block;
+}
+.hide-sm {
+  display: none;
+}
+
+/* ── tab bar ─────────────────────────────────────────────────────────────── */
+.tabs {
+  display: flex;
+  gap: 2px;
+  padding: 0 clamp(var(--s4), 4vw, var(--s7));
+  overflow-x: auto;
+  scrollbar-width: none;
+  border-bottom: 1px solid var(--line);
+  background: color-mix(in oklab, var(--panel) 70%, transparent);
+  position: sticky;
+  top: 53px;
+  z-index: 40;
+}
+.tabs::-webkit-scrollbar {
+  display: none;
+}
+.tab {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--ink-3);
+  font-family: var(--ui);
+  font-size: var(--fs-label);
+  font-weight: 550;
+  padding: var(--s3) var(--s3) calc(var(--s3) + 1px);
+  min-height: 46px;
+  cursor: pointer;
+  white-space: nowrap;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--s2);
+  transition: color 0.18s ease;
+}
+.tab:hover {
+  color: var(--ink);
+}
+.tab[aria-selected="true"] {
+  color: var(--ink);
+}
+.tab::after {
+  content: "";
+  position: absolute;
+  left: var(--s3);
+  right: var(--s3);
+  bottom: -1px;
+  height: 2px;
+  border-radius: 2px 2px 0 0;
+  background: var(--accent);
+  transform: scaleX(0);
+  transform-origin: center;
+  transition: transform 0.22s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.tab[aria-selected="true"]::after {
+  transform: scaleX(1);
+}
+.tab .tab-count {
+  font-family: var(--mono);
+  font-size: 0.6875rem;
+  color: var(--ink-4);
+  letter-spacing: 0;
+}
+.tab[aria-selected="true"] .tab-count {
+  color: var(--accent-ink);
+}
+.tab:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -3px;
+  border-radius: var(--r-sm);
+}
+
+/* ── view container ─────────────────────────────────────────────────────── */
+main {
+  flex: 1 1 auto;
+}
+.container {
+  max-width: 1220px;
+  margin: 0 auto;
+  padding: clamp(var(--s5), 4vw, var(--s7)) clamp(var(--s4), 4vw, var(--s7)) var(--s8);
+  /* Sticky tab bar is ~40px under the 53px topbar — keep heads clear. */
+  scroll-margin-top: 100px;
+}
+
+/* editorial, left-aligned, asymmetric head with a mono spec line */
+.view-head {
+  margin-bottom: var(--s6);
+  max-width: 60ch;
+  scroll-margin-top: 100px;
+}
+.view-head .eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--s2);
+  padding-bottom: var(--s3);
+}
+.view-head .eyebrow::before {
+  content: "";
+  width: 22px;
+  height: 1px;
+  background: var(--accent);
+}
+.view-head h1 {
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: var(--fs-h1);
+  letter-spacing: -0.02em;
+  line-height: 1.06;
+  margin: 0 0 var(--s4);
+  text-wrap: balance;
+}
+.view-head p {
+  color: var(--ink-2);
+  font-size: var(--fs-lg);
+  line-height: 1.6;
+  max-width: 58ch;
+}
+
+/* ── bento grid — 12-col so the rhythm can be genuinely varied ──────────── */
+.grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--s4);
+}
+@media (min-width: 720px) {
+  .grid {
+    grid-template-columns: repeat(12, 1fr);
+    gap: var(--s4);
+    align-items: start;
+  }
+  .col-2 {
+    grid-column: span 4;
+  }
+  .col-3 {
+    grid-column: span 5;
+  }
+  .col-4 {
+    grid-column: span 7;
+  }
+  .col-6 {
+    grid-column: span 12;
+  }
+}
+@media (min-width: 1000px) {
+  .grid {
+    gap: var(--s5);
+  }
+  .col-2 {
+    grid-column: span 4;
+  }
+  .col-3 {
+    grid-column: span 6;
+  }
+  .col-4 {
+    grid-column: span 8;
+  }
+}
+
+/* ── card ───────────────────────────────────────────────────────────────── */
+.card {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--r-lg);
+  padding: var(--s5);
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: var(--s4);
+  min-width: 0;
+  transition:
+    transform 0.22s cubic-bezier(0.22, 1, 0.36, 1),
+    box-shadow 0.22s ease,
+    border-color 0.22s ease;
+}
+.card.pad-lg {
+  padding: clamp(var(--s5), 3vw, var(--s6));
+}
+.card.hover:hover {
+  /* NO transform here: a transform on a card breaks the interactive charts' pointer→SVG
+     mapping (hover/focus drift). The shadow + border lift is the affordance instead. */
+  box-shadow: var(--shadow);
+  border-color: color-mix(in oklab, var(--accent) 30%, var(--line));
+}
+.card.accent {
+  border-color: var(--accent-line);
+  background: linear-gradient(178deg, var(--accent-soft), transparent 38%), var(--panel);
+}
+.card-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--s3);
+}
+.card-title {
+  font-size: var(--fs-h3);
+  font-weight: 600;
+  letter-spacing: -0.012em;
+  line-height: 1.2;
+}
+.card-sub {
+  color: var(--ink-3);
+  font-size: var(--fs-label);
+  line-height: 1.4;
+  margin-top: 4px;
+}
+.card-tag {
+  flex: none;
+  font-family: var(--mono);
+  font-size: 0.6875rem;
+  letter-spacing: 0.03em;
+  color: var(--ink-3);
+  padding: 3px 8px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-sm);
+  background: var(--panel-2);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+}
+
+/* chart fills its frame; the frame is a quiet instrument bezel */
+.chart-fill {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+.chart-frame {
+  position: relative;
+  border-radius: var(--r);
+  background: var(--panel-2);
+  border: 1px solid var(--line-2);
+  /* extra top headroom: the interactive hover readout (.mc-spark-readout) anchors
+     just above the chart's top edge, so it needs clear space or it crowds the top lane. */
+  padding: 30px var(--s4) var(--s4);
+  box-shadow: inset 0 1px 0 oklch(1 0 0 / 0.5);
+}
+
+/* a picker readout under a chart — the active/pinned unit read back in words */
+.picker-readout {
+  font-family: var(--mono);
+  font-size: var(--fs-cap);
+  color: var(--ink-3);
+  letter-spacing: 0.01em;
+}
+.picker-readout .num {
+  color: var(--accent-ink);
+  font-weight: 600;
+}
+
+/* a live scrub chip pinned to a chart-frame corner (onActive readouts that
+   don't already get one from the chart's own interactive entry) */
+.scrub-chip {
+  position: absolute;
+  top: var(--s2);
+  right: var(--s2);
+  padding: 3px 8px;
+  border-radius: var(--r-pill);
+  border: 1px solid var(--accent-line);
+  background: color-mix(in oklab, var(--panel) 85%, var(--accent-soft));
+  font-family: var(--mono);
+  font-size: var(--fs-eyebrow);
+  font-weight: 600;
+  color: var(--accent-ink);
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+/* Legend for the flame chart's blue/gray span coding. */
+.trace-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--s5, 20px);
+  margin-top: var(--s3);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  letter-spacing: 0.01em;
+  color: var(--ink-2);
+}
+.trace-legend__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+.trace-sw {
+  width: 11px;
+  height: 11px;
+  border-radius: 3px;
+  flex: none;
+}
+.trace-sw--crit {
+  background: var(--mc-accent);
+}
+.trace-sw--off {
+  background: var(--mc-neutral, oklch(0.5 0.012 250));
+}
+
+/* ── readout bar (KPI cluster — one instrument, not four cards) ─────────── */
+.readout {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1px;
+  background: var(--line);
+  border: 1px solid var(--line);
+  border-radius: var(--r);
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+}
+@media (min-width: 720px) {
+  .readout {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+.readout-cell {
+  background: var(--panel);
+  padding: var(--s4) var(--s4) var(--s3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--s2);
+  position: relative;
+}
+.readout-label {
+  font-family: var(--mono);
+  font-size: var(--fs-eyebrow);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+}
+.readout-value {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  font-size: clamp(1.5rem, 1.2rem + 1.1vw, 2rem);
+  font-weight: 600;
+  letter-spacing: -0.03em;
+  line-height: 1;
+  color: var(--ink);
+}
+.readout-value small {
+  font-size: 0.52em;
+  font-weight: 500;
+  color: var(--ink-3);
+  margin-left: 3px;
+  letter-spacing: 0;
+}
+.readout-delta {
+  display: flex;
+  align-items: center;
+  gap: var(--s2);
+  font-family: var(--mono);
+  font-size: var(--fs-cap);
+  color: var(--ink-3);
+}
+
+/* ── model roster ───────────────────────────────────────────────────────── */
+.roster {
+  display: flex;
+  flex-direction: column;
+}
+.roster-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
+  align-items: center;
+  gap: var(--s3);
+  padding: var(--s3) var(--s2);
+  border-radius: var(--r-sm);
+  transition: background 0.15s ease;
+}
+.roster-row:hover {
+  background: var(--panel-inset);
+}
+.roster-row + .roster-row {
+  border-top: 1px solid var(--line-2);
+}
+.roster-name {
+  font-family: var(--mono);
+  font-size: var(--fs-label);
+  font-weight: 600;
+  color: var(--ink);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.roster-tier {
+  font-family: var(--mono);
+  font-size: var(--fs-eyebrow);
+  color: var(--ink-3);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-top: 3px;
+}
+.roster-metric {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  font-size: var(--fs-label);
+  text-align: right;
+  color: var(--ink-2);
+}
+.roster-metric small {
+  color: var(--ink-4);
+  font-size: 0.72em;
+  margin-left: 2px;
+}
+
+/* ── orbit small-multiples ──────────────────────────────────────────────── */
+.orbit-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(112px, 1fr));
+  gap: var(--s3);
+}
+.orbit-cell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--s2);
+  padding: var(--s3) var(--s2);
+  border: 1px solid var(--line-2);
+  border-radius: var(--r);
+  background: var(--panel-2);
+  text-align: center;
+  transition: border-color 0.18s ease;
+}
+.orbit-cell:hover {
+  border-color: var(--accent-line);
+}
+.orbit-cell .glyph {
+  width: 64px;
+  height: 64px;
+}
+.orbit-name {
+  font-family: var(--mono);
+  font-size: var(--fs-eyebrow);
+  letter-spacing: 0.02em;
+  color: var(--ink-2);
+}
+
+/* ── legend / meta rows ─────────────────────────────────────────────────── */
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--s2) var(--s4);
+  font-size: var(--fs-cap);
+  color: var(--ink-3);
+  line-height: 1.4;
+}
+.legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.legend .num {
+  color: var(--ink-2);
+}
+.swatch {
+  width: 9px;
+  height: 9px;
+  border-radius: 2px;
+  flex: none;
+}
+.statline {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--s2) var(--s5);
+  padding-top: var(--s3);
+  border-top: 1px solid var(--line-2);
+  font-family: var(--mono);
+  font-size: var(--fs-cap);
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+}
+.statline b {
+  color: var(--ink);
+  font-family: var(--mono);
+  font-weight: 600;
+  text-transform: none;
+  letter-spacing: -0.01em;
+}
+.statline span {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+/* ── transcript reader (the signature) ──────────────────────────────────── */
+.transcript {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--s5);
+}
+@media (min-width: 900px) {
+  .transcript {
+    grid-template-columns: minmax(0, 1.7fr) minmax(258px, 1fr);
+    align-items: start;
+  }
+}
+
+/* the confidence instrument that frames the reading */
+.conf-readout {
+  display: flex;
+  align-items: stretch;
+  gap: var(--s5);
+  padding: var(--s5);
+  border: 1px solid var(--accent-line);
+  border-radius: var(--r);
+  background: linear-gradient(176deg, var(--accent-soft), transparent 70%), var(--panel-2);
+}
+.conf-mean {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: var(--s2);
+  flex: none;
+  padding-right: var(--s5);
+  border-right: 1px solid var(--line);
+}
+.conf-mean-value {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  font-size: clamp(2rem, 1.5rem + 2vw, 2.9rem);
+  font-weight: 600;
+  letter-spacing: -0.04em;
+  line-height: 0.9;
+  color: var(--ink);
+}
+.conf-mean-scale {
+  font-family: var(--mono);
+  font-size: var(--fs-eyebrow);
+  color: var(--ink-4);
+  letter-spacing: 0.04em;
+}
+.conf-mean-label {
+  font-family: var(--mono);
+  font-size: var(--fs-eyebrow);
+  line-height: 1.35;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+}
+.conf-meter-wrap {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: var(--s3);
+}
+.conf-meter-caption {
+  font-family: var(--mono);
+  font-size: var(--fs-eyebrow);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-4);
+}
+.conf-meter {
+  display: flex;
+  height: 12px;
+  gap: 2px;
+  border-radius: var(--r-pill);
+  overflow: hidden;
+}
+.conf-seg {
+  min-width: 3px;
+  border-radius: 2px;
+}
+@media (prefers-reduced-motion: no-preference) {
+  .conf-seg {
+    transform-origin: left center;
+    animation: seg-grow 0.7s cubic-bezier(0.16, 1, 0.3, 1) both;
+  }
+  @keyframes seg-grow {
+    from {
+      transform: scaleX(0);
+    }
+    to {
+      transform: scaleX(1);
+    }
+  }
+}
+.conf-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--s2) var(--s4);
+  font-family: var(--mono);
+  font-size: var(--fs-cap);
+  color: var(--ink-3);
+}
+.conf-tier {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.conf-tier b {
+  color: var(--ink);
+  font-weight: 600;
+}
+@media (max-width: 559px) {
+  .conf-readout {
+    flex-direction: column;
+    gap: var(--s4);
+    padding: var(--s4);
+  }
+  .conf-mean {
+    flex-direction: row;
+    align-items: baseline;
+    padding-right: 0;
+    padding-bottom: var(--s4);
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+    width: 100%;
+    gap: var(--s3);
+  }
+}
+
+.msg {
+  display: flex;
+  gap: var(--s3);
+  align-items: flex-start;
+}
+.msg + .msg {
+  margin-top: var(--s5);
+}
+.avatar {
+  width: 28px;
+  height: 28px;
+  flex: none;
+  border-radius: 8px;
+  display: grid;
+  place-items: center;
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  font-weight: 600;
+  border: 1px solid var(--line);
+  background: var(--panel-2);
+  color: var(--ink-3);
+}
+.avatar.assistant {
+  color: oklch(0.99 0 0);
+  border: 0;
+  background: var(--accent);
+}
+.bubble {
+  min-width: 0;
+  flex: 1 1 auto;
+}
+.bubble .who {
+  font-family: var(--mono);
+  font-size: var(--fs-eyebrow);
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  margin-bottom: var(--s2);
+}
+/* the reading itself — generous, editorial measure */
+.answer-body {
+  font-size: 1.05rem;
+  line-height: 1.9;
+  letter-spacing: -0.002em;
+  max-width: 60ch;
+  color: var(--ink);
+}
+.answer-body .mc-root {
+  line-height: inherit;
+}
+.user-q {
+  font-size: var(--fs-body);
+  color: var(--ink-2);
+  line-height: 1.65;
+  max-width: 62ch;
+}
+
+/* flagged spans — leading confidence chip + full hairline, no accent stripe */
+.flags {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s3);
+}
+.flag {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: var(--s3);
+  align-items: center;
+  padding: var(--s3);
+  border: 1px solid var(--line);
+  border-radius: var(--r-sm);
+  background: var(--panel-2);
+  transition:
+    transform 0.16s cubic-bezier(0.22, 1, 0.36, 1),
+    border-color 0.16s ease;
+}
+.flag:hover {
+  transform: translateY(-1px);
+  border-color: color-mix(in oklab, var(--flag-hue) 40%, var(--line));
+}
+.flag.unsure {
+  --flag-hue: var(--mc-cat-1, #c98a1e);
+}
+.flag.guessing {
+  --flag-hue: var(--mc-negative, #bd4b2d);
+}
+.flag-conf {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  font-size: var(--fs-cap);
+  font-weight: 600;
+  color: var(--flag-hue);
+  padding: 4px 7px;
+  border-radius: var(--r-sm);
+  background: color-mix(in oklab, var(--flag-hue) 12%, transparent);
+  white-space: nowrap;
+  align-self: start;
+}
+.flag-body {
+  min-width: 0;
+}
+.flag-text {
+  font-size: var(--fs-label);
+  line-height: 1.45;
+  color: var(--ink);
+}
+.flag-meta {
+  margin-top: 5px;
+  font-family: var(--mono);
+  font-size: var(--fs-eyebrow);
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+}
+
+/* ── generic small stat pills ───────────────────────────────────────────── */
+.pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--s2);
+}
+.pill {
+  font-family: var(--mono);
+  font-size: var(--fs-cap);
+  color: var(--ink-2);
+  border: 1px solid var(--line);
+  border-radius: var(--r-sm);
+  padding: 4px 10px;
+  background: var(--panel-2);
+}
+
+/* ── footer ─────────────────────────────────────────────────────────────── */
+.foot {
+  border-top: 1px solid var(--line);
+  padding: var(--s5) clamp(var(--s4), 4vw, var(--s7));
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--s3) var(--s5);
+  align-items: center;
+  justify-content: space-between;
+  color: var(--ink-3);
+  font-family: var(--mono);
+  font-size: var(--fs-cap);
+  letter-spacing: 0.02em;
+}
+.foot .mono {
+  color: var(--ink-2);
+}
+
+/* ── entrance motion (reduced-motion safe) ──────────────────────────────── */
+@media (prefers-reduced-motion: no-preference) {
+  /* Two animations: opacity persists (forwards); the TRANSFORM animation has NO fill so
+     it reverts to `none` at rest. A `forwards` transform (even ending at translateY(0)) leaves
+     an identity matrix on the card, and any ancestor transform breaks the interactive charts'
+     pointer→SVG mapping (hover/focus drift). No lasting transform = no drift. */
+  .stagger > * {
+    opacity: 0;
+    animation:
+      riseIn 0.55s cubic-bezier(0.16, 1, 0.3, 1) forwards,
+      riseUp 0.55s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+  .stagger > *:nth-child(1) {
+    animation-delay: 0.03s;
+  }
+  .stagger > *:nth-child(2) {
+    animation-delay: 0.08s;
+  }
+  .stagger > *:nth-child(3) {
+    animation-delay: 0.13s;
+  }
+  .stagger > *:nth-child(4) {
+    animation-delay: 0.18s;
+  }
+  .stagger > *:nth-child(5) {
+    animation-delay: 0.23s;
+  }
+  .stagger > *:nth-child(6) {
+    animation-delay: 0.28s;
+  }
+  .stagger > *:nth-child(7) {
+    animation-delay: 0.33s;
+  }
+  .stagger > *:nth-child(8) {
+    animation-delay: 0.38s;
+  }
+  .view-enter {
+    animation: fade 0.34s ease both;
+  }
+  @keyframes riseIn {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+  @keyframes riseUp {
+    from {
+      transform: translateY(12px);
+    }
+    to {
+      transform: translateY(0);
+    }
+  }
+  @keyframes fade {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+}
+
+/* ── responsive tuning ──────────────────────────────────────────────────── */
+@media (min-width: 560px) {
+  .hide-sm {
+    display: inline-flex;
+  }
+}
+@media (max-width: 559px) {
+  .brand-sub {
+    display: none;
+  }
+  .card {
+    padding: var(--s4);
+    border-radius: var(--r);
+  }
+  .chart-frame {
+    padding: var(--s3);
+  }
+}
+
+/* ============================================================================
+   DARK — hand-tuned (not inverted), placed last so it wins over microcharts'
+   prefers-color-scheme block. Warm-graphite near-black, brighter cobalt.
+   ========================================================================== */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: oklch(0.17 0.008 78);
+    --bg-grid: oklch(0.215 0.009 78);
+    --panel: oklch(0.205 0.009 78);
+    --panel-2: oklch(0.228 0.01 78);
+    --panel-inset: oklch(0.265 0.011 78);
+    --ink: oklch(0.94 0.006 82);
+    --ink-2: oklch(0.79 0.008 82);
+    --ink-3: oklch(0.63 0.009 80);
+    --ink-4: oklch(0.51 0.009 80);
+    --line: oklch(0.29 0.01 78);
+    --line-2: oklch(0.25 0.009 78);
+
+    --accent: oklch(0.72 0.145 250);
+    --accent-ink: oklch(0.8 0.13 250);
+    --accent-soft: oklch(0.72 0.145 250 / 0.12);
+    --accent-line: oklch(0.72 0.145 250 / 0.32);
+
+    --shadow-sm: 0 1px 2px oklch(0 0 0 / 0.4);
+    --shadow: 0 2px 8px -2px oklch(0 0 0 / 0.5), 0 18px 40px -22px oklch(0 0 0 / 0.7);
+    --shadow-lg: 0 4px 14px -4px oklch(0 0 0 / 0.55), 0 30px 64px -28px oklch(0 0 0 / 0.8);
+  }
+  .chart-frame {
+    box-shadow: inset 0 1px 0 oklch(1 0 0 / 0.04);
+  }
+  .avatar.assistant {
+    color: oklch(0.16 0.008 78);
+  }
+}

--- a/examples/cortex-ai/src/components/EvalsView.tsx
+++ b/examples/cortex-ai/src/components/EvalsView.tsx
@@ -1,0 +1,317 @@
+import { useState } from "react";
+import { CalibrationStrip } from "@microcharts/react/calibration-strip/interactive";
+import { ConfusionGrid } from "@microcharts/react/confusion-grid/interactive";
+import { PercentileTrace } from "@microcharts/react/percentile-trace/interactive";
+import { QuantileDots } from "@microcharts/react/quantile-dots/interactive";
+import { ControlStrip } from "@microcharts/react/control-strip/interactive";
+import { Bullet } from "@microcharts/react/bullet/interactive";
+import { SegmentedBar } from "@microcharts/react/segmented-bar/interactive";
+import { BiasStrip } from "@microcharts/react/bias-strip/interactive";
+import { Card, CardHead, StatLine } from "./ui";
+import * as d from "../data";
+
+// Shared picker payload — includes 0.7 `formatted` (chart's own display string).
+type Unit = { index: number; value: number | null; label?: string; formatted?: string } | null;
+
+const mixColors = [
+  "var(--mc-positive, #0e7a5f)",
+  "var(--mc-negative, #bd4b2d)",
+  "var(--mc-cat-1, #d2982f)",
+  "var(--mc-cat-6, #a85c8c)",
+  "var(--mc-neutral, #8a8986)",
+];
+
+export function EvalsView() {
+  const total = d.confusion.counts.flat().reduce((a, b) => a + b, 0);
+  const correct = d.confusion.counts.reduce((a, row, i) => a + row[i], 0);
+  const acc = ((correct / total) * 100).toFixed(1);
+  const slaOdds = d.slaPastDots();
+  const slaP50 = (() => {
+    const s = d.slaSample.slice().sort((a, b) => a - b);
+    return s[Math.floor(s.length / 2)]!;
+  })();
+
+  const [calibActive, setCalibActive] = useState<Unit>(null);
+  const [calibSelected, setCalibSelected] = useState<Unit>(null);
+  const shownBin = calibActive ?? calibSelected;
+
+  const [pinnedCell, setPinnedCell] = useState<Unit>(null);
+  const [pinnedOutcome, setPinnedOutcome] = useState<Unit>(null);
+
+  return (
+    <div className="view-enter">
+      <div className="view-head">
+        <div className="eyebrow">Evaluation · release r24.7 · 12,842 cases</div>
+        <h1>Is the model actually good, and is it staying good?</h1>
+        <p>
+          Reliability, error structure and standing across releases — the checks a launch decision
+          rests on. Nothing here reduces to a single accuracy number, and that's the point.
+        </p>
+      </div>
+
+      <div className="grid stagger">
+        {/* Calibration */}
+        <Card span={4}>
+          <CardHead
+            title="Calibration"
+            sub="Observed frequency vs. the identity diagonal, per confidence bin"
+            tag={<>reliability</>}
+          />
+          <div className="chart-frame">
+            <CalibrationStrip
+              data={d.calibration}
+              mode="dots"
+              width={640}
+              height={246}
+              className="chart-fill"
+              animate
+              readout={false}
+              onActive={setCalibActive}
+              onSelect={setCalibSelected}
+              selectedIndex={calibSelected?.index ?? null}
+            />
+          </div>
+          <div className="picker-readout">
+            {shownBin ? (
+              <>
+                {shownBin.formatted ?? (
+                  <>
+                    predicted <span className="num">{shownBin.label}</span> → observed{" "}
+                    <span className="num">{(shownBin.value ?? 0).toFixed(2)}</span>
+                  </>
+                )}
+                {calibSelected && !calibActive ? " · pinned" : ""}
+              </>
+            ) : (
+              "Hover or focus a bin — value lives here, not in a floating chip"
+            )}
+          </div>
+          <div className="legend">
+            <span>
+              <span className="swatch" style={{ background: "var(--mc-neutral, #8a8986)" }} /> Bins
+              above 0.6 drift below the line — mild over-confidence
+            </span>
+          </div>
+        </Card>
+
+        {/* Confusion */}
+        <Card span={2}>
+          <CardHead
+            title="Intent classifier"
+            sub="Row-normalized recall · 4 classes"
+            tag={<>{acc}%</>}
+          />
+          <div style={{ display: "grid", placeItems: "center", padding: "var(--s2)" }}>
+            <ConfusionGrid
+              data={d.confusion}
+              normalize="row"
+              accent="diagonal"
+              shape="round"
+              label="accuracy"
+              size={220}
+              animate
+              onSelect={setPinnedCell}
+            />
+          </div>
+          <div className="picker-readout">
+            {pinnedCell ? (
+              <>
+                pinned <span className="num">{pinnedCell.label}</span> ·{" "}
+                <span className="num">{Math.round((pinnedCell.value ?? 0) * 100)}%</span> of row
+              </>
+            ) : (
+              <>
+                <span className="num">Other → Tech</span> is the busiest confusion
+              </>
+            )}
+          </div>
+        </Card>
+
+        {/* Percentile trace */}
+        <Card span={3}>
+          <CardHead
+            title="Standing across releases"
+            sub="Percentile rank vs. the model population, locked 0–100 scale"
+            tag={<>rank</>}
+          />
+          <div className="chart-frame">
+            <PercentileTrace
+              data={d.percentileTrace}
+              showBands
+              positive="up"
+              unit="release"
+              label="last"
+              width={480}
+              height={150}
+              className="chart-fill"
+              animate
+            />
+          </div>
+          <StatLine
+            items={[
+              [
+                "now",
+                <span className="num">p{d.percentileTrace[d.percentileTrace.length - 1]}</span>,
+              ],
+              ["low", <span className="num">p{Math.min(...d.percentileTrace)}</span>],
+              ["releases", <span className="num">{d.percentileTrace.length}</span>],
+            ]}
+          />
+        </Card>
+
+        {/* SLA odds */}
+        <Card span={3}>
+          <CardHead
+            title="Will we miss the SLA?"
+            sub={`Posterior latency draws vs. the ${d.slaThreshold}ms budget`}
+            tag={<>odds</>}
+          />
+          <div className="chart-frame">
+            <QuantileDots
+              data={d.slaSample}
+              count={d.slaDotCount}
+              threshold={d.slaThreshold}
+              side="above"
+              label="count"
+              width={480}
+              height={150}
+              className="chart-fill"
+              style={{ width: "100%", height: "auto" }}
+              animate
+              title={`Posterior latency draws vs the ${d.slaThreshold}ms SLA`}
+            />
+          </div>
+          <StatLine
+            items={[
+              [
+                "miss",
+                <span className="num">
+                  {slaOdds} in {d.slaDotCount}
+                </span>,
+              ],
+              ["SLA line", <span className="num">{d.slaThreshold}ms</span>],
+              ["p50", <span className="num">{slaP50}ms</span>],
+            ]}
+          />
+          <p className="legend">
+            Vertical line is the {d.slaThreshold}ms budget. Accent-ringed dots are quantile draws
+            above it — {slaOdds} of {d.slaDotCount} (~{Math.round((slaOdds / d.slaDotCount) * 100)}%
+            chance of missing).
+          </p>
+        </Card>
+
+        {/* Drift control */}
+        <Card span={3}>
+          <CardHead
+            title="Quality drift monitor"
+            sub="Daily pass-rate vs. the ±3σ̂ control band · Western Electric rules"
+            tag={<>SPC</>}
+          />
+          <div className="chart-frame">
+            <ControlStrip
+              data={d.driftSeries}
+              baseline={d.driftBaseline}
+              rules="we"
+              dots="out"
+              width={480}
+              height={184}
+              className="chart-fill"
+              animate
+            />
+          </div>
+          <div className="legend">
+            <span>
+              <span className="swatch" style={{ background: "var(--mc-negative, #bd4b2d)" }} /> An
+              excursion around day 31 tripped a run rule
+            </span>
+          </div>
+        </Card>
+
+        <Card span={3}>
+          <CardHead
+            title="Model vs. human judge"
+            sub="Bland–Altman · score pairs on the same cases"
+            tag={<>bias</>}
+          />
+          <div className="chart-frame">
+            <BiasStrip
+              data={d.judgePairs}
+              limits={1.96}
+              label="bias"
+              format={{ maximumFractionDigits: 2 }}
+              width={480}
+              height={184}
+              className="chart-fill"
+              style={{ width: "100%", height: "auto" }}
+              animate
+              title="Agreement between model scores and human judges"
+            />
+          </div>
+          <p className="legend">
+            Dashed line = perfect agreement (diff 0). Solid accent = measured bias (
+            {d.judgeBias >= 0 ? "+" : ""}
+            {d.judgeBias}). Dots are case pairs at (mean score, model−human).
+          </p>
+        </Card>
+
+        {/* Pass rate bullet + label mix */}
+        <Card span={6}>
+          <CardHead title="Suite pass-rate" sub="Against the 90% launch gate" />
+          <div className="chart-frame">
+            <Bullet
+              value={d.passRate.value}
+              target={d.passRate.target}
+              bands={d.passRate.bands}
+              domain={[0, 100]}
+              format={(n) => `${n}%`}
+              width={280}
+              height={44}
+              className="chart-fill"
+              animate
+            />
+          </div>
+          <StatLine
+            items={[
+              ["pass", <span className="num">{d.passRate.value}%</span>],
+              ["gate", <span className="num">{d.passRate.target}%</span>],
+              [
+                "gap",
+                <span className="num">−{(d.passRate.target - d.passRate.value).toFixed(1)}</span>,
+              ],
+            ]}
+          />
+
+          <div style={{ marginTop: "var(--s2)" }}>
+            <div className="card-sub" style={{ marginBottom: "var(--s2)" }}>
+              Outcome mix · {d.fmtInt(d.labelMix.reduce((a, m) => a + m.value, 0))} cases
+            </div>
+            <SegmentedBar
+              data={d.labelMix}
+              order="data"
+              label="percent"
+              colors={mixColors}
+              width={280}
+              height={26}
+              className="chart-fill"
+              animate
+              onSelect={setPinnedOutcome}
+            />
+            <div className="legend" style={{ marginTop: "var(--s3)" }}>
+              {d.labelMix.map((m, i) => (
+                <span key={m.label}>
+                  <span className="swatch" style={{ background: mixColors[i] }} /> {m.label}
+                </span>
+              ))}
+            </div>
+            {pinnedOutcome ? (
+              <div className="picker-readout">
+                pinned <span className="num">{pinnedOutcome.label}</span> ·{" "}
+                <span className="num">{d.fmtInt(pinnedOutcome.value ?? 0)}</span> cases
+              </div>
+            ) : null}
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/examples/cortex-ai/src/components/LiveView.tsx
+++ b/examples/cortex-ai/src/components/LiveView.tsx
@@ -1,0 +1,274 @@
+import { useState } from "react";
+import { HeartbeatBlip } from "@microcharts/react/heartbeat-blip/interactive";
+import { CometTrail } from "@microcharts/react/comet-trail/interactive";
+import { OrbitStatus } from "@microcharts/react/orbit-status/interactive";
+import { StatusDot } from "@microcharts/react/status-dot/interactive";
+import { Delta } from "@microcharts/react/delta/interactive";
+import { ActivityGrid } from "@microcharts/react/activity-grid/interactive";
+import { EtaBar } from "@microcharts/react/eta-bar/interactive";
+import { Card, CardHead, StatLine } from "./ui";
+import * as d from "../data";
+
+type Unit = { index: number; value: number | null; label?: string } | null;
+
+const stateLabel: Record<d.ModelState, string> = {
+  ok: "healthy",
+  busy: "saturated",
+  warn: "degraded",
+  error: "failing",
+  off: "offline",
+};
+
+export function LiveView() {
+  const remainingMin = ((1 - d.batchEval.progress) / d.batchEval.rate).toFixed(0);
+  const [tokenScrub, setTokenScrub] = useState<Unit>(null);
+
+  return (
+    <div className="view-enter">
+      <div className="view-head">
+        <div className="eyebrow">Platform · us-east-2</div>
+        <h1>Everything the fleet is doing, right now</h1>
+        <p>
+          Live request rate, throughput momentum and per-endpoint health across four served models.
+          Green means lower is better on cost, latency and errors.
+        </p>
+      </div>
+
+      {/* Readout bar — one instrument cluster, hairline-divided */}
+      <div
+        className="readout"
+        style={{ marginBottom: "var(--s5)" }}
+        role="group"
+        aria-label="Fleet vitals, last 24h"
+      >
+        <div className="readout-cell">
+          <span className="readout-label">Cost</span>
+          <span className="readout-value">
+            $0.42<small>/1k</small>
+          </span>
+          <span className="readout-delta">
+            <Delta value={d.kpis.cost.now} from={d.kpis.cost.from} positive="down" animate /> vs 24h
+          </span>
+        </div>
+        <div className="readout-cell">
+          <span className="readout-label">p95 latency</span>
+          <span className="readout-value">
+            1,180<small>ms</small>
+          </span>
+          <span className="readout-delta">
+            <Delta value={d.kpis.p95.now} from={d.kpis.p95.from} positive="down" animate /> vs 24h
+          </span>
+        </div>
+        <div className="readout-cell">
+          <span className="readout-label">Error rate</span>
+          <span className="readout-value">
+            0.6<small>%</small>
+          </span>
+          <span className="readout-delta">
+            <Delta value={d.kpis.error.now} from={d.kpis.error.from} positive="down" animate /> vs
+            24h
+          </span>
+        </div>
+        <div className="readout-cell">
+          <span className="readout-label">Throughput</span>
+          <span className="readout-value">
+            10.9<small>rps</small>
+          </span>
+          <span className="readout-delta">
+            <Delta
+              value={d.kpis.throughput.now}
+              from={d.kpis.throughput.from}
+              positive="up"
+              animate
+            />{" "}
+            vs 24h
+          </span>
+        </div>
+      </div>
+
+      <div className="grid stagger">
+        {/* Hero: request pulse */}
+        <Card span={4} className="pad-lg" accent>
+          <CardHead
+            title="Request pulse"
+            sub="Inference calls across the fleet, last 60 seconds"
+            tag={
+              <>
+                <span
+                  className="swatch"
+                  style={{ background: "var(--accent)", borderRadius: 999 }}
+                />{" "}
+                live
+              </>
+            }
+          />
+          <div className="chart-frame">
+            <HeartbeatBlip
+              events={d.requestPulse.events}
+              now={d.requestPulse.now}
+              window={d.requestPulse.window}
+              label="count"
+              width={640}
+              height={88}
+              className="chart-fill"
+            />
+          </div>
+          <StatLine
+            items={[
+              ["events / min", <span className="num">{d.requestPulse.events.length}</span>],
+              ["peak", <span className="num">142 rps</span>],
+              ["window", <span className="num">60s</span>],
+            ]}
+          />
+        </Card>
+
+        {/* Tokens/sec momentum */}
+        <Card span={2}>
+          <CardHead title="Tokens / sec" sub="Decode throughput, with momentum" />
+          <div className="chart-frame">
+            <CometTrail
+              data={d.tokensPerSec}
+              trail={14}
+              label="last"
+              width={260}
+              height={90}
+              className="chart-fill"
+              onActive={setTokenScrub}
+            />
+            {tokenScrub && tokenScrub.value !== null ? (
+              <span className="scrub-chip">{Math.round(tokenScrub.value)} tok/s</span>
+            ) : null}
+          </div>
+          <StatLine
+            items={[
+              ["now", <span className="num">{d.tokensPerSec[d.tokensPerSec.length - 1]}</span>],
+              ["min", <span className="num">{Math.min(...d.tokensPerSec)}</span>],
+              ["max", <span className="num">{Math.max(...d.tokensPerSec)}</span>],
+            ]}
+          />
+        </Card>
+
+        {/* Model roster */}
+        <Card span={3}>
+          <CardHead
+            title="Served models"
+            sub="Endpoint state · p50 latency · req/s"
+            tag={<>4 online</>}
+          />
+          <div className="roster">
+            {d.models.map((m) => (
+              <div className="roster-row" key={m.id}>
+                <StatusDot status={m.state} pulse={m.state === "ok" || m.state === "busy"} />
+                <div style={{ minWidth: 0 }}>
+                  <div className="roster-name">{m.name}</div>
+                  <div className="roster-tier">
+                    {m.tier} · {stateLabel[m.state]}
+                  </div>
+                </div>
+                <div className="roster-metric">
+                  {m.latency}
+                  <small>ms</small>
+                </div>
+                <div className="roster-metric">
+                  {m.rate.toFixed(1)}
+                  <small>rps</small>
+                </div>
+              </div>
+            ))}
+          </div>
+        </Card>
+
+        {/* Orbit health small-multiples */}
+        <Card span={3}>
+          <CardHead
+            title="Endpoint health"
+            sub="Orbit radius = latency · dash speed = request rate"
+            tag={<>±ms</>}
+          />
+          <div className="orbit-grid">
+            {d.orbit.map((o) => (
+              <div className="orbit-cell" key={o.id}>
+                <OrbitStatus
+                  latency={o.latency}
+                  rate={o.rate}
+                  latencyDomain={d.latencyDomain}
+                  rateDomain={d.rateDomain}
+                  threshold={d.latencyAlert}
+                  size={64}
+                  className="glyph"
+                />
+                <div className="orbit-name">{o.name.replace("cortex-", "")}</div>
+              </div>
+            ))}
+          </div>
+          <div className="legend">
+            <span>
+              <span className="swatch" style={{ background: "var(--mc-negative, #bd4b2d)" }} /> ≥{" "}
+              {d.latencyAlert}ms flagged
+            </span>
+          </div>
+        </Card>
+
+        {/* Activity grid */}
+        <Card span={4}>
+          <CardHead
+            title="Eval-run cadence"
+            sub="Suites executed per day, last 18 weeks"
+            tag={<>18w</>}
+          />
+          <div className="chart-frame">
+            <ActivityGrid
+              data={d.evalRuns}
+              layout="grid"
+              shape="round"
+              anchor={d.evalRunsStart}
+              weekStart={1}
+              cell={11}
+              className="chart-fill"
+              style={{ width: "100%", height: "auto" }}
+              animate
+            />
+          </div>
+          <StatLine
+            items={[
+              [
+                "runs",
+                <span className="num">{d.fmtInt(d.evalRuns.reduce((a, b) => a + b, 0))}</span>,
+              ],
+              ["busiest", <span className="num">{Math.max(...d.evalRuns)}</span>],
+              [
+                "quiet days",
+                <span className="num">{d.evalRuns.filter((v) => v === 0).length}</span>,
+              ],
+            ]}
+          />
+        </Card>
+
+        {/* Batch eval ETA */}
+        <Card span={2}>
+          <CardHead title="Batch eval" sub={d.batchEval.suite} tag={<>running</>} />
+          <div className="chart-frame">
+            <EtaBar
+              progress={d.batchEval.progress}
+              elapsed={d.batchEval.elapsed}
+              rate={d.batchEval.rate}
+              label="eta"
+              etaFormat={(t) => `${Math.round(t)} min`}
+              width={260}
+              height={52}
+              className="chart-fill"
+              animate
+            />
+          </div>
+          <StatLine
+            items={[
+              ["cases", <span className="num">{d.fmtInt(d.batchEval.cases)}</span>],
+              ["done", <span className="num">{Math.round(d.batchEval.progress * 100)}%</span>],
+              ["eta", <span className="num">~{remainingMin}m</span>],
+            ]}
+          />
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/examples/cortex-ai/src/components/TracesView.tsx
+++ b/examples/cortex-ai/src/components/TracesView.tsx
@@ -1,0 +1,172 @@
+import { useState } from "react";
+import { TraceFold } from "@microcharts/react/trace-fold/interactive";
+import { EventRaster } from "@microcharts/react/event-raster/interactive";
+import { Waveform } from "@microcharts/react/waveform/interactive";
+import { Sparkline } from "@microcharts/react/sparkline/interactive";
+import { Card, CardHead, StatLine } from "./ui";
+import * as d from "../data";
+
+type Unit = { index: number; value: number | null; label?: string } | null;
+
+function voicePhase(i: number): { name: string; note: string } {
+  if (i < 55) {
+    return {
+      name: "greeting",
+      note: "Opens the request — auth and route light first on the flame chart",
+    };
+  }
+  if (i < 130) {
+    return {
+      name: "intent",
+      note: "Caller states the task — plan, embed, and search spans fire next",
+    };
+  }
+  return {
+    name: "confirm",
+    note: "Caller confirms — generate is already the critical-path bottleneck",
+  };
+}
+
+export function TracesView() {
+  const slowest = d.stepLatency.indexOf(Math.max(...d.stepLatency));
+  const [waveActive, setWaveActive] = useState<Unit>(null);
+  const [pinnedStep, setPinnedStep] = useState<Unit>(null);
+  const phase = waveActive ? voicePhase(waveActive.index) : null;
+
+  return (
+    <div className="view-enter">
+      <div className="view-head">
+        <div className="eyebrow">Trace · req 9f2c…a1 · agent.run</div>
+        <h1>Follow one agent request end to end</h1>
+        <p>
+          A single tool-using request, unfolded: the voice turn that started it, where the wall time
+          went, and which tools fired at each step. Scrub the waveform — it points into the flame
+          chart.
+        </p>
+      </div>
+
+      <div className="grid stagger">
+        <Card span={6}>
+          <CardHead
+            title="Voice turn · what kicked this off"
+            sub="Per-bucket amplitude · three speech bursts"
+            tag={<>{Math.round(d.waveformProgress * 100)}% played</>}
+          />
+          <div className="chart-frame">
+            <Waveform
+              data={d.waveform}
+              progress={d.waveformProgress}
+              mode="bars"
+              mirror
+              width={1000}
+              height={126}
+              className="chart-fill"
+              animate
+              onActive={setWaveActive}
+            />
+          </div>
+          <div className="picker-readout">
+            {waveActive ? (
+              <>
+                <span className="num">{phase!.name}</span> · bucket {waveActive.index} · amp{" "}
+                {(waveActive.value ?? 0).toFixed(2)} — {phase!.note}
+              </>
+            ) : (
+              "Scrub a burst — greeting, intent, or confirm maps onto the spans below"
+            )}
+          </div>
+        </Card>
+
+        <Card span={6} className="pad-lg">
+          <CardHead
+            title="Request trace"
+            sub={`Flame chart · ${d.traceTotalMs.toLocaleString("en-US")}ms wall time · critical path accented`}
+            tag={<>10 spans</>}
+          />
+          <div className="chart-frame">
+            <TraceFold
+              data={d.traceSpans}
+              emphasis="critical"
+              labels
+              width={1000}
+              height={264}
+              className="chart-fill"
+              animate
+            />
+          </div>
+          <div className="trace-legend">
+            <span className="trace-legend__item">
+              <i className="trace-sw trace-sw--crit" /> on the critical path
+            </span>
+            <span className="trace-legend__item">
+              <i className="trace-sw trace-sw--off" /> off it — parallel or non-blocking
+            </span>
+          </div>
+          <StatLine
+            items={[
+              ["wall", <span className="num">4,200ms</span>],
+              ["on critical path", <span className="num">llm.generate</span>],
+              ["longest span", <span className="num">2,470ms</span>],
+            ]}
+          />
+        </Card>
+
+        <Card span={4}>
+          <CardHead
+            title="Tool calls by step"
+            sub="One lane per tool · x = time within the request"
+            tag={<>raster</>}
+          />
+          <div className="chart-frame">
+            <EventRaster
+              data={d.rasterLanes}
+              labels
+              domain={d.rasterDomain}
+              width={640}
+              height={222}
+              className="chart-fill"
+            />
+          </div>
+          <div className="legend">
+            <span>
+              <span className="swatch" style={{ background: "var(--accent)" }} /> generate steps
+              drive every other tool
+            </span>
+          </div>
+        </Card>
+
+        <Card span={2}>
+          <CardHead title="Step latency" sub="ms per pipeline stage" />
+          <div className="chart-frame">
+            <Sparkline
+              data={d.stepLatency}
+              curve="smooth"
+              dots="minmax"
+              format={(n) => `${Math.round(n)}ms`}
+              width={260}
+              height={90}
+              className="chart-fill"
+              animate
+              onSelect={setPinnedStep}
+              selectedIndex={pinnedStep?.index ?? null}
+            />
+          </div>
+          <StatLine
+            items={[
+              ["slowest", <span className="num">{d.stepNames[slowest]}</span>],
+              ["max", <span className="num">{Math.max(...d.stepLatency)}ms</span>],
+              [
+                "pinned",
+                <span className="num">
+                  {pinnedStep
+                    ? `${d.stepNames[pinnedStep.index]} ${Math.round(pinnedStep.value ?? 0)}ms`
+                    : "—"}
+                </span>,
+              ],
+            ]}
+          />
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/examples/cortex-ai/src/components/TranscriptsView.tsx
+++ b/examples/cortex-ai/src/components/TranscriptsView.tsx
@@ -1,0 +1,200 @@
+import { useState } from "react";
+import { TokenConfidence } from "@microcharts/react/token-confidence/interactive";
+import { RubricStrip } from "@microcharts/react/rubric-strip/interactive";
+import { StarSpoke } from "@microcharts/react/star-spoke/interactive";
+import { Card, CardHead, StatLine } from "./ui";
+import * as d from "../data";
+
+type Unit = { index: number; value: number | null; label?: string } | null;
+
+export function TranscriptsView() {
+  const [starActive, setStarActive] = useState<Unit>(null);
+  // Tier the "word" tokens (skip whitespace-only / bare-punctuation chunks).
+  const words = d.answerTokens.filter((t) => t.token.replace(/[\s.,]/g, "") !== "");
+  const tiers = { confident: 0, unsure: 0, guessing: 0 };
+  for (const t of words) tiers[d.tierOf(t.confidence)]++;
+  const flaggedCount = tiers.unsure + tiers.guessing;
+  const meanConf = d.answerTokens.reduce((a, t) => a + t.confidence, 0) / d.answerTokens.length;
+
+  const tierBands: { key: keyof typeof tiers; label: string; color: string }[] = [
+    // Colours track the chart's own tier encoding: unsure = amber underline
+    // (--mc-cat-1), guessing = red dotted (--mc-negative). Confident is unmarked
+    // in the answer, so the meter reads it as the calm positive baseline.
+    { key: "confident", label: "Confident", color: "var(--mc-positive, #0e7a5f)" },
+    { key: "unsure", label: "Unsure", color: "var(--mc-cat-1, #d2982f)" },
+    { key: "guessing", label: "Guessing", color: "var(--mc-negative, #bd4b2d)" },
+  ];
+
+  return (
+    <div className="view-enter">
+      <div className="view-head">
+        <div className="eyebrow">Transcript · run #48213 · cortex-opus-4</div>
+        <h1>Read the answer the way the model wrote it</h1>
+        <p>
+          Every token carries the model's own confidence. Hedges and specifics that the model was
+          unsure of are marked inline, so a reviewer sees exactly where to look before shipping the
+          reply.
+        </p>
+      </div>
+
+      <div className="transcript">
+        {/* Conversation */}
+        <Card hover={false} className="pad-lg">
+          <CardHead title="Support · past-window refund" tag={<>graded</>} />
+
+          {/* Signature: the confidence instrument that frames the reading */}
+          <div className="conf-readout">
+            <div className="conf-mean">
+              <span className="conf-mean-value">{meanConf.toFixed(2)}</span>
+              <span className="conf-mean-scale">of 1.00</span>
+              <span className="conf-mean-label">
+                mean token
+                <br />
+                confidence
+              </span>
+            </div>
+            <div className="conf-meter-wrap">
+              <span className="conf-meter-caption">
+                {words.length} tokens · {flaggedCount} flagged
+              </span>
+              <div
+                className="conf-meter"
+                role="img"
+                aria-label={`${tiers.confident} confident, ${tiers.unsure} unsure, ${tiers.guessing} guessing tokens`}
+              >
+                {tierBands.map((b) =>
+                  tiers[b.key] > 0 ? (
+                    <span
+                      key={b.key}
+                      className="conf-seg"
+                      style={{ flexGrow: tiers[b.key], background: b.color }}
+                    />
+                  ) : null,
+                )}
+              </div>
+              <div className="conf-legend">
+                {tierBands.map((b) => (
+                  <span key={b.key} className="conf-tier">
+                    <span className="swatch" style={{ background: b.color }} />
+                    {b.label}
+                    <b className="num">{tiers[b.key]}</b>
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <div className="msg">
+            <div className="avatar">U</div>
+            <div className="bubble">
+              <div className="who">Customer</div>
+              <p className="user-q">
+                A customer wants a refund but it's 44 days after purchase, past our 30-day window.
+                How should I route it?
+              </p>
+            </div>
+          </div>
+
+          <div className="msg">
+            <div className="avatar assistant">C</div>
+            <div className="bubble">
+              <div className="who">cortex-opus-4</div>
+              <div className="answer-body">
+                <TokenConfidence data={d.answerTokens} tiers={d.confidenceTiers} show="flagged" />
+              </div>
+            </div>
+          </div>
+
+          <StatLine
+            items={[
+              ["tokens", <span className="num">{words.length}</span>],
+              ["flagged", <span className="num">{flaggedCount}</span>],
+              ["needs review", <span className="num">{tiers.guessing} spans</span>],
+            ]}
+          />
+        </Card>
+
+        {/* Flagged spans panel */}
+        <Card hover={false}>
+          <CardHead
+            title="Flagged spans"
+            sub="Lowest-confidence phrases to verify"
+            tag={<>{d.flaggedSpans.length}</>}
+          />
+          <div className="flags">
+            {d.flaggedSpans.map((s, i) => (
+              <div className={`flag ${s.tier}`} key={i}>
+                <span className="flag-conf">{s.confidence.toFixed(2)}</span>
+                <div className="flag-body">
+                  <div className="flag-text">"{s.text}"</div>
+                  <div className="flag-meta">{s.tier === "guessing" ? "guessing" : "unsure"}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </Card>
+      </div>
+
+      {/* Scorecard + profile */}
+      <div className="grid stagger" style={{ marginTop: "var(--s5)" }}>
+        <Card span={4}>
+          <CardHead
+            title="Rubric scorecard"
+            sub="Bar length = score · thickness = weight · tick = pass threshold"
+            tag={<>target {Math.round(d.rubricTarget * 100)}%</>}
+          />
+          <div className="chart-frame">
+            <RubricStrip
+              data={d.rubric}
+              target={d.rubricTarget}
+              labels
+              domain={[0, 1]}
+              format={(n) => `${Math.round(n * 100)}%`}
+              width={640}
+              height={246}
+              className="chart-fill"
+              style={{ width: "100%", height: "auto" }}
+              animate
+            />
+          </div>
+          <div className="legend">
+            <span>
+              <span className="swatch" style={{ background: "var(--mc-negative, #bd4b2d)" }} />{" "}
+              Citations &amp; accuracy sit below target
+            </span>
+          </div>
+        </Card>
+
+        <Card span={2}>
+          <CardHead title="Answer profile" sub="This answer vs. the prior model (ghost)" />
+          <div style={{ display: "grid", placeItems: "center", padding: "var(--s3)" }}>
+            <StarSpoke
+              data={d.qualities}
+              compare={d.qualitiesBaseline}
+              guides
+              labels
+              domain={[0, 1]}
+              size={210}
+              animate
+              onActive={setStarActive}
+            />
+          </div>
+          <StatLine
+            items={[
+              ["strongest", <span className="num">Safe</span>],
+              ["weakest", <span className="num">Grounded</span>],
+              [
+                "focus",
+                <span className="num">
+                  {starActive
+                    ? `${starActive.label} ${Math.round((starActive.value ?? 0) * 100)}%`
+                    : "—"}
+                </span>,
+              ],
+            ]}
+          />
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/examples/cortex-ai/src/components/ui.tsx
+++ b/examples/cortex-ai/src/components/ui.tsx
@@ -1,0 +1,49 @@
+import type { ReactNode } from "react";
+
+export function Card({
+  children,
+  className = "",
+  span,
+  hover = true,
+  accent = false,
+}: {
+  children: ReactNode;
+  className?: string;
+  span?: 2 | 3 | 4 | 6;
+  hover?: boolean;
+  accent?: boolean;
+}) {
+  const cls = ["card", hover && "hover", accent && "accent", span && `col-${span}`, className]
+    .filter(Boolean)
+    .join(" ");
+  return <section className={cls}>{children}</section>;
+}
+
+export function CardHead({ title, sub, tag }: { title: string; sub?: string; tag?: ReactNode }) {
+  return (
+    <header className="card-head">
+      <div style={{ minWidth: 0 }}>
+        <div className="card-title">{title}</div>
+        {sub && <div className="card-sub">{sub}</div>}
+      </div>
+      {tag && <span className="card-tag">{tag}</span>}
+    </header>
+  );
+}
+
+export function StatLine({ items }: { items: [string, ReactNode][] }) {
+  return (
+    <div className="statline">
+      {items.map(([k, v]) => (
+        <span key={k}>
+          {k} <b>{v}</b>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+/** Small accent dot used in tags/legends. */
+export function Dot({ color = "var(--accent)" }: { color?: string }) {
+  return <span className="swatch" style={{ background: color, borderRadius: 999 }} />;
+}

--- a/examples/cortex-ai/src/data.ts
+++ b/examples/cortex-ai/src/data.ts
@@ -1,0 +1,420 @@
+// Cortex — seeded, deterministic mock data for the eval & observability console.
+// One small PRNG; every dataset computed once at module load (no per-render churn).
+
+function mulberry32(seed: number) {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+const rnd = mulberry32(0x0c07e2);
+const rangeR = (lo: number, hi: number) => lo + rnd() * (hi - lo);
+const round = (n: number, dp = 0) => {
+  const f = 10 ** dp;
+  return Math.round(n * f) / f;
+};
+
+// ── Models roster ────────────────────────────────────────────────────────────
+export type ModelState = "ok" | "warn" | "error" | "busy" | "off";
+export interface ModelRow {
+  id: string;
+  name: string;
+  tier: string;
+  state: ModelState;
+  latency: number; // p50 ms
+  rate: number; // req/s
+  share: number; // % of traffic
+}
+export const models: ModelRow[] = [
+  {
+    id: "cx-opus",
+    name: "cortex-opus-4",
+    tier: "frontier",
+    state: "ok",
+    latency: 640,
+    rate: 1.7,
+    share: 41,
+  },
+  {
+    id: "cx-sonnet",
+    name: "cortex-sonnet-4",
+    tier: "balanced",
+    state: "busy",
+    latency: 410,
+    rate: 3.2,
+    share: 34,
+  },
+  {
+    id: "cx-haiku",
+    name: "cortex-haiku-4",
+    tier: "fast",
+    state: "ok",
+    latency: 180,
+    rate: 5.1,
+    share: 19,
+  },
+  {
+    id: "cx-guard",
+    name: "guardrail-mini",
+    tier: "safety",
+    state: "warn",
+    latency: 920,
+    rate: 0.9,
+    share: 6,
+  },
+];
+
+// ── Live: request-rate heartbeat (event timestamps in ms, fixed clock) ─────────
+const NOW = 60_000;
+function heartbeat(density: number): number[] {
+  const ev: number[] = [];
+  let t = 0;
+  while (t < NOW) {
+    t += rangeR(600, 2600) / density;
+    if (t < NOW) ev.push(Math.round(t));
+  }
+  return ev;
+}
+export const requestPulse = { events: heartbeat(1.9), now: NOW, window: NOW };
+export const headerPulse = { events: heartbeat(1.4), now: NOW, window: NOW };
+
+// ── Live: tokens/sec comet trail (momentum) ────────────────────────────────────
+export const tokensPerSec: number[] = (() => {
+  const out: number[] = [];
+  let v = 1180;
+  for (let i = 0; i < 18; i++) {
+    v += rangeR(-90, 130);
+    v = Math.max(720, Math.min(1680, v));
+    out.push(round(v));
+  }
+  return out;
+})();
+
+// ── Live: per-model orbit health (latency + rate) ──────────────────────────────
+export const orbit = models.map((m) => ({
+  id: m.id,
+  name: m.name,
+  latency: m.latency,
+  rate: m.rate,
+}));
+export const latencyDomain: [number, number] = [0, 1100];
+export const rateDomain: [number, number] = [0, 6];
+export const latencyAlert = 850;
+
+// ── Live: KPI deltas (positive="down" where lower is better) ────────────────────
+export const kpis = {
+  cost: { now: 0.42, from: 0.49, unit: "$/1k req" }, // -14%
+  p95: { now: 1180, from: 1090, unit: "ms" }, // +8% (regression)
+  error: { now: 0.6, from: 0.9, unit: "%" }, // -33%
+  throughput: { now: 10.9, from: 9.4, unit: "req/s" }, // +16% (up good)
+};
+
+// ── Live: daily eval-run cadence (18 weeks) ────────────────────────────────────
+export const evalRuns: number[] = (() => {
+  const out: number[] = [];
+  for (let i = 0; i < 126; i++) {
+    const weekday = i % 7;
+    const weekend = weekday === 5 || weekday === 6;
+    let v = weekend ? rangeR(0, 8) : rangeR(6, 46);
+    if (rnd() < 0.05) v = 0; // an occasional quiet day
+    if (rnd() < 0.04) v = rangeR(52, 74); // a release-day spike
+    out.push(Math.round(v));
+  }
+  return out;
+})();
+export const evalRunsStart = "2026-03-09"; // a Monday
+
+// ── Live: running batch-eval ETA ────────────────────────────────────────────────
+export const batchEval = {
+  progress: 0.62,
+  elapsed: 14.2,
+  rate: 0.038,
+  suite: "safety-redteam-v7",
+  cases: 8400,
+};
+
+// ── Transcripts: the answer, token-by-token confidence ─────────────────────────
+export const confidenceTiers: [number, number] = [0.55, 0.85];
+export interface Tok {
+  token: string;
+  confidence: number;
+}
+// A believable support-agent answer. Hedges + specifics carry lower confidence.
+const RAW =
+  "Yes|c you|c can|c still|c process|c the|c refund|c after|c the|c 30-day|u window|c ,|c but|c it|c needs|c a|c manager|u override|u .|c " +
+  "Open|c the|c order|c in|c Atlas|g ,|c switch|c the|c status|c to|c Exception|u ,|c and|c apply|c the|c code|c GOODWILL-30|g .|c " +
+  "The|c customer|c should|c see|c the|c credit|c within|c three|u to|c five|c business|c days|u ,|c though|c prepaid|u cards|u can|c take|c up|c to|c ten|g .|c " +
+  "If|c the|c amount|c is|c over|c $500|g ,|c route|c it|c to|c the|c Finance|c queue|c instead|u ,|c since|c large|c goodwill|u credits|c need|c a|c second|c approval|u .|c";
+// The chart concatenates token strings verbatim — whitespace must live inside
+// each token. Prepend a space to every token except the first and punctuation.
+export const answerTokens: Tok[] = RAW.split(" ").map((chunk, idx) => {
+  const cut = chunk.lastIndexOf("|");
+  const bare = chunk.slice(0, cut);
+  const flag = chunk.slice(cut + 1);
+  const punct = /^[.,]$/.test(bare);
+  const token = idx === 0 || punct ? bare : " " + bare;
+  const confidence =
+    flag === "g"
+      ? round(rangeR(0.28, 0.5), 2)
+      : flag === "u"
+        ? round(rangeR(0.6, 0.82), 2)
+        : round(rangeR(0.9, 0.99), 2);
+  return { token, confidence };
+});
+
+export function tierOf(confidence: number): "confident" | "unsure" | "guessing" {
+  if (confidence < confidenceTiers[0]) return "guessing";
+  if (confidence < confidenceTiers[1]) return "unsure";
+  return "confident";
+}
+// Flagged spans (consecutive non-confident tokens grouped).
+export interface FlaggedSpan {
+  text: string;
+  tier: "unsure" | "guessing";
+  confidence: number;
+}
+export const flaggedSpans: FlaggedSpan[] = (() => {
+  const out: FlaggedSpan[] = [];
+  let cur: { toks: string[]; min: number } | null = null;
+  const flush = () => {
+    if (!cur) return;
+    const t = tierOf(cur.min) as "unsure" | "guessing";
+    out.push({
+      text: cur.toks.join(" ").replace(/\s+([.,])/g, "$1"),
+      tier: t,
+      confidence: cur.min,
+    });
+    cur = null;
+  };
+  for (const t of answerTokens) {
+    const tier = tierOf(t.confidence);
+    const bare = t.token.replace(/[.,]/g, "").trim();
+    if (tier === "confident" || bare === "") {
+      flush();
+      continue;
+    }
+    if (!cur) cur = { toks: [], min: 1 };
+    cur.toks.push(t.token.trim());
+    cur.min = Math.min(cur.min, t.confidence);
+  }
+  flush();
+  return out.sort((a, b) => a.confidence - b.confidence).slice(0, 6);
+})();
+
+// ── Transcripts: rubric scorecard ───────────────────────────────────────────────
+export const rubric = [
+  { label: "Instruction-following", score: 0.94, weight: 3 },
+  { label: "Factual accuracy", score: 0.71, weight: 3 },
+  { label: "Safety", score: 0.98, weight: 3 },
+  { label: "Citations", score: 0.52, weight: 2 },
+  { label: "Concision", score: 0.83, weight: 1 },
+  { label: "Tone", score: 0.9, weight: 1 },
+];
+export const rubricTarget = 0.7;
+
+// ── Transcripts: answer-quality star profile (vs prior model) ──────────────────
+export const qualities = [
+  { label: "Helpful", value: 0.9 },
+  { label: "Accurate", value: 0.72 },
+  { label: "Safe", value: 0.97 },
+  { label: "Concise", value: 0.83 },
+  { label: "Grounded", value: 0.58 },
+  { label: "Tone", value: 0.88 },
+];
+export const qualitiesBaseline = qualities.map((q) =>
+  round(Math.max(0.35, q.value - rangeR(0.05, 0.22)), 2),
+);
+
+// ── Evals: calibration (pre-binned reliability) ────────────────────────────────
+export const calibration = (() => {
+  const rows: { predicted: number; observed: number; count: number }[] = [];
+  for (let i = 0; i < 10; i++) {
+    const predicted = round((i + 0.5) / 10, 2);
+    // slight over-confidence in the high bins
+    const drift = predicted > 0.6 ? -rangeR(0.03, 0.11) : rangeR(-0.03, 0.05);
+    const observed = round(Math.max(0, Math.min(1, predicted + drift)), 2);
+    const count = Math.round(rangeR(40, 260) * (1 - Math.abs(predicted - 0.5)) + 30);
+    rows.push({ predicted, observed, count });
+  }
+  return rows;
+})();
+
+// ── Evals: confusion (4-class intent classifier) ───────────────────────────────
+export const confusion = {
+  labels: ["Refund", "Billing", "Tech", "Other"],
+  counts: [
+    [412, 22, 9, 17],
+    [31, 388, 14, 27],
+    [12, 19, 344, 41],
+    [24, 33, 38, 196],
+  ],
+};
+
+// ── Evals: percentile-rank drift across releases ───────────────────────────────
+export const percentileTrace: number[] = (() => {
+  const out: number[] = [];
+  let p = 58;
+  for (let i = 0; i < 14; i++) {
+    p += rangeR(-6, 9);
+    p = Math.max(20, Math.min(96, p));
+    out.push(Math.round(p));
+  }
+  out[out.length - 1] = 91; // shipped a strong release
+  return out;
+})();
+
+// ── Evals: SLA-miss odds (posterior latency draws) ─────────────────────────────
+export const slaSample: number[] = (() => {
+  const out: number[] = [];
+  for (let i = 0; i < 80; i++) {
+    // log-normal-ish latency around 640ms, right tail crosses the 900ms SLA
+    const base = 560 + rangeR(-120, 120);
+    const tail = rnd() < 0.22 ? rangeR(180, 520) : rangeR(0, 120);
+    out.push(Math.round(base + tail));
+  }
+  return out;
+})();
+export const slaThreshold = 900;
+export const slaDotCount = 20;
+
+/** Match <QuantileDots count> framing: how many of N equal-probability quantiles miss. */
+export function slaPastDots(
+  sample: readonly number[] = slaSample,
+  threshold = slaThreshold,
+  count = slaDotCount,
+): number {
+  const sorted = sample
+    .filter((v) => Number.isFinite(v))
+    .slice()
+    .sort((a, b) => a - b);
+  if (sorted.length === 0) return 0;
+  let past = 0;
+  for (let i = 1; i <= count; i++) {
+    const q = (i - 0.5) / count;
+    const pos = q * (sorted.length - 1);
+    const lo = Math.floor(pos);
+    const hi = Math.ceil(pos);
+    const v = lo === hi ? sorted[lo]! : sorted[lo]! * (1 - (pos - lo)) + sorted[hi]! * (pos - lo);
+    if (v > threshold) past++;
+  }
+  return past;
+}
+
+// ── Evals: drift control chart ─────────────────────────────────────────────────
+export const driftSeries: number[] = (() => {
+  const out: number[] = [];
+  let v = 0.83;
+  for (let i = 0; i < 44; i++) {
+    v += rangeR(-0.018, 0.018);
+    if (i === 30) v += 0.06; // an excursion
+    if (i === 31) v += 0.03;
+    v = Math.max(0.6, Math.min(0.98, v));
+    out.push(round(v, 3));
+  }
+  return out;
+})();
+export const driftBaseline = 0.83;
+
+// ── Evals: pass-rate vs target ─────────────────────────────────────────────────
+export const passRate = { value: 86.4, target: 90, bands: [70, 85] };
+
+// ── Evals: eval-label mix ──────────────────────────────────────────────────────
+export const labelMix = [
+  { label: "Pass", value: 3120 },
+  { label: "Regression", value: 214 },
+  { label: "Flaky", value: 96 },
+  { label: "Refusal", value: 142 },
+  { label: "Timeout", value: 38 },
+];
+
+// ── Traces: agent request flame chart ──────────────────────────────────────────
+export interface Span {
+  label: string;
+  start: number;
+  duration: number;
+  depth: number;
+  parent?: number;
+  critical?: boolean;
+}
+export const traceSpans: Span[] = [
+  { label: "agent.run", start: 0, duration: 4200, depth: 0, critical: true },
+  { label: "plan", start: 40, duration: 360, depth: 1, parent: 0, critical: true },
+  { label: "retrieve", start: 420, duration: 760, depth: 1, parent: 0, critical: true },
+  { label: "tool.web_search", start: 450, duration: 320, depth: 2, parent: 2, critical: true },
+  { label: "vector.query", start: 800, duration: 290, depth: 2, parent: 2 },
+  { label: "rerank", start: 1180, duration: 190, depth: 1, parent: 0 },
+  { label: "llm.generate", start: 1380, duration: 2470, depth: 1, parent: 0, critical: true },
+  { label: "tool.calculator", start: 1600, duration: 90, depth: 2, parent: 6 },
+  { label: "guardrail.check", start: 3870, duration: 290, depth: 1, parent: 0, critical: true },
+  { label: "emit", start: 4160, duration: 40, depth: 1, parent: 0, critical: true },
+];
+export const traceTotalMs = 4200;
+
+// ── Traces: tool-call raster across agent steps ────────────────────────────────
+export const rasterLanes = [
+  { label: "llm.generate", events: [80, 1390, 2010, 2640, 3210, 3780] },
+  { label: "web_search", events: [455, 690, 940] },
+  { label: "vector.query", events: [472, 610, 748] },
+  { label: "calculator", events: [1605] },
+  { label: "guardrail", events: [3872, 3990, 4110] },
+];
+export const rasterDomain: [number, number] = [0, 4200];
+
+// ── Traces: voice-agent log volume waveform ────────────────────────────────────
+export const waveform: number[] = (() => {
+  const out: number[] = [];
+  for (let i = 0; i < 200; i++) {
+    // three speech bursts with silence between
+    const b1 = Math.exp(-(((i - 34) / 22) ** 2));
+    const b2 = Math.exp(-(((i - 104) / 30) ** 2));
+    const b3 = Math.exp(-(((i - 168) / 18) ** 2));
+    const env = Math.max(b1, b2 * 0.9, b3 * 0.8);
+    const s = env * (0.55 + rnd() * 0.45) * (rnd() < 0.5 ? 1 : -1);
+    out.push(round(s, 3));
+  }
+  return out;
+})();
+export const waveformProgress = 0.46;
+
+// ── Traces: per-step latency sparkline ─────────────────────────────────────────
+export const stepLatency: number[] = [42, 51, 380, 210, 690, 190, 88, 2470, 90, 240, 40];
+export const stepNames = [
+  "auth",
+  "route",
+  "plan",
+  "embed",
+  "search",
+  "rerank",
+  "compose",
+  "generate",
+  "calc",
+  "guard",
+  "emit",
+];
+
+/** Model score vs. human judge — Bland–Altman pairs for BiasStrip on Evals. */
+export const judgePairs = (() => {
+  const out: { a: number; b: number }[] = [];
+  for (let i = 0; i < 48; i++) {
+    const human = 0.35 + rnd() * 0.6;
+    const model = human + (rnd() - 0.42) * 0.14;
+    out.push({
+      a: Math.round(Math.min(1, Math.max(0, model)) * 100) / 100,
+      b: Math.round(Math.min(1, Math.max(0, human)) * 100) / 100,
+    });
+  }
+  return out;
+})();
+
+/** Mean model−human difference — the BiasStrip accent line. */
+export const judgeBias =
+  Math.round((judgePairs.reduce((s, p) => s + (p.a - p.b), 0) / judgePairs.length) * 100) / 100;
+
+// ── Small chrome-side formatters (never used inside microcharts) ───────────────
+export const fmtInt = (n: number) => Math.round(n).toLocaleString("en-US");
+export const fmtPct = (n: number, dp = 1) => `${n.toFixed(dp)}%`;
+export const fmtMs = (n: number) => `${Math.round(n)}ms`;

--- a/examples/cortex-ai/src/main.tsx
+++ b/examples/cortex-ai/src/main.tsx
@@ -1,0 +1,43 @@
+import { StrictMode, useEffect, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { MicroProvider } from "@microcharts/react";
+import { defineTheme } from "@microcharts/react/theme";
+import "@microcharts/react/styles.css";
+import "@microcharts/react/motion";
+import "./app.css";
+import "./analytics";
+import { App } from "./App";
+
+// Cortex brand: blueprint-cobalt accent, slightly heavier stroke.
+// `dark: "auto"` derives a brighter twin for the near-black surface — picked
+// at render time below so charts track the OS scheme, same as the rest of
+// the CSS-var-driven dark mode in app.css.
+const brand = defineTheme({ accent: "#3b6ea5", strokeWidth: 1.15, dark: "auto" });
+
+function usePrefersDark(): boolean {
+  const [dark, setDark] = useState(
+    () => typeof matchMedia !== "undefined" && matchMedia("(prefers-color-scheme: dark)").matches,
+  );
+  useEffect(() => {
+    const mq = matchMedia("(prefers-color-scheme: dark)");
+    const onChange = () => setDark(mq.matches);
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
+  return dark;
+}
+
+function Root() {
+  const dark = usePrefersDark();
+  return (
+    <MicroProvider style={dark ? brand.darkVars : brand.vars}>
+      <App />
+    </MicroProvider>
+  );
+}
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <Root />
+  </StrictMode>,
+);

--- a/examples/cortex-ai/tsconfig.json
+++ b/examples/cortex-ai/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "moduleDetection": "force",
+    "isolatedModules": true
+  },
+  "include": ["src"]
+}

--- a/examples/cortex-ai/vite.config.ts
+++ b/examples/cortex-ai/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+export default defineConfig({
+  plugins: [react()],
+  server: { port: 4007, strictPort: true, host: true },
+});

--- a/examples/deploy-cloudflare.sh
+++ b/examples/deploy-cloudflare.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Deploy the microcharts example apps to Cloudflare Pages — one project (one URL) per app.
+#
+# Prereqs (one time):
+#   - A Cloudflare account.
+#   - Auth ONE of these ways:
+#       a) interactive:  npx wrangler login
+#       b) CI/token:     export CLOUDFLARE_API_TOKEN=...   (needs "Cloudflare Pages: Edit")
+#                        export CLOUDFLARE_ACCOUNT_ID=...
+#
+# Usage:
+#   ./deploy-cloudflare.sh              # build + deploy all 7
+#   ./deploy-cloudflare.sh cortex-ai    # build + deploy just one
+#   MC_PAGES_PREFIX=acme ./deploy-cloudflare.sh   # override the project-name prefix
+#
+# Each app becomes a Pages project "<prefix>-<short>" → https://<prefix>-<short>.pages.dev
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+PREFIX="${MC_PAGES_PREFIX:-microcharts}"
+BRANCH="${CF_PAGES_BRANCH:-production}"
+WRANGLER="npx --yes wrangler@4"
+
+ALL="pulse-analytics ledger-finance vitals-health shipyard-devops dispatch-editorial atlas-realestate cortex-ai"
+
+short_name() { case "$1" in
+  pulse-analytics) echo pulse ;;   ledger-finance) echo ledger ;;
+  vitals-health) echo vitals ;;    shipyard-devops) echo shipyard ;;
+  dispatch-editorial) echo dispatch ;; atlas-realestate) echo atlas ;;
+  cortex-ai) echo cortex ;;        *) echo "$1" ;;
+esac; }
+
+# Next.js (pulse) exports to out/; the Vite apps build to dist/.
+out_dir() { case "$1" in pulse-analytics) echo out ;; *) echo dist ;; esac; }
+
+TARGETS="${*:-$ALL}"
+
+for app in $TARGETS; do
+  dir="$ROOT/$app"
+  [ -d "$dir" ] || { echo "!! no such app: $app"; exit 1; }
+  proj="$PREFIX-$(short_name "$app")"
+  outd="$(out_dir "$app")"
+
+  echo ""
+  echo "==================================================================="
+  echo ">> $app  →  project '$proj'  (https://$proj.pages.dev)"
+  echo "==================================================================="
+
+  echo "-- installing deps (if needed) & building"
+  ( cd "$dir" && [ -d node_modules ] || npm install --no-audit --no-fund )
+  ( cd "$dir" && rm -rf "$outd" .next && npm run build )
+
+  [ -d "$dir/$outd" ] || { echo "!! build produced no $outd/ for $app"; exit 1; }
+
+  echo "-- ensuring Pages project exists"
+  ( cd "$dir" && $WRANGLER pages project create "$proj" \
+      --production-branch "$BRANCH" 2>/dev/null ) || true
+
+  echo "-- deploying $outd/ to Cloudflare Pages"
+  ( cd "$dir" && $WRANGLER pages deploy "$outd" \
+      --project-name "$proj" --branch "$BRANCH" --commit-dirty=true )
+done
+
+echo ""
+echo "Done. URLs:"
+for app in $TARGETS; do
+  echo "  https://$PREFIX-$(short_name "$app").pages.dev   ($app)"
+done

--- a/examples/dispatch-editorial/index.html
+++ b/examples/dispatch-editorial/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <meta name="color-scheme" content="light" />
+    <meta
+      name="description"
+      content="Dispatch — a data-journalism magazine, and a stress test of inline @microcharts/react marks set in running editorial prose."
+    />
+    <title>Dispatch — field notes in charts · a microcharts example</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Bodoni+Moda:ital,opsz,wght@0,6..96,600..900;1,6..96,600..800&family=Hanken+Grotesk:ital,wght@0,400..700;1,400..600&family=Literata:ital,opsz,wght@0,7..72,400..600;1,7..72,400..520&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/dispatch-editorial/package.json
+++ b/examples/dispatch-editorial/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "example-dispatch-editorial",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite --port 4005 --strictPort",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview --port 4005 --strictPort"
+  },
+  "dependencies": {
+    "@microcharts/react": "^0.8.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^5.0.0",
+    "typescript": "^5.7.0",
+    "vite": "^7.0.0"
+  }
+}

--- a/examples/dispatch-editorial/public/robots.txt
+++ b/examples/dispatch-editorial/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/examples/dispatch-editorial/src/App.tsx
+++ b/examples/dispatch-editorial/src/App.tsx
@@ -1,0 +1,25 @@
+import { useState } from "react";
+import { Masthead, type View } from "./components/Masthead";
+import { Feature } from "./components/Feature";
+import { Overnight } from "./components/Overnight";
+import { Almanac } from "./components/Almanac";
+import { ChartsIndex } from "./components/ChartsIndex";
+import { SiteFooter } from "./components/SiteFooter";
+
+export function App() {
+  const [view, setView] = useState<View>("feature");
+
+  return (
+    <div className="page">
+      <Masthead view={view} onNavigate={setView} />
+      {/* key forces a fresh mount per view so the entrance replays */}
+      <main key={view} className="view">
+        {view === "feature" && <Feature />}
+        {view === "overnight" && <Overnight />}
+        {view === "almanac" && <Almanac />}
+        {view === "index" && <ChartsIndex />}
+      </main>
+      <SiteFooter />
+    </div>
+  );
+}

--- a/examples/dispatch-editorial/src/analytics.ts
+++ b/examples/dispatch-editorial/src/analytics.ts
@@ -1,0 +1,14 @@
+// Cloudflare Web Analytics — privacy-first, cookieless page-view/visit beacon.
+// Injected only when VITE_CF_BEACON_TOKEN is set at build time; otherwise a no-op.
+// Get a token: Cloudflare dashboard → Web Analytics → Add a site → copy the token
+// (or just enable Web Analytics on the Pages project, which auto-injects instead). See DEPLOY.md.
+const token = (import.meta as unknown as { env?: Record<string, string | undefined> }).env
+  ?.VITE_CF_BEACON_TOKEN;
+if (token) {
+  const s = document.createElement("script");
+  s.defer = true;
+  s.src = "https://static.cloudflareinsights.com/beacon.min.js";
+  s.setAttribute("data-cf-beacon", JSON.stringify({ token }));
+  document.head.appendChild(s);
+}
+export {};

--- a/examples/dispatch-editorial/src/app.css
+++ b/examples/dispatch-editorial/src/app.css
@@ -1,0 +1,1030 @@
+/* ============================================================================
+   DISPATCH — an editorial specimen for @microcharts/react
+   ----------------------------------------------------------------------------
+   A high-end print magazine on warm paper stock. Charts sit as typographic
+   marks on the baseline; the article is the star. One second ink (madder red),
+   hairline rules, a real reading serif, a didone display voice, letterpress
+   restraint. Committed to LIGHT — a magazine is one paper, not two.
+   ============================================================================ */
+
+/* --- TYPE TOKENS ---------------------------------------------------------- */
+:root {
+  /* Three voices. Bodoni Moda is the didone display (masthead, headlines,
+     numerals, drop cap). Literata is the reading serif. Hanken Grotesk is the
+     grotesque used for department labels, folios, captions — and, crucially,
+     for the chart SVG text so inline marks never inherit a serif. */
+  --font-display: "Bodoni Moda", "Bodoni 72", "Didot", "Times New Roman", serif;
+  --font-serif:
+    "Literata", "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, "Times New Roman", serif;
+  --font-sans: "Hanken Grotesk", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+
+  /* THE FONT TRAP — pin the microcharts font token to the grotesque so every
+     label, value and axis figure stays clean sans while the body sets serif. */
+  --mc-font: var(--font-sans);
+  --mc-font-numeric: var(--font-sans);
+
+  /* --- CHART TOKEN PINNING (the invisible-stroke fix) ---------------------
+     @microcharts flips --mc-stroke to near-white under prefers-color-scheme:
+     dark via a zero-specificity :where(:root). Because this page commits to
+     warm paper in every OS scheme, we re-assert the light-appropriate chart
+     tokens here at :root (specificity 0,1,0) so that media query can never win
+     and strokes never vanish on a dark-OS machine. Semantic valence
+     (positive / negative) is preserved exactly; only accent is retuned. */
+  --mc-stroke: var(--ink);
+  --mc-positive: #0e7a5f; /* bluish-green — never recolored */
+  --mc-negative: #bd4b2d; /* vermillion — never recolored */
+  --mc-neutral: color-mix(in oklab, var(--ink) 45%, var(--paper));
+  --mc-accent: var(--accent); /* madder red, matches the page ink */
+  --mc-moon: #b8862b;
+  --mc-cat-1: #b06a2c;
+  --mc-cat-2: #3f7d8c;
+  --mc-cat-3: #2e8c66;
+  --mc-cat-4: #7d5a86;
+  --mc-cat-5: #c2543a;
+  --mc-cat-6: #9c7a3f;
+
+  /* --- SPACE SCALE (4pt, semantic) --------------------------------------- */
+  --space-2xs: 4px;
+  --space-xs: 8px;
+  --space-sm: 12px;
+  --space-md: 16px;
+  --space-lg: 24px;
+  --space-xl: 32px;
+  --space-2xl: 48px;
+  --space-3xl: 64px;
+  --space-4xl: 96px;
+
+  /* Reading measure — the printed column. */
+  --measure: 65ch;
+}
+
+/* --- PAPER PALETTE (OKLCH, warm, no pure #fff/#000) ----------------------- */
+:root {
+  color-scheme: light;
+
+  /* Neutrals tinted toward the madder hue (~55) for subconscious cohesion. */
+  --paper: oklch(0.968 0.011 78); /* warm ivory press sheet */
+  --paper-edge: oklch(0.945 0.014 74); /* card / plate stock, one shade down */
+  --paper-sink: oklch(0.925 0.016 72); /* pressed-in wells */
+  --ink: oklch(0.255 0.017 55); /* warm near-black, the body ink */
+  --ink-soft: oklch(0.42 0.02 50); /* secondary text */
+  --ink-faint: oklch(0.575 0.019 55); /* labels, captions, folios */
+  --rule: oklch(0.86 0.02 68); /* hairline rules */
+  --rule-strong: oklch(0.6 0.025 55); /* the double rule under the nameplate */
+  --accent: oklch(0.47 0.132 32); /* MADDER RED — the one second ink */
+  --accent-deep: oklch(0.4 0.12 32); /* pressed accent (active states) */
+  --highlight: oklch(0.95 0.05 78); /* faint underlay for drop cap etc. */
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background-color: var(--paper);
+  /* A whisper of paper tooth — two offset dot fields, near-invisible, that
+     keep the flat ivory from reading as a screen. */
+  background-image:
+    radial-gradient(oklch(0.5 0.02 55 / 0.02) 0.5px, transparent 0.5px),
+    radial-gradient(oklch(0.5 0.02 55 / 0.018) 0.5px, transparent 0.5px);
+  background-size:
+    22px 22px,
+    22px 22px;
+  background-position:
+    0 0,
+    11px 11px;
+  color: var(--ink);
+  font-family: var(--font-serif);
+  font-optical-sizing: auto;
+  font-size: 19px;
+  line-height: 1.62;
+  font-feature-settings:
+    "kern",
+    "liga",
+    "onum" 1,
+    "pnum" 1;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+.page {
+  min-height: 100vh;
+}
+
+::selection {
+  background: oklch(0.47 0.132 32 / 0.16);
+}
+
+/* ============================================================================
+   MASTHEAD
+   ============================================================================ */
+.masthead {
+  max-width: 940px;
+  margin: 0 auto;
+  padding: clamp(16px, 3vw, 28px) var(--space-lg) 0;
+}
+
+/* Top folio: edition · ornament · dateline. Grotesque small-caps, tabular. */
+.masthead__bar {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: var(--space-md);
+  font-family: var(--font-sans);
+  font-size: 11.5px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  padding-bottom: var(--space-xs);
+  border-bottom: 1px solid var(--rule);
+  font-variant-numeric: tabular-nums;
+}
+
+.masthead__bar > :last-child {
+  text-align: right;
+}
+
+.masthead__ornament {
+  color: var(--accent);
+  font-size: 13px;
+  letter-spacing: 0.3em;
+  padding-left: 0.3em; /* optical: the letter-spacing hangs right */
+}
+
+.masthead__nameplate {
+  text-align: center;
+  padding: clamp(14px, 2.6vw, 24px) 0 var(--space-sm);
+  border-bottom: 3px double var(--rule-strong);
+}
+
+.masthead__title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(56px, 13vw, 116px);
+  font-weight: 800;
+  font-optical-sizing: auto;
+  letter-spacing: -0.012em;
+  line-height: 1.05;
+  color: var(--ink);
+  padding-bottom: 0.06em;
+}
+
+.masthead__tagline {
+  margin: var(--space-lg) 0 0;
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: 15.5px;
+  line-height: 1.4;
+  color: var(--ink-soft);
+}
+
+.masthead__nav {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0 clamp(6px, 2.4vw, 22px);
+  margin-top: var(--space-sm);
+}
+
+.tab {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  font-family: var(--font-sans);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  padding: var(--space-sm) var(--space-2xs) 10px;
+  position: relative;
+  transition: color 0.18s ease;
+}
+
+/* The active/hover mark is a printed underline that grows from the center —
+   not a pill. A pill reads app-chrome; an underline reads editorial. */
+.tab::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  right: 50%;
+  bottom: 4px;
+  height: 1.5px;
+  background: var(--accent);
+  transition:
+    left 0.22s cubic-bezier(0.22, 1, 0.36, 1),
+    right 0.22s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.tab:hover {
+  color: var(--ink);
+}
+
+.tab:hover::after {
+  left: 20%;
+  right: 20%;
+}
+
+.tab:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+  border-radius: 2px;
+}
+
+.tab:active {
+  color: var(--accent-deep);
+}
+
+.tab--active {
+  color: var(--ink);
+}
+
+.tab--active::after {
+  left: 6%;
+  right: 6%;
+}
+
+/* ============================================================================
+   ARTICLE
+   ============================================================================ */
+.article {
+  max-width: var(--measure);
+  margin: 0 auto;
+  padding: clamp(28px, 6vw, 56px) var(--space-lg) var(--space-4xl);
+}
+
+.article__kicker {
+  font-family: var(--font-sans);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0 0 var(--space-md);
+  display: flex;
+  align-items: center;
+  gap: 0.7em;
+}
+
+/* a short madder rule leading the kicker, like a printed section mark */
+.article__kicker::before {
+  content: "";
+  width: 26px;
+  height: 2px;
+  background: var(--accent);
+}
+
+.article__headline {
+  font-family: var(--font-display);
+  font-size: clamp(38px, 6.4vw, 62px);
+  font-weight: 700;
+  font-optical-sizing: auto;
+  line-height: 1.02;
+  letter-spacing: -0.01em;
+  margin: 0 0 var(--space-md);
+  text-wrap: balance;
+}
+
+.article__dek {
+  font-family: var(--font-serif);
+  font-size: clamp(20px, 2.6vw, 24px);
+  line-height: 1.42;
+  color: var(--ink-soft);
+  font-style: italic;
+  margin: 0 0 var(--space-lg);
+  max-width: 54ch;
+  text-wrap: pretty;
+}
+
+.article__byline {
+  font-family: var(--font-sans);
+  font-size: 12.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin: 0 0 var(--space-xl);
+  padding-bottom: var(--space-lg);
+  border-bottom: 1px solid var(--rule);
+}
+
+.article__author {
+  color: var(--ink);
+  font-weight: 700;
+}
+
+.article p {
+  margin: 0 0 var(--space-lg);
+  text-wrap: pretty;
+  hanging-punctuation: first last;
+}
+
+/* Drop cap in the display face — a raised, slightly overhung madder initial. */
+.article__lead::first-letter {
+  float: left;
+  font-family: var(--font-display);
+  font-size: 4.6em;
+  line-height: 0.74;
+  font-weight: 700;
+  padding: 0.06em 0.09em 0 0;
+  margin-left: -0.04em; /* optical hang into the margin */
+  color: var(--accent);
+}
+
+/* Pull quote — NO side stripe. A centered display aside, hairline-ruled top
+   and bottom, with a hanging madder open-quote as the ornament. */
+.pullquote {
+  margin: var(--space-2xl) auto;
+  max-width: 34ch;
+  padding: var(--space-lg) 0 var(--space-md);
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  text-align: center;
+  font-family: var(--font-display);
+  font-size: clamp(24px, 3.6vw, 31px);
+  font-weight: 600;
+  font-optical-sizing: auto;
+  line-height: 1.24;
+  font-style: italic;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+  position: relative;
+}
+
+.pullquote::before {
+  content: "\201C";
+  display: block;
+  font-family: var(--font-display);
+  font-style: normal;
+  font-size: 1.9em;
+  line-height: 0.6;
+  color: var(--accent);
+  margin-bottom: 0.08em;
+}
+
+.article__end {
+  margin-top: var(--space-xl);
+  padding-top: var(--space-md);
+  border-top: 1px solid var(--rule);
+  font-family: var(--font-serif);
+  font-size: 15px;
+  font-style: italic;
+  color: var(--ink-faint);
+}
+
+.article__end::after {
+  content: " \25A0";
+  font-style: normal;
+  font-size: 0.8em;
+  color: var(--accent);
+  margin-left: 0.15em;
+}
+
+/* --- INLINE CHARTS ------------------------------------------------------- */
+/* SVG marks only. Leave <Delta> bare — it owns baseline (styles.css). */
+.article .mc-inline {
+  display: inline-flex;
+  align-items: center;
+  vertical-align: -0.18em;
+  margin: 0 0.12em;
+  padding: 0;
+  border: 0;
+  background: none;
+  --mc-inline-nudge: 0;
+}
+.article .mc-inline .mc-root,
+.article .mc-inline [data-mc-seated] {
+  translate: none;
+}
+.article .mc-delta-live {
+  font-size: inherit;
+  padding: 0;
+  border: 0;
+  background: none;
+}
+.article .mc-delta {
+  font-size: 1em;
+  font-weight: 600;
+  padding: 0;
+  border: 0;
+  background: none;
+}
+
+/* ============================================================================
+   FIGURES — plate + hairline-ruled caption
+   ============================================================================ */
+.figure {
+  margin: var(--space-2xl) 0;
+  padding: 0;
+}
+
+.figure__plate {
+  padding: clamp(14px, 2.4vw, 22px);
+  background: var(--paper-edge);
+  border: 1px solid var(--rule);
+}
+
+.figure__plate > * {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+}
+
+.figure__plate svg {
+  display: block;
+  width: 100%;
+  height: auto;
+  max-width: 100%;
+}
+
+/* wide figure breaks the reading measure for the big series chart */
+.figure--wide {
+  margin-left: calc((100% - min(94vw, 800px)) / 2);
+  margin-right: calc((100% - min(94vw, 800px)) / 2);
+  width: min(94vw, 800px);
+}
+
+.figure figcaption {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--ink-faint);
+  margin-top: var(--space-sm);
+  padding-top: 10px;
+  border-top: 1px solid var(--rule);
+  font-variant-numeric: tabular-nums;
+  max-width: 60ch;
+}
+
+/* the "Fig. N —" lead-in reads as a printed caption label */
+.figure figcaption b {
+  color: var(--ink);
+  font-weight: 700;
+}
+
+.figure--wide figcaption {
+  margin-inline: auto;
+}
+
+/* ============================================================================
+   CHARTS INDEX — a type specimen, grouped by role, not a uniform card grid
+   ============================================================================ */
+.index {
+  max-width: 940px;
+  margin: 0 auto;
+  padding: clamp(28px, 6vw, 56px) var(--space-lg) var(--space-4xl);
+}
+
+.index__title {
+  font-family: var(--font-display);
+  font-size: clamp(32px, 5.4vw, 50px);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  line-height: 1.02;
+  margin: 0 0 var(--space-sm);
+}
+
+.index__intro {
+  font-family: var(--font-serif);
+  font-size: 19px;
+  line-height: 1.55;
+  color: var(--ink-soft);
+  max-width: 58ch;
+  margin: 0 0 var(--space-2xl);
+}
+
+/* A role group: a small-caps header on a hairline, then its specimens. */
+.index__group {
+  margin-top: var(--space-2xl);
+}
+
+.index__group-head {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-lg);
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--rule);
+}
+
+.index__group-title {
+  font-family: var(--font-sans);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0;
+}
+
+.index__group-note {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: 14px;
+  color: var(--ink-faint);
+}
+
+.index__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1px; /* hairline seams between specimen cells */
+  background: var(--rule);
+  border: 1px solid var(--rule);
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+}
+
+.card {
+  background: var(--paper-edge);
+  padding: var(--space-lg);
+  display: flex;
+  flex-direction: column;
+  transition: background 0.2s ease;
+}
+
+.card:hover {
+  background: var(--paper);
+}
+
+/* figure specimens want the full measure — span every column so an all-figure
+   register never strands an empty trailing column. */
+.card--figure {
+  grid-column: 1 / -1;
+}
+
+.card__head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-xs);
+  margin-bottom: var(--space-sm);
+}
+
+.card__name {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 21px;
+  font-weight: 700;
+  letter-spacing: -0.005em;
+}
+
+.card__role {
+  font-family: var(--font-sans);
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  white-space: nowrap;
+}
+
+.card__demo {
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  padding: var(--space-xs) 0 var(--space-md);
+  font-size: 17px;
+  color: var(--ink-soft);
+}
+.card__demo .mc-inline {
+  padding: 0;
+  border: 0;
+  background: none;
+  margin: 0 0.12em;
+  vertical-align: -0.18em;
+}
+.card__demo .mc-delta,
+.card__demo .mc-delta-live {
+  font-size: 1em;
+  font-weight: 600;
+  background: none;
+  padding: 0;
+  border: 0;
+}
+.card__demo > * {
+  max-width: 100%;
+}
+.card--figure .card__demo > * {
+  width: 100%;
+}
+.card__demo svg {
+  max-width: 100%;
+  height: auto;
+}
+.card--figure .card__demo svg {
+  width: 100%;
+}
+
+.card--inline .card__demo {
+  justify-content: flex-start;
+}
+
+.card--glyph .card__demo {
+  justify-content: center;
+  min-height: 96px;
+}
+
+.card--glyph .card__demo svg {
+  width: auto;
+  max-width: 100%;
+}
+
+.card__caption {
+  margin: 0;
+  margin-top: auto;
+  font-family: var(--font-sans);
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--ink-faint);
+  padding-top: var(--space-sm);
+  border-top: 1px solid var(--rule);
+  font-variant-numeric: tabular-nums;
+}
+
+.card__caption code {
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 0.85em;
+  color: var(--ink-soft);
+}
+
+/* --- OUTPUT-CONTEXT SPECIMENS — print & e-ink token bundles, side by side -- */
+.specimen-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1px;
+  background: var(--rule);
+  border: 1px solid var(--rule);
+}
+
+.specimen {
+  padding: var(--space-lg);
+  background: var(--paper-edge);
+}
+
+/* e-ink is genuinely paper-white, unlike the warm ivory page — it's the one
+   specimen meant to simulate a physical grayscale display, not print stock. */
+.specimen[data-mc-theme="eink"] {
+  background: #fff;
+}
+
+.specimen__label {
+  display: block;
+  font-family: var(--font-sans);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin-bottom: var(--space-sm);
+}
+
+.specimen__charts {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+}
+
+/* ============================================================================
+   THE ALMANAC — a field ledger of glyph charts
+   ============================================================================ */
+.almanac {
+  max-width: 1060px;
+  margin: 0 auto;
+  padding: clamp(28px, 6vw, 56px) var(--space-lg) var(--space-4xl);
+}
+
+.almanac__head {
+  max-width: 60ch;
+  margin: 0 auto var(--space-xs);
+  text-align: center;
+  padding-bottom: var(--space-lg);
+  border-bottom: 3px double var(--rule-strong);
+}
+
+.almanac__title {
+  font-family: var(--font-display);
+  font-size: clamp(34px, 5.6vw, 52px);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  line-height: 1.02;
+  margin: var(--space-2xs) 0 var(--space-sm);
+}
+
+.almanac__standfirst {
+  font-family: var(--font-serif);
+  font-size: 18px;
+  line-height: 1.5;
+  font-style: italic;
+  color: var(--ink-soft);
+  margin: 0 auto;
+}
+
+.alm-section {
+  margin-top: var(--space-3xl);
+}
+
+.alm-section__head {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: auto auto;
+  column-gap: var(--space-md);
+  align-items: baseline;
+  margin-bottom: var(--space-lg);
+  padding-bottom: var(--space-sm);
+  border-bottom: 1px solid var(--rule);
+}
+
+.alm-section__index {
+  grid-row: 1 / 3;
+  align-self: center;
+  font-family: var(--font-display);
+  font-size: clamp(38px, 6.4vw, 56px);
+  font-weight: 600;
+  font-style: italic;
+  line-height: 0.9;
+  color: var(--accent);
+  padding-right: var(--space-2xs);
+}
+
+.alm-section__title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(23px, 3.6vw, 30px);
+  font-weight: 700;
+  letter-spacing: -0.005em;
+  line-height: 1.15;
+}
+
+.alm-section__blurb {
+  grid-column: 2;
+  margin: var(--space-sm) 0 0;
+  font-family: var(--font-serif);
+  font-size: 15px;
+  line-height: 1.5;
+  color: var(--ink-faint);
+  max-width: 68ch;
+}
+
+.alm-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
+  gap: 1px;
+  background: var(--rule);
+  border: 1px solid var(--rule);
+}
+
+.alm-entry {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  background: var(--paper-edge);
+  padding: var(--space-md);
+  transition: background 0.2s ease;
+}
+
+.alm-entry:hover {
+  background: var(--paper);
+}
+
+.alm-entry__label {
+  font-family: var(--font-sans);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.alm-entry__glyph {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 96px;
+  padding: var(--space-sm) 0;
+}
+
+.alm-entry__glyph svg {
+  display: block;
+  width: auto;
+  max-width: 100%;
+  height: auto;
+}
+
+.alm-entry__reading {
+  width: 100%;
+  margin: 0;
+  padding: var(--space-sm) 0 var(--space-md);
+  border-top: 1px solid var(--rule);
+  font-family: var(--font-serif);
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--ink-soft);
+  font-variant-numeric: tabular-nums;
+}
+
+.alm-entry__reading b {
+  color: var(--ink);
+  font-weight: 700;
+}
+
+.alm-entry--wide {
+  grid-column: 1 / -1;
+}
+
+.alm-entry--wide .alm-entry__glyph {
+  min-height: 0;
+}
+
+.alm-entry--wide .alm-entry__reading {
+  max-width: 52ch;
+}
+
+/* ============================================================================
+   FOOTER — a printer's colophon
+   ============================================================================ */
+.site-footer {
+  max-width: 940px;
+  margin: 0 auto;
+  padding: var(--space-lg) var(--space-lg) var(--space-2xl);
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: var(--space-md);
+  flex-wrap: wrap;
+  border-top: 3px double var(--rule-strong);
+  font-family: var(--font-sans);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  color: var(--ink-faint);
+}
+
+.site-footer__brand {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 18px;
+  letter-spacing: 0;
+  color: var(--ink);
+}
+
+.site-footer code {
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 11px;
+  color: var(--ink-soft);
+}
+
+/* ============================================================================
+   MOTION — one orchestrated page-load, all gated on reduced-motion.
+   ============================================================================ */
+@media (prefers-reduced-motion: no-preference) {
+  /* View swap: a quick paper-settle. */
+  .view {
+    animation: view-in 0.42s cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+
+  @keyframes view-in {
+    from {
+      opacity: 0;
+      transform: translateY(10px);
+    }
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
+
+  /* Masthead lays itself up like a printed page: folio, then nameplate, then
+     the rest — a short staggered cascade on first paint. */
+  .masthead__bar,
+  .masthead__nameplate,
+  .masthead__nav {
+    opacity: 0;
+    animation: lift-in 0.6s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  }
+  .masthead__bar {
+    animation-delay: 0.02s;
+  }
+  .masthead__nameplate {
+    animation-delay: 0.12s;
+  }
+  .masthead__nav {
+    animation-delay: 0.24s;
+  }
+
+  /* Article header stagger — kicker → headline → dek → byline → lead. */
+  .article__kicker,
+  .article__headline,
+  .article__dek,
+  .article__byline,
+  .article__lead,
+  .almanac__head {
+    opacity: 0;
+    animation: lift-in 0.6s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  }
+  .article__kicker {
+    animation-delay: 0.06s;
+  }
+  .article__headline {
+    animation-delay: 0.13s;
+  }
+  .article__dek {
+    animation-delay: 0.22s;
+  }
+  .article__byline {
+    animation-delay: 0.31s;
+  }
+  .article__lead {
+    animation-delay: 0.4s;
+  }
+
+  @keyframes lift-in {
+    from {
+      opacity: 0;
+      transform: translateY(12px);
+    }
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
+
+  /* Figures & almanac entries develop as they scroll into view. */
+  .figure,
+  .alm-entry {
+    opacity: 0;
+    transform: translateY(16px);
+    transition:
+      opacity 0.55s cubic-bezier(0.22, 1, 0.36, 1),
+      transform 0.55s cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  .figure[data-revealed="true"],
+  .alm-entry[data-revealed="true"] {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* ============================================================================
+   RESPONSIVE — verified at 375 / 768 / 1280. No horizontal scroll at 375.
+   ============================================================================ */
+
+/* Tablet: collapse the wide-figure bleed. */
+@media (max-width: 860px) {
+  .figure--wide {
+    margin-left: 0;
+    margin-right: 0;
+    width: 100%;
+  }
+}
+
+/* Phone. */
+@media (max-width: 620px) {
+  body {
+    font-size: 18px;
+  }
+  .masthead,
+  .article,
+  .almanac,
+  .index,
+  .site-footer {
+    padding-left: var(--space-md);
+    padding-right: var(--space-md);
+  }
+  .masthead__bar {
+    font-size: 10.5px;
+    letter-spacing: 0.1em;
+  }
+  .card--figure {
+    grid-column: span 1;
+  }
+  .index__list {
+    grid-template-columns: 1fr;
+  }
+  .alm-grid {
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  }
+  .alm-section__blurb {
+    font-size: 14px;
+  }
+}
+
+/* Narrow phone: two-up almanac, roomier tap targets, tighter folio. */
+@media (max-width: 400px) {
+  .masthead__bar {
+    font-size: 9.5px;
+    gap: var(--space-xs);
+  }
+  .alm-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+  .alm-entry--wide {
+    grid-column: 1 / -1;
+  }
+}

--- a/examples/dispatch-editorial/src/components/Almanac.tsx
+++ b/examples/dispatch-editorial/src/components/Almanac.tsx
@@ -1,0 +1,325 @@
+import type { ReactNode } from "react";
+import { StationGlyph } from "@microcharts/react/station-glyph/interactive";
+import { WindBarb } from "@microcharts/react/wind-barb";
+import { MoonPhase } from "@microcharts/react/moon-phase/interactive";
+import { Hourglass } from "@microcharts/react/hourglass/interactive";
+import { FillWord } from "@microcharts/react/fill-word/interactive";
+import { DicePips } from "@microcharts/react/dice-pips/interactive";
+import { GardenGrid } from "@microcharts/react/garden-grid/interactive";
+import { MusicStaff } from "@microcharts/react/music-staff/interactive";
+import { useReveal } from "./useReveal";
+import {
+  airSeverity,
+  fireDanger,
+  migrationFlow,
+  moonNewIn,
+  moonTonight,
+  prevailingWind,
+  rainRhythm,
+  reservoirFraction,
+  snowpackFraction,
+  solsticeElapsed,
+  stations,
+  tideHighs,
+  weekHighs,
+} from "../data";
+
+/** One almanac entry: a glyph plate, a small-caps label, an almanac reading. */
+function Entry({
+  label,
+  reading,
+  children,
+  wide = false,
+}: {
+  label: string;
+  reading: ReactNode;
+  children: ReactNode;
+  wide?: boolean;
+}) {
+  const ref = useReveal<HTMLDivElement>();
+  return (
+    <div ref={ref} className={wide ? "alm-entry alm-entry--wide" : "alm-entry"}>
+      <span className="alm-entry__label">{label}</span>
+      <div className="alm-entry__glyph">{children}</div>
+      <p className="alm-entry__reading">{reading}</p>
+    </div>
+  );
+}
+
+function Section({
+  index,
+  title,
+  blurb,
+  children,
+}: {
+  index: string;
+  title: string;
+  blurb: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="alm-section">
+      <div className="alm-section__head">
+        <span className="alm-section__index">{index}</span>
+        <h3 className="alm-section__title">{title}</h3>
+        <p className="alm-section__blurb">{blurb}</p>
+      </div>
+      <div className="alm-grid">{children}</div>
+    </section>
+  );
+}
+
+export function Almanac() {
+  return (
+    <div className="almanac" data-mc-theme="editorial">
+      <header className="almanac__head">
+        <p className="article__kicker">The Almanac</p>
+        <h2 className="almanac__title">The Reckoning of the Week</h2>
+        <p className="almanac__standfirst">
+          A field ledger for the days ahead: the skies overhead, the winds that move through them,
+          the water in the ground, and the odds of trouble. Every mark below is a small chart,
+          printed to read in gray.
+        </p>
+      </header>
+
+      <Section
+        index="I"
+        title="State of the Skies"
+        blurb="Station models for four regional posts, read at a glance: the disc gives sky cover, the barb gives wind, the corners give temperature, dew point, and pressure."
+      >
+        {stations.map((s) => (
+          <Entry
+            key={s.station}
+            label={s.place}
+            reading={
+              <>
+                <b>{s.station}</b> · {s.temp}°F, wind {s.wind.magnitude} mph,{" "}
+                {Math.round(s.cloud * 100)}% sky cover.
+              </>
+            }
+          >
+            <StationGlyph
+              station={s.station}
+              cloud={s.cloud}
+              wind={s.wind}
+              temp={s.temp}
+              dewpoint={s.dewpoint}
+              pressure={s.pressure}
+              size={72}
+              summary={false}
+            />
+          </Entry>
+        ))}
+      </Section>
+
+      <Section
+        index="II"
+        title="Winds & Wanderers"
+        blurb="What moves through the region this week — the prevailing wind off the coast, and the net bearing of the season's songbird passage overhead."
+      >
+        <Entry
+          label="Prevailing Wind"
+          reading={
+            <>
+              From the <b>southwest</b>, steady near {prevailingWind.magnitude} mph. Each barb
+              counts ten.
+            </>
+          }
+        >
+          <WindBarb
+            direction={prevailingWind.direction}
+            magnitude={prevailingWind.magnitude}
+            step={10}
+            label="value"
+            size={72}
+            summary={false}
+          />
+        </Entry>
+        <Entry
+          label="Migration Flow"
+          reading={
+            <>
+              Net southerly passage, <b>heavy</b> — roughly 340 birds an hour crossing the ridge
+              line after dusk.
+            </>
+          }
+        >
+          <WindBarb
+            direction={migrationFlow.direction}
+            magnitude={migrationFlow.magnitude}
+            step={10}
+            label="value"
+            size={72}
+            summary={false}
+          />
+        </Entry>
+      </Section>
+
+      <Section
+        index="III"
+        title="The Sky Calendar"
+        blurb="Time and light: the moon tonight, the slow drain of the season toward the solstice, and the shape of the week's forecast highs as a short melody."
+      >
+        <Entry
+          label="The Moon Tonight"
+          reading={
+            <>
+              <b>Waning gibbous</b>, {Math.round(moonTonight * 100)}% lit. New moon in{" "}
+              {Math.round(moonNewIn * 28)} days.
+            </>
+          }
+        >
+          <MoonPhase value={moonTonight} mode="cycle" size={72} summary={false} />
+        </Entry>
+        <Entry
+          label="Toward the Solstice"
+          reading={
+            <>
+              The autumn season runs <b>two-thirds</b> elapsed; the sand marks what light is left
+              before the year turns.
+            </>
+          }
+        >
+          <Hourglass
+            value={solsticeElapsed}
+            label="remaining"
+            width={54}
+            height={72}
+            summary={false}
+          />
+        </Entry>
+        <Entry
+          label="The Week in Weather"
+          wide
+          reading={
+            <>
+              Forecast highs, Monday through Sunday (°F). A midweek peak at 63, then a cool slide
+              into the weekend.
+            </>
+          }
+        >
+          <MusicStaff
+            data={weekHighs}
+            mode="ledger"
+            label="last"
+            width={220}
+            height={72}
+            format={{ maximumFractionDigits: 0 }}
+            summary={false}
+          />
+        </Entry>
+      </Section>
+
+      <Section
+        index="IV"
+        title="Water & Ground"
+        blurb="What the land is holding: mountain snowpack and reservoir storage as inked words, and five weeks of measurable rain printed as a grayscale rhythm."
+      >
+        <Entry
+          label="Snowpack"
+          reading={
+            <>
+              <b>{Math.round(snowpackFraction * 100)}%</b> of the April-1 normal in the headwaters —
+              a lean start to the water year.
+            </>
+          }
+        >
+          <FillWord
+            word="SNOWPACK"
+            value={snowpackFraction}
+            mode="fill"
+            label="value"
+            fontSize={26}
+            summary={false}
+          />
+        </Entry>
+        <Entry
+          label="Reservoir"
+          reading={
+            <>
+              Storage at <b>{Math.round(reservoirFraction * 100)}%</b> of capacity, and holding
+              through the dry stretch.
+            </>
+          }
+        >
+          <FillWord
+            word="RESERVOIR"
+            value={reservoirFraction}
+            mode="fill"
+            label="value"
+            fontSize={26}
+            summary={false}
+          />
+        </Entry>
+        <Entry
+          label="Rain Rhythm"
+          wide
+          reading={
+            <>
+              Measurable-rain days over five weeks, darker for heavier fall. The wet middle week
+              stands out against the dry flanks.
+            </>
+          }
+        >
+          <GardenGrid
+            data={rainRhythm}
+            rows={7}
+            steps={5}
+            unit="rain days"
+            cell={13}
+            summary={false}
+          />
+        </Entry>
+      </Section>
+
+      <Section
+        index="V"
+        title="The Odds of Trouble"
+        blurb="Two hazard readings on the almanac's old six-point dice, and the coming week's tide highs as a second melody for those who work the water."
+      >
+        <Entry
+          label="Fire Weather"
+          reading={
+            <>
+              <b>Four of six</b> on the danger die — elevated, on account of low humidity and a
+              persistent offshore breeze.
+            </>
+          }
+        >
+          <DicePips value={fireDanger} size={56} summary={false} />
+        </Entry>
+        <Entry
+          label="Air Quality"
+          reading={
+            <>
+              <b>Two of six</b> — good to moderate, with a little haze settling in the valleys
+              overnight.
+            </>
+          }
+        >
+          <DicePips value={airSeverity} size={56} summary={false} />
+        </Entry>
+        <Entry
+          label="The Week in Tides"
+          wide
+          reading={
+            <>
+              Predicted high tides, in feet, Monday through Sunday. Spring tides crest midweek
+              before the range eases off.
+            </>
+          }
+        >
+          <MusicStaff
+            data={tideHighs}
+            mode="ledger"
+            label="last"
+            width={220}
+            height={72}
+            format={{ maximumFractionDigits: 1 }}
+            summary={false}
+          />
+        </Entry>
+      </Section>
+    </div>
+  );
+}

--- a/examples/dispatch-editorial/src/components/ChartsIndex.tsx
+++ b/examples/dispatch-editorial/src/components/ChartsIndex.tsx
@@ -1,0 +1,399 @@
+import type { ReactNode } from "react";
+import { Sparkline } from "@microcharts/react/sparkline/interactive";
+import { SparkBar } from "@microcharts/react/sparkbar/interactive";
+import { Delta } from "@microcharts/react/delta/interactive";
+import { TrendArrow } from "@microcharts/react/trend-arrow/interactive";
+import { StatusDot } from "@microcharts/react/status-dot/interactive";
+import { HistogramStrip } from "@microcharts/react/histogram-strip/interactive";
+import { Dumbbell } from "@microcharts/react/dumbbell/interactive";
+import { Slope } from "@microcharts/react/slope/interactive";
+import { SegmentedBar } from "@microcharts/react/segmented-bar/interactive";
+import { LikertStrip } from "@microcharts/react/likert-strip/interactive";
+import { PartitionStrip } from "@microcharts/react/partition-strip/interactive";
+import { PairedBars } from "@microcharts/react/paired-bars/interactive";
+import { StationGlyph } from "@microcharts/react/station-glyph/interactive";
+import { WindBarb } from "@microcharts/react/wind-barb";
+import { MoonPhase } from "@microcharts/react/moon-phase/interactive";
+import { Hourglass } from "@microcharts/react/hourglass/interactive";
+import { FillWord } from "@microcharts/react/fill-word/interactive";
+import { DicePips } from "@microcharts/react/dice-pips/interactive";
+import { GardenGrid } from "@microcharts/react/garden-grid/interactive";
+import { MusicStaff } from "@microcharts/react/music-staff/interactive";
+import { Threshold, Marker } from "@microcharts/react/annotations";
+import {
+  breachIndex,
+  budgetComposition,
+  districtSpend,
+  exportDestinations,
+  futuresSeries,
+  harvestSwing,
+  moonTonight,
+  prevailingWind,
+  priceCeiling,
+  priceNow,
+  priceYearAgo,
+  rainfallAnomaly,
+  rainfallByRegion,
+  rainRhythm,
+  readerPoll,
+  reservoirFraction,
+  retailYoY,
+  solsticeElapsed,
+  springRunUp,
+  stations,
+  weekHighs,
+  yieldsByCountry,
+} from "../data";
+
+type Role = "inline" | "figure" | "glyph";
+
+type IndexEntry = {
+  name: string;
+  role: Role;
+  caption: string;
+  demo: ReactNode;
+};
+
+const inline = (demo: ReactNode): ReactNode => <span className="mc-inline">{demo}</span>;
+
+const ENTRIES: IndexEntry[] = [
+  {
+    name: "Sparkline",
+    role: "inline",
+    caption:
+      "A run of values compressed onto the baseline: “prices climbed [chart] through the spring.”",
+    demo: inline(
+      <Sparkline data={springRunUp} width={64} height={20} summary={false} dots="none" />,
+    ),
+  },
+  {
+    name: "Delta",
+    role: "inline",
+    caption:
+      "A signed change against a prior value — with `from`, it reads as a percent, set in running text.",
+    demo: <Delta value={priceNow} from={priceYearAgo} positive="down" summary={false} />,
+  },
+  {
+    name: "TrendArrow",
+    role: "inline",
+    caption: "Direction of movement as a single glyph, tuned for the flow of a sentence.",
+    demo: inline(<TrendArrow value={-retailYoY} glyph="chevron" positive="up" summary={false} />),
+  },
+  {
+    name: "SparkBar",
+    role: "inline",
+    caption: "A win/loss streak of successive periods: each bar one interval against the last.",
+    demo: inline(
+      <SparkBar data={harvestSwing} width={56} height={20} mode="winloss" summary={false} />,
+    ),
+  },
+  {
+    name: "StatusDot",
+    role: "inline",
+    caption: "A state token mid-sentence: “supply remains [dot] constrained.”",
+    demo: inline(<StatusDot status="warn" summary={false} />),
+  },
+  {
+    name: "HistogramStrip",
+    role: "figure",
+    caption: "The shape of a distribution, with one bin marked to show where the median falls.",
+    demo: (
+      <HistogramStrip
+        data={rainfallAnomaly}
+        bins={10}
+        markValue={-410}
+        width={520}
+        height={110}
+        format={{ maximumFractionDigits: 0 }}
+        summary={false}
+      />
+    ),
+  },
+  {
+    name: "Dumbbell",
+    role: "figure",
+    caption: "Before and after by category — the normal season against this one.",
+    demo: (
+      <Dumbbell
+        data={rainfallByRegion}
+        highlight="Minas Gerais"
+        positive="up"
+        label="value"
+        domain={[700, 2100]}
+        width={640}
+        height={200}
+        format={{ maximumFractionDigits: 0 }}
+        summary={false}
+        style={{ width: "100%", height: "auto" }}
+      />
+    ),
+  },
+  {
+    name: "Slope",
+    role: "figure",
+    caption:
+      "A two-point comparison across items — yields then and now, for Brazil, Vietnam, Colombia, Ethiopia and Honduras.",
+    demo: (
+      <Slope
+        data={yieldsByCountry}
+        highlight="Vietnam"
+        positive="up"
+        label="value"
+        width={640}
+        height={280}
+        format={{ maximumFractionDigits: 0 }}
+        summary={false}
+        style={{ width: "100%", height: "auto" }}
+      />
+    ),
+  },
+  {
+    name: "SegmentedBar",
+    role: "figure",
+    caption: "Composition as parts of a whole — where the crop is consumed.",
+    demo: (
+      <SegmentedBar
+        data={exportDestinations}
+        label="percent"
+        width={520}
+        height={52}
+        summary={false}
+      />
+    ),
+  },
+  {
+    name: "PartitionStrip",
+    role: "figure",
+    caption:
+      "A two-level breakdown — program areas over line items, each width its share of the whole.",
+    demo: (
+      <PartitionStrip data={budgetComposition} labels width={520} height={120} summary={false} />
+    ),
+  },
+  {
+    name: "PairedBars",
+    role: "figure",
+    caption: "Two series per row, zero-anchored — budget as a ghost behind the actual spend.",
+    demo: (
+      <PairedBars
+        data={districtSpend}
+        mode="overlay"
+        orientation="horizontal"
+        positive="down"
+        width={520}
+        height={170}
+        format={{ maximumFractionDigits: 1 }}
+        summary={false}
+      />
+    ),
+  },
+  {
+    name: "LikertStrip",
+    role: "figure",
+    caption: "A survey row diverging from a center line — disagreement left, agreement right.",
+    demo: (
+      <div style={{ paddingRight: 14 }}>
+        <LikertStrip
+          data={readerPoll}
+          neutral="split"
+          label="ends"
+          width={520}
+          height={64}
+          summary={false}
+        />
+      </div>
+    ),
+  },
+  {
+    name: "Sparkline + annotations",
+    role: "figure",
+    caption: "A full-width series carrying a Threshold hairline and a Marker flag as children.",
+    demo: (
+      <Sparkline
+        data={futuresSeries}
+        width={520}
+        height={140}
+        fill
+        dots="minmax"
+        format={{ maximumFractionDigits: 0 }}
+        summary={false}
+      >
+        <Threshold y={priceCeiling} label="300¢" />
+        <Marker x={breachIndex} label="Breach" />
+      </Sparkline>
+    ),
+  },
+  {
+    name: "StationGlyph",
+    role: "glyph",
+    caption:
+      "The meteorologist's dense station model — sky cover, wind, and three corner numerals in one cell.",
+    demo: (
+      <StationGlyph
+        station={stations[0].station}
+        cloud={stations[0].cloud}
+        wind={stations[0].wind}
+        temp={stations[0].temp}
+        dewpoint={stations[0].dewpoint}
+        pressure={stations[0].pressure}
+        size={72}
+        summary={false}
+      />
+    ),
+  },
+  {
+    name: "WindBarb",
+    role: "glyph",
+    caption: "Direction as shaft angle, strength as quantized barbs — each barb ten.",
+    demo: (
+      <WindBarb
+        direction={prevailingWind.direction}
+        magnitude={prevailingWind.magnitude}
+        step={10}
+        label="value"
+        size={72}
+        summary={false}
+      />
+    ),
+  },
+  {
+    name: "MoonPhase",
+    role: "glyph",
+    caption: "An illuminated fraction as the lit face of the moon.",
+    demo: <MoonPhase value={moonTonight} mode="cycle" size={72} summary={false} />,
+  },
+  {
+    name: "Hourglass",
+    role: "glyph",
+    caption: "A deadline as sand — top remaining, bottom elapsed.",
+    demo: (
+      <Hourglass value={solsticeElapsed} label="remaining" width={54} height={72} summary={false} />
+    ),
+  },
+  {
+    name: "FillWord",
+    role: "glyph",
+    caption: "A labelled progress read where the word is the metric and the ink is the value.",
+    demo: (
+      <FillWord
+        word="RESERVOIR"
+        value={reservoirFraction}
+        mode="fill"
+        label="value"
+        fontSize={24}
+        summary={false}
+      />
+    ),
+  },
+  {
+    name: "DicePips",
+    role: "glyph",
+    caption: "A subitized count 0–6 on a die — severity or rating in a single cell.",
+    demo: <DicePips value={4} size={56} summary={false} />,
+  },
+  {
+    name: "GardenGrid",
+    role: "glyph",
+    caption: "A calendar-shaped intensity, quantized to five gray steps for print.",
+    demo: (
+      <GardenGrid data={rainRhythm} rows={7} steps={5} unit="rain days" cell={12} summary={false} />
+    ),
+  },
+  {
+    name: "MusicStaff",
+    role: "glyph",
+    caption: "A short series as pitch on a five-line staff — a week read as a melody.",
+    demo: (
+      <MusicStaff
+        data={weekHighs}
+        mode="ledger"
+        label="last"
+        width={220}
+        height={72}
+        format={{ maximumFractionDigits: 0 }}
+        summary={false}
+      />
+    ),
+  },
+];
+
+const ROLE_LABEL: Record<Role, string> = {
+  inline: "in prose",
+  figure: "figure",
+  glyph: "glyph",
+};
+
+const GROUPS: { role: Role; title: string; note: string }[] = [
+  {
+    role: "inline",
+    title: "Set in running text",
+    note: "a few dozen pixels, riding the baseline",
+  },
+  {
+    role: "figure",
+    title: "Standing figures",
+    note: "the block charts that break the column",
+  },
+  {
+    role: "glyph",
+    title: "Almanac glyphs",
+    note: "one reading packed into a single cell",
+  },
+];
+
+export function ChartsIndex() {
+  return (
+    <section className="index" data-mc-theme="editorial">
+      <p className="article__kicker">Colophon</p>
+      <h2 className="index__title">Specimen of marks in this issue</h2>
+      <p className="index__intro">
+        A back-of-book sample of every mark that appears in Dispatch — not a catalog of the library.
+        Three registers only: prose inline, standing figures, and almanac glyphs. Each demo is the
+        live component, set the way an editor would set it.
+      </p>
+      {GROUPS.map((g) => (
+        <div key={g.role} className="index__group">
+          <div className="index__group-head">
+            <h3 className="index__group-title">{g.title}</h3>
+            <span className="index__group-note">— {g.note}</span>
+          </div>
+          <ul className="index__list">
+            {ENTRIES.filter((e) => e.role === g.role).map((e) => (
+              <li key={e.name} className={`card card--${e.role}`}>
+                <div className="card__head">
+                  <h3 className="card__name">{e.name}</h3>
+                  <span className="card__role">{ROLE_LABEL[e.role]}</span>
+                </div>
+                <div className="card__demo">{e.demo}</div>
+                <p className="card__caption">{e.caption}</p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+
+      <div className="index__group">
+        <div className="index__group-head">
+          <h3 className="index__group-title">Output contexts</h3>
+          <span className="index__group-note">— the same marks, tuned for paper and e-paper</span>
+        </div>
+        <div className="specimen-row">
+          <div className="specimen" data-mc-theme="print">
+            <span className="specimen__label">Print</span>
+            <div className="specimen__charts">
+              <Sparkline data={springRunUp} width={64} height={20} summary={false} dots="none" />
+              <Delta value={priceNow} from={priceYearAgo} positive="down" summary={false} />
+            </div>
+          </div>
+          <div className="specimen" data-mc-theme="eink">
+            <span className="specimen__label">E-ink</span>
+            <div className="specimen__charts">
+              <Sparkline data={springRunUp} width={64} height={20} summary={false} dots="none" />
+              <Delta value={priceNow} from={priceYearAgo} positive="down" summary={false} />
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/examples/dispatch-editorial/src/components/Feature.tsx
+++ b/examples/dispatch-editorial/src/components/Feature.tsx
@@ -1,0 +1,250 @@
+import { Sparkline } from "@microcharts/react/sparkline";
+import { Sparkline as InteractiveSparkline } from "@microcharts/react/sparkline/interactive";
+import { SparkBar } from "@microcharts/react/sparkbar";
+import { Delta } from "@microcharts/react/delta";
+import { TrendArrow } from "@microcharts/react/trend-arrow";
+import { StatusDot } from "@microcharts/react/status-dot";
+import { HistogramStrip } from "@microcharts/react/histogram-strip/interactive";
+import { Dumbbell } from "@microcharts/react/dumbbell/interactive";
+import { Slope } from "@microcharts/react/slope/interactive";
+import { SegmentedBar } from "@microcharts/react/segmented-bar/interactive";
+import { Threshold, Marker, TargetZone, Callout } from "@microcharts/react/annotations";
+import { Figure } from "./Figure";
+import {
+  breachIndex,
+  exportDestinations,
+  futuresSeries,
+  harvestSwing,
+  priceCeiling,
+  priceNow,
+  priceYearAgo,
+  rainfallAnomaly,
+  rainfallByRegion,
+  retailYoY,
+  springRunUp,
+  stockCover,
+  yieldsByCountry,
+} from "../data";
+
+export function Feature() {
+  return (
+    <article className="article prose" data-mc-theme="editorial">
+      <p className="article__kicker">Commodities · Climate</p>
+      <h2 className="article__headline">The Bitter Arithmetic of a Warming Cup</h2>
+      <p className="article__dek">
+        A third failed rainy season across the coffee belt has pushed the price of a morning ritual
+        to levels the trade has not seen in half a century. The math behind the mug is no longer
+        reassuring.
+      </p>
+      <p className="article__byline">
+        By <span className="article__author">Marisol Everett</span>
+        <span className="article__place"> · Poços de Caldas, Brazil</span>
+      </p>
+
+      <p className="article__lead">
+        For four generations the Ferraz family has read the sky over their hillside rows the way
+        others read a ledger. This spring the ledger came due. Arabica futures climbed{" "}
+        <span className="mc-inline">
+          <Sparkline data={springRunUp} width={64} height={20} summary={false} dots="none" />
+        </span>{" "}
+        almost without pause through the planting months, and by the second week of June the
+        benchmark contract in New York settled at 342 cents a pound{" "}
+        <Delta value={priceNow} from={priceYearAgo} positive="down" summary={false} /> year over
+        year. For a crop that trades on weather more than on any central bank, the number was less a
+        shock than a verdict.
+      </p>
+
+      <p>
+        The cause is not mysterious. Rainfall across the belt has arrived late, thin, and in the
+        wrong order for three seasons running{" "}
+        <span className="mc-inline">
+          <TrendArrow value={-retailYoY} glyph="chevron" positive="up" summary={false} />
+        </span>
+        , and the supply that reaches the ports remains&nbsp;
+        <span className="mc-inline">
+          <StatusDot status="warn" summary={false} />
+        </span>{" "}
+        constrained. Warehouse stocks have thinned from eleven weeks of cover to six&nbsp;
+        <span className="mc-inline">
+          <SparkBar data={stockCover} width={52} height={20} summary={false} />
+        </span>{" "}
+        since the turn of the year, and each of the last six harvests has swung hard against the one
+        before it{" "}
+        <span className="mc-inline">
+          <SparkBar data={harvestSwing} width={56} height={20} mode="winloss" summary={false} />
+        </span>
+        , so a run of bad years no longer averages out to a good decade.
+      </p>
+
+      <blockquote className="pullquote">
+        &ldquo;We used to lose a branch here and there to frost. Now we lose the rain that the whole
+        hill drinks.&rdquo;
+      </blockquote>
+
+      <p>
+        Zoom out from any single farm and the pattern hardens into a distribution. Measured against
+        the thirty-year normal, the coffee belt&rsquo;s stations this season clustered firmly on the
+        dry side of the ledger&mdash;most reporting deficits of three to five hundred millimetres, a
+        shortfall that arrives precisely when the cherries are setting.
+      </p>
+
+      <Figure
+        caption={
+          <>
+            <b>Fig. 1 &mdash; A dry season, by the station.</b> Rainfall anomaly across 46 belt
+            stations, millimetres below the 30-year normal. The marked bin holds the belt&rsquo;s
+            median deficit of roughly 410&nbsp;mm.
+          </>
+        }
+      >
+        <HistogramStrip
+          data={rainfallAnomaly}
+          bins={10}
+          markValue={-410}
+          width={640}
+          height={140}
+          format={{ maximumFractionDigits: 0 }}
+          summary={false}
+          style={{ width: "100%", height: "auto" }}
+        />
+      </Figure>
+
+      <p>
+        The regions that anchor the world&rsquo;s supply were hit unevenly but without exception. In
+        Minas Gerais, the state that alone grows more arabica than any country outside Brazil, the
+        season delivered barely two thirds of its usual water. The wetter highlands of Vietnam fared
+        better in absolute terms and still lost a third of their margin.
+      </p>
+
+      <Figure
+        caption={
+          <>
+            <b>Fig. 2 &mdash; What the hills expected, and what they got.</b> Seasonal rainfall by
+            growing region: the 30-year normal (open) against the 2025 season (filled), in
+            millimetres.
+          </>
+        }
+      >
+        <Dumbbell
+          data={rainfallByRegion}
+          highlight="Minas Gerais"
+          positive="up"
+          label="value"
+          domain={[700, 2100]}
+          width={640}
+          height={220}
+          format={{ maximumFractionDigits: 0 }}
+          summary={false}
+          style={{ width: "100%", height: "auto" }}
+        />
+      </Figure>
+
+      <blockquote className="pullquote">
+        A run of bad years no longer averages out to a good decade.
+      </blockquote>
+
+      <p>
+        Yields tell the same story a decade deep. Compare the bags each producing country coaxed
+        from a hectare in 2015 with the harvest of 2025 and the lines mostly slope the wrong way.
+        Vietnam&rsquo;s once commanding productivity has slipped hardest; only Colombia and
+        Ethiopia, buoyed by replanting and altitude, held or gained ground.
+      </p>
+
+      <Figure
+        wide
+        caption={
+          <>
+            <b>Fig. 3 &mdash; Ten years, per hectare.</b> Green-coffee yield by country, bags per
+            hectare, 2015 against 2025. Countries shown: Brazil, Vietnam, Colombia, Ethiopia,
+            Honduras &mdash; Vietnam highlighted.
+          </>
+        }
+      >
+        <Slope
+          data={yieldsByCountry}
+          highlight="Vietnam"
+          positive="up"
+          label="value"
+          width={760}
+          height={320}
+          format={{ maximumFractionDigits: 0 }}
+          summary={false}
+          style={{ width: "100%", height: "auto" }}
+        />
+      </Figure>
+
+      <p>
+        Where the beans finally go has barely moved, and that is its own kind of pressure. Europe
+        still drinks the largest share of the world&rsquo;s green coffee, with North America and
+        Japan absorbing most of the rest&mdash;a concentrated demand that leaves little slack when a
+        harvest disappoints.
+      </p>
+
+      <Figure
+        caption={
+          <>
+            <b>Fig. 4 &mdash; One crop, a few tables.</b> Destination share of green-coffee exports
+            by volume. Demand stays concentrated even as supply thins.
+          </>
+        }
+      >
+        <SegmentedBar
+          data={exportDestinations}
+          label="percent"
+          width={640}
+          height={72}
+          summary={false}
+          style={{ width: "100%", height: "auto" }}
+        />
+      </Figure>
+
+      <p>
+        Traders spent the spring watching a single line and a single number. For years, three
+        hundred cents a pound had served as a kind of ceiling&mdash;a level the market approached
+        and retreated from. This season it stopped retreating.
+      </p>
+
+      <Figure
+        wide
+        caption={
+          <>
+            <b>Fig. 5 &mdash; The ceiling that became a floor.</b> ICE arabica futures, monthly
+            close in US cents per pound, over 18 months. The hairline marks the 300¢ level the
+            market kept testing; the flag marks the month it closed above and stayed.
+          </>
+        }
+      >
+        <InteractiveSparkline
+          data={futuresSeries}
+          width={760}
+          height={210}
+          fill
+          dots="minmax"
+          label="last"
+          format={{ maximumFractionDigits: 0 }}
+          summary={false}
+          animate
+          style={{ width: "100%", height: "auto" }}
+        >
+          <TargetZone y={[280, 320]} label="ceiling band" />
+          <Threshold y={priceCeiling} label="300¢ ceiling" />
+          <Marker x={breachIndex} label="First close above" celebrate />
+          <Callout x={breachIndex} y={futuresSeries[breachIndex]} label="breach" />
+        </InteractiveSparkline>
+      </Figure>
+
+      <p>
+        None of this reads as a temporary squeeze to the people who grow the crop. The Ferraz family
+        has begun replanting a fifth of their rows with a hardier, lower-yielding
+        varietal&mdash;insurance against a climate that no longer keeps its old appointments. The
+        cup on the far end of that decision will cost more, and it will keep costing more, because
+        the arithmetic that used to forgive a bad year has quietly stopped doing so.
+      </p>
+
+      <p className="article__end">
+        Marisol Everett is a contributing correspondent for Dispatch. Additional reporting from São
+        Paulo.
+      </p>
+    </article>
+  );
+}

--- a/examples/dispatch-editorial/src/components/Figure.tsx
+++ b/examples/dispatch-editorial/src/components/Figure.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from "react";
+import { useReveal } from "./useReveal";
+
+/**
+ * A block figure with a rule-topped caption. Reveals once on scroll-in.
+ * `wide` breaks the reading measure for the large charts.
+ */
+export function Figure({
+  children,
+  caption,
+  wide = false,
+}: {
+  children: ReactNode;
+  caption: ReactNode;
+  wide?: boolean;
+}) {
+  const ref = useReveal<HTMLElement>();
+  return (
+    <figure ref={ref} className={wide ? "figure figure--wide" : "figure"}>
+      <div className="figure__plate">{children}</div>
+      <figcaption>{caption}</figcaption>
+    </figure>
+  );
+}

--- a/examples/dispatch-editorial/src/components/Masthead.tsx
+++ b/examples/dispatch-editorial/src/components/Masthead.tsx
@@ -1,0 +1,41 @@
+export type View = "feature" | "overnight" | "almanac" | "index";
+
+const SECTIONS: { id: View; label: string }[] = [
+  { id: "feature", label: "The Feature" },
+  { id: "overnight", label: "Cities" },
+  { id: "almanac", label: "The Almanac" },
+  { id: "index", label: "Specimen" },
+];
+
+export function Masthead({ view, onNavigate }: { view: View; onNavigate: (v: View) => void }) {
+  return (
+    <header className="masthead">
+      <div className="masthead__bar">
+        <span className="masthead__issue">Vol. XIV · No. 6</span>
+        <span className="masthead__ornament" aria-hidden="true">
+          ✦ ✦ ✦
+        </span>
+        <span className="masthead__date">Sat, June 14, 2025 · Price 4¢</span>
+      </div>
+      <div className="masthead__nameplate">
+        <h1 className="masthead__title">Dispatch</h1>
+        <p className="masthead__tagline">
+          Field notes on markets, climate, and the arithmetic between them
+        </p>
+      </div>
+      <nav className="masthead__nav" aria-label="Sections">
+        {SECTIONS.map((s) => (
+          <button
+            key={s.id}
+            type="button"
+            className={view === s.id ? "tab tab--active" : "tab"}
+            aria-current={view === s.id ? "page" : undefined}
+            onClick={() => onNavigate(s.id)}
+          >
+            {s.label}
+          </button>
+        ))}
+      </nav>
+    </header>
+  );
+}

--- a/examples/dispatch-editorial/src/components/Overnight.tsx
+++ b/examples/dispatch-editorial/src/components/Overnight.tsx
@@ -1,0 +1,188 @@
+import { Sparkline } from "@microcharts/react/sparkline";
+import { Sparkline as InteractiveSparkline } from "@microcharts/react/sparkline/interactive";
+import { SparkBar } from "@microcharts/react/sparkbar";
+import { Delta } from "@microcharts/react/delta";
+import { TrendArrow } from "@microcharts/react/trend-arrow";
+import { StatusDot } from "@microcharts/react/status-dot";
+import { LikertStrip } from "@microcharts/react/likert-strip/interactive";
+import { PartitionStrip } from "@microcharts/react/partition-strip/interactive";
+import { PairedBars } from "@microcharts/react/paired-bars/interactive";
+import { Figure } from "./Figure";
+import {
+  budgetComposition,
+  costPerRiderNow,
+  costPerRiderProjected,
+  districtSpend,
+  fareEvasionYoY,
+  incidentsWeekly,
+  onTimeNights,
+  overnightRidership,
+  readerPoll,
+  venueReopenings,
+} from "../data";
+
+export function Overnight() {
+  return (
+    <article className="article prose" data-mc-theme="editorial">
+      <p className="article__kicker">Cities · Transit</p>
+      <h2 className="article__headline">The Line That Never Sleeps</h2>
+      <p className="article__dek">
+        A year ago the last train left at midnight. Then Halvorsen kept the lights on until dawn,
+        and a mid-size city learned what its nights were worth.
+      </p>
+      <p className="article__byline">
+        By <span className="article__author">Dev Okonkwo</span>
+        <span className="article__place"> · Halvorsen, Oregon</span>
+      </p>
+
+      <p className="article__lead">
+        The 2:40 to Harbor is not a romantic train. It smells of floor cleaner and cold coffee, and
+        on a Tuesday it carries maybe forty people. But a year into the city&rsquo;s overnight
+        pilot, those forty have become a crowd: average overnight boardings have climbed{" "}
+        <span className="mc-inline">
+          <InteractiveSparkline
+            data={overnightRidership}
+            width={72}
+            height={22}
+            summary={false}
+            dots="none"
+            animate
+            style={{ width: "3.4em", height: "1em" }}
+          />
+        </span>{" "}
+        from four thousand a night to nearly eighteen, and the cost of moving each of them has
+        fallen{" "}
+        <Delta
+          value={costPerRiderNow}
+          from={costPerRiderProjected}
+          positive="down"
+          format={{ style: "currency", currency: "USD" }}
+          summary={false}
+        />{" "}
+        against what the planners had penciled in.
+      </p>
+
+      <p>
+        The worries that dominated the council hearings have mostly not materialized. Fare evasion
+        is down{" "}
+        <span className="mc-inline">
+          <TrendArrow value={fareEvasionYoY} glyph="chevron" positive="down" summary={false} />
+        </span>
+        , reported incidents have thinned week over week{" "}
+        <span className="mc-inline">
+          <SparkBar data={incidentsWeekly} width={52} height={20} summary={false} />
+        </span>
+        , and on-time performance has held&nbsp;
+        <span className="mc-inline">
+          <StatusDot status="ok" summary={false} />
+        </span>{" "}
+        steady even on the nights maintenance runs long{" "}
+        <span className="mc-inline">
+          <SparkBar data={onTimeNights} width={56} height={20} mode="winloss" summary={false} />
+        </span>
+        . Along the Harbor corridor, eighteen late-night venues have reopened or extended hours{" "}
+        <span className="mc-inline">
+          <Sparkline data={venueReopenings} width={56} height={20} summary={false} dots="none" />
+        </span>{" "}
+        since the first all-night timetable took effect.
+      </p>
+
+      <blockquote className="pullquote">
+        &ldquo;We didn&rsquo;t build a train for the night shift. We found out how many people were
+        already living on it.&rdquo;
+      </blockquote>
+
+      <p>
+        None of it is free. The overnight program runs on a forty-five-million dollar budget, and
+        where that money goes says a great deal about what it takes to keep a city moving after
+        midnight. Nearly half of every dollar pays the people on the platform&mdash;operators,
+        mechanics, the security staff whose visible presence did more for ridership than any fare
+        promotion.
+      </p>
+
+      <Figure
+        caption={
+          <>
+            <b>Fig. 1 &mdash; Where the night&rsquo;s money goes.</b> The overnight operating
+            budget, $45.9M, by program area and line item. Labor dominates operations; capital
+            renewal is the second call on the purse.
+          </>
+        }
+      >
+        <PartitionStrip
+          data={budgetComposition}
+          labels
+          width={640}
+          height={148}
+          summary={false}
+          style={{ width: "100%", height: "auto" }}
+        />
+      </Figure>
+
+      <p>
+        The spend did not land evenly across the map, and the variance is the story planners now
+        study most closely. Four of the five service districts came in within a whisker of budget;
+        only Downtown, where a signal retrofit slipped a quarter, finished meaningfully under.
+      </p>
+
+      <Figure
+        caption={
+          <>
+            <b>Fig. 2 &mdash; Budget against actual, by district.</b> Planned allocation (ghost)
+            versus money actually spent (solid), in millions. Coming in under budget is the
+            favorable outcome.
+          </>
+        }
+      >
+        <PairedBars
+          data={districtSpend}
+          mode="overlay"
+          orientation="horizontal"
+          positive="down"
+          width={640}
+          height={220}
+          format={{ maximumFractionDigits: 1 }}
+          summary={false}
+          style={{ width: "100%", height: "auto" }}
+        />
+      </Figure>
+
+      <p>
+        Whether any of it was worth doing is, in the end, a question the ledger cannot answer. So
+        Dispatch asked the people who ride. Of 2,140 readers polled along the corridor, a clear
+        majority now say the overnight line has earned its keep&mdash;though a stubborn fifth remain
+        unconvinced the fare box will ever catch the cost.
+      </p>
+
+      <Figure
+        wide
+        caption={
+          <>
+            <b>Fig. 3 &mdash; &ldquo;Was the overnight line worth the cost?&rdquo;</b> Reader poll,
+            n = 2,140, from strongly oppose (left) to strongly support (right). The center holds
+            those with no strong opinion.
+          </>
+        }
+      >
+        <LikertStrip
+          data={readerPoll}
+          neutral="split"
+          label="ends"
+          width={760}
+          height={88}
+          summary={false}
+          style={{ width: "100%", height: "auto" }}
+        />
+      </Figure>
+
+      <p>
+        The council votes in the fall on whether to make the pilot permanent. The 2:40 to Harbor,
+        for its part, will keep running until then&mdash;half empty on the slow nights,
+        standing-room on the loud ones, a moving argument for a city that decided its dark hours
+        were worth counting.
+      </p>
+
+      <p className="article__end">Dev Okonkwo covers cities and infrastructure for Dispatch.</p>
+    </article>
+  );
+}

--- a/examples/dispatch-editorial/src/components/SiteFooter.tsx
+++ b/examples/dispatch-editorial/src/components/SiteFooter.tsx
@@ -1,0 +1,11 @@
+export function SiteFooter() {
+  return (
+    <footer className="site-footer">
+      <span className="site-footer__brand">Dispatch</span>
+      <span>
+        Set in Bodoni Moda &amp; Literata · charts by <code>@microcharts/react</code> on the{" "}
+        <code>editorial</code> theme
+      </span>
+    </footer>
+  );
+}

--- a/examples/dispatch-editorial/src/components/useReveal.ts
+++ b/examples/dispatch-editorial/src/components/useReveal.ts
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Adds `data-revealed="true"` to the element the first time it scrolls into
+ * view, so CSS can run a one-shot entrance. All motion is defined inside
+ * `@media (prefers-reduced-motion: no-preference)`, so this is a no-op for
+ * readers who ask for less motion — the element is simply visible from the
+ * start. One shared observer would be leaner, but figures are few here.
+ */
+export function useReveal<T extends HTMLElement = HTMLElement>() {
+  const ref = useRef<T>(null);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+
+    // No IntersectionObserver (or already past): reveal immediately.
+    if (typeof IntersectionObserver === "undefined") {
+      node.dataset.revealed = "true";
+      return;
+    }
+
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            (entry.target as HTMLElement).dataset.revealed = "true";
+            io.unobserve(entry.target);
+          }
+        }
+      },
+      { rootMargin: "0px 0px -12% 0px", threshold: 0.12 },
+    );
+
+    io.observe(node);
+    return () => io.disconnect();
+  }, []);
+
+  return ref;
+}

--- a/examples/dispatch-editorial/src/data.ts
+++ b/examples/dispatch-editorial/src/data.ts
@@ -1,0 +1,262 @@
+// Mock editorial data for "Dispatch," a data-journalism magazine.
+// Every number is a plausible journalistic invention, not a sourced figure.
+// Kept in one module so charts across views share the same seeded facts.
+
+/* ============================================================================
+   FEATURE — "The Bitter Arithmetic of a Warming Cup" (coffee & climate)
+   ========================================================================== */
+
+// ICE arabica futures, monthly close in US cents per pound, 18 months.
+export const futuresSeries: number[] = [
+  168, 172, 165, 178, 190, 187, 203, 221, 214, 232, 248, 255, 241, 263, 288, 301, 316, 342,
+];
+
+// The spring run-up only — woven into a sentence as a tiny sparkline.
+export const springRunUp: number[] = [241, 263, 288, 301, 316, 342];
+
+// Year-over-year price comparison for the inline Delta (c/lb).
+export const priceNow = 342;
+export const priceYearAgo = 214;
+
+// Signed YoY change in the retail bag index, for the inline TrendArrow.
+export const retailYoY = 0.19;
+
+// Brazil's annual harvest swing, percent change vs the prior crop year.
+export const harvestSwing: number[] = [4, -2, 6, -3, -9, -5];
+
+// Seasonal rainfall anomaly (mm below the 30-year normal) across 46 stations
+// in Brazil's coffee belt — raw observations, binned by the histogram.
+export const rainfallAnomaly: number[] = [
+  -420, -380, -510, -290, -340, -470, -230, -560, -410, -300, -390, -480, -260, -350, -440, -520,
+  -310, -370, -430, -280, -500, -360, -450, -240, -400, -330, -490, -270, -410, -380, -540, -320,
+  -460, -250, -420, -350, -470, -300, -390, -410, -530, -290, -440, -360, -480, -330,
+];
+
+// The psychological price ceiling the market kept breaching (c/lb).
+export const priceCeiling = 300;
+// Index of the month the ceiling was first breached (0-based into futuresSeries).
+export const breachIndex = 15;
+
+// Stock drawdown across the spring, a tiny bar strip in prose (weeks of cover).
+export const stockCover: number[] = [11, 10, 10, 9, 8, 7, 6, 6];
+
+// Rainfall by growing region: 30-year normal vs the 2025 season (mm).
+export const rainfallByRegion = [
+  { label: "Minas Gerais", from: 1420, to: 980 },
+  { label: "Espírito Santo", from: 1180, to: 870 },
+  { label: "Sul de Minas", from: 1350, to: 1010 },
+  { label: "Central Highlands", from: 1980, to: 1490 },
+];
+
+// Producing-country yields, bags per hectare, 2015 vs 2025.
+export const yieldsByCountry = [
+  { label: "Brazil", from: 28, to: 22 },
+  { label: "Vietnam", from: 41, to: 33 },
+  { label: "Colombia", from: 19, to: 26 },
+  { label: "Ethiopia", from: 7, to: 8 },
+  { label: "Honduras", from: 16, to: 13 },
+];
+
+// Where the beans go: destination share of green-coffee exports, percent.
+export const exportDestinations = [
+  { label: "European Union", value: 41 },
+  { label: "United States", value: 24 },
+  { label: "Japan", value: 11 },
+  { label: "Canada", value: 6 },
+  { label: "Other", value: 18 },
+];
+
+/* ============================================================================
+   SECOND STORY — "The Line That Never Sleeps" (a city's overnight transit)
+   ========================================================================== */
+
+// Average overnight boardings, in thousands, month by month across the pilot.
+export const overnightRidership: number[] = [
+  4.2, 5.1, 6.8, 7.3, 8.9, 9.4, 11.2, 12.6, 13.1, 14.8, 16.2, 17.9,
+];
+
+// Cost to move one overnight rider, dollars: projected vs realized.
+export const costPerRiderProjected = 4.1;
+export const costPerRiderNow = 2.85;
+
+// Fare-evasion rate change year over year (signed), for the inline TrendArrow.
+export const fareEvasionYoY = -0.12;
+
+// On-time performance streak, night by night — win/loss against the 5-min bar.
+export const onTimeNights: number[] = [1, 1, -1, 1, 1, 1, -1, 1, 1, 1, 1, -1];
+
+// Weekly overnight incidents reported, a small down-trending strip in prose.
+export const incidentsWeekly: number[] = [14, 12, 13, 9, 10, 7, 6, 5];
+
+// Operating budget, two levels, in millions of dollars. Parent = program area,
+// children = line items. PartitionStrip reads share of the whole.
+export const budgetComposition = [
+  {
+    label: "Operations",
+    children: [
+      { label: "Operators", value: 14.2 },
+      { label: "Maintenance", value: 6.1 },
+      { label: "Security", value: 4.4 },
+      { label: "Cleaning", value: 2.3 },
+    ],
+  },
+  {
+    label: "Capital",
+    children: [
+      { label: "Rolling stock", value: 7.8 },
+      { label: "Stations", value: 3.6 },
+      { label: "Signals", value: 2.9 },
+    ],
+  },
+  {
+    label: "Overhead",
+    children: [
+      { label: "Admin", value: 2.1 },
+      { label: "Insurance", value: 1.5 },
+    ],
+  },
+];
+
+// Spend by district: budgeted (ref) vs actual (value), in millions. Under
+// budget is the good outcome, so `positive="down"` on the chart.
+export const districtSpend = [
+  { label: "Downtown", value: 11.5, ref: 12.1 },
+  { label: "Riverside", value: 8.4, ref: 7.9 },
+  { label: "Northgate", value: 6.2, ref: 6.8 },
+  { label: "Eastpark", value: 5.3, ref: 5.0 },
+  { label: "Harbor", value: 3.7, ref: 4.1 },
+];
+
+// Reader poll, ordered most-negative → most-positive, share of respondents.
+// "Was the overnight line worth the cost?" (n = 2,140). Middle = neutral.
+export const readerPoll = [
+  { label: "Strongly oppose", value: 8 },
+  { label: "Oppose", value: 14 },
+  { label: "No opinion", value: 21 },
+  { label: "Support", value: 33 },
+  { label: "Strongly support", value: 24 },
+];
+
+// Late-night venue reopenings along the corridor, a small run in prose.
+export const venueReopenings: number[] = [3, 5, 4, 8, 11, 9, 14, 18];
+
+/* ============================================================================
+   THE ALMANAC — glyph charts as almanac entries
+   ========================================================================== */
+
+// Regional station models for the "State of the Skies" table.
+export type Station = {
+  station: string;
+  place: string;
+  cloud: number;
+  wind: { direction: number; magnitude: number };
+  temp: number;
+  dewpoint: number;
+  pressure: number;
+};
+
+export const stations: Station[] = [
+  {
+    station: "KPDX",
+    place: "Portland",
+    cloud: 0.75,
+    wind: { direction: 225, magnitude: 15 },
+    temp: 54,
+    dewpoint: 48,
+    pressure: 1013,
+  },
+  {
+    station: "KBOI",
+    place: "Boise",
+    cloud: 0.2,
+    wind: { direction: 315, magnitude: 8 },
+    temp: 61,
+    dewpoint: 39,
+    pressure: 1019,
+  },
+  {
+    station: "KSEA",
+    place: "Seattle",
+    cloud: 1.0,
+    wind: { direction: 200, magnitude: 22 },
+    temp: 51,
+    dewpoint: 47,
+    pressure: 1006,
+  },
+  {
+    station: "KMSO",
+    place: "Missoula",
+    cloud: 0.45,
+    wind: { direction: 290, magnitude: 11 },
+    temp: 49,
+    dewpoint: 34,
+    pressure: 1016,
+  },
+];
+
+// Prevailing wind for the season (from-direction, mph).
+export const prevailingWind = { direction: 245, magnitude: 18 };
+// The autumn songbird corridor: net flow bearing and volume (birds/hr, ÷10).
+export const migrationFlow = { direction: 190, magnitude: 34 };
+
+// Moon phase tonight (illuminated fraction, cycle mapping) + a countdown.
+export const moonTonight = 0.72;
+export const moonNewIn = 0.28;
+
+// Fraction of the season elapsed toward the winter solstice.
+export const solsticeElapsed = 0.68;
+
+// Mountain snowpack as a share of the April-1 normal (fill-word "SNOWPACK").
+export const snowpackFraction = 0.41;
+// Reservoir storage as a share of capacity (fill-word "RESERVOIR").
+export const reservoirFraction = 0.63;
+
+// Fire-weather severity for the week, 0–6 (dice-pips severity cell).
+export const fireDanger = 4;
+// Air-quality severity, 0–6.
+export const airSeverity = 2;
+
+// Five weeks of measurable-rain days, intensity 0–4 (garden-grid, 7 rows).
+// Column-major by design so each 7-cell column is one week.
+export const rainRhythm: (number | null)[] = [
+  2,
+  1,
+  0,
+  3,
+  4,
+  1,
+  0, // week 1
+  0,
+  0,
+  2,
+  3,
+  1,
+  0,
+  0, // week 2
+  1,
+  2,
+  4,
+  4,
+  2,
+  1,
+  0, // week 3
+  0,
+  1,
+  1,
+  0,
+  3,
+  2,
+  0, // week 4
+  3,
+  4,
+  2,
+  1,
+  0,
+  0,
+  1, // week 5
+];
+
+// The week's forecast high temperatures, Mon–Sun (music-staff melody, °F).
+export const weekHighs: (number | null)[] = [58, 61, 63, 57, 52, 55, 60];
+// Predicted tide highs across a week, feet (a second staff melody).
+export const tideHighs: (number | null)[] = [7.8, 8.1, 8.6, 8.9, 8.4, 7.9, 7.2];

--- a/examples/dispatch-editorial/src/main.tsx
+++ b/examples/dispatch-editorial/src/main.tsx
@@ -1,0 +1,13 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import "@microcharts/react/styles.css";
+import "@microcharts/react/motion";
+import "./app.css";
+import "./analytics";
+import { App } from "./App";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/examples/dispatch-editorial/tsconfig.json
+++ b/examples/dispatch-editorial/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "moduleDetection": "force",
+    "isolatedModules": true
+  },
+  "include": ["src"]
+}

--- a/examples/dispatch-editorial/vite.config.ts
+++ b/examples/dispatch-editorial/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: { port: 4005, strictPort: true, host: true },
+});

--- a/examples/ledger-finance/index.html
+++ b/examples/ledger-finance/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#14120d" />
+    <title>Ledger Terminal — a microcharts example</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Azeret+Mono:wght@400;500;600;700&family=Schibsted+Grotesk:wght@400;500;600;700;800&display=swap"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/ledger-finance/package.json
+++ b/examples/ledger-finance/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "example-ledger-finance",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite --port 4002 --strictPort",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview --port 4002 --strictPort"
+  },
+  "dependencies": {
+    "@microcharts/react": "^0.8.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^5.0.0",
+    "typescript": "^5.7.0",
+    "vite": "^7.0.0"
+  }
+}

--- a/examples/ledger-finance/public/robots.txt
+++ b/examples/ledger-finance/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/examples/ledger-finance/src/App.tsx
+++ b/examples/ledger-finance/src/App.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState } from "react";
+import { Portfolio } from "./components/Portfolio";
+import { Markets } from "./components/Markets";
+import { Asset } from "./components/Asset";
+import { Analytics } from "./components/Analytics";
+
+type Tab = "portfolio" | "markets" | "asset" | "analytics";
+
+const TABS: { id: Tab; label: string }[] = [
+  { id: "portfolio", label: "Portfolio" },
+  { id: "markets", label: "Markets" },
+  { id: "asset", label: "NVDA" },
+  { id: "analytics", label: "Analytics" },
+];
+
+/** A precise ledger mark: a hairline rule with a rising close — an OHLC in miniature. */
+function BrandMark() {
+  return (
+    <svg className="brand-mark" viewBox="0 0 22 24" fill="none" aria-hidden="true">
+      <line x1="1" y1="20.5" x2="21" y2="20.5" stroke="currentColor" strokeWidth="1.4" />
+      <line x1="4.5" y1="20.5" x2="4.5" y2="13" stroke="currentColor" strokeWidth="1.4" />
+      <line x1="10.5" y1="20.5" x2="10.5" y2="8" stroke="currentColor" strokeWidth="1.4" />
+      <rect x="8.7" y="8" width="3.6" height="6.5" fill="currentColor" />
+      <line x1="16.5" y1="20.5" x2="16.5" y2="3" stroke="currentColor" strokeWidth="1.4" />
+      <rect x="14.7" y="3" width="3.6" height="9" fill="currentColor" />
+    </svg>
+  );
+}
+
+/** UTC session clock — the one live readout in the chrome. */
+function SessionClock() {
+  const [now, setNow] = useState(() => new Date());
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(id);
+  }, []);
+  const hh = String(now.getUTCHours()).padStart(2, "0");
+  const mm = String(now.getUTCMinutes()).padStart(2, "0");
+  const ss = String(now.getUTCSeconds()).padStart(2, "0");
+  return (
+    <span className="session-clock" aria-label="Session time, coordinated universal">
+      <b>
+        {hh}:{mm}
+      </b>
+      :{ss}
+      <span>UTC</span>
+    </span>
+  );
+}
+
+export function App() {
+  const [tab, setTab] = useState<Tab>("portfolio");
+
+  return (
+    <div className="ledger">
+      <header className="topbar">
+        <div className="topbar-inner">
+          <a className="brand" href="#" aria-label="Ledger Terminal">
+            <BrandMark />
+            <span className="brand-name">Ledger</span>
+            <span className="brand-tag">Terminal</span>
+          </a>
+
+          <nav className="tabs" role="tablist" aria-label="Views">
+            {TABS.map((t) => (
+              <button
+                key={t.id}
+                role="tab"
+                aria-selected={tab === t.id}
+                className="tab"
+                onClick={() => setTab(t.id)}
+              >
+                {t.label}
+              </button>
+            ))}
+          </nav>
+
+          <div className="session">
+            <span className="session-status">
+              <span className="live-dot" aria-hidden="true" />
+              Night session
+            </span>
+            <SessionClock />
+          </div>
+        </div>
+      </header>
+
+      <div className="wrap">
+        {tab === "portfolio" && <Portfolio />}
+        {tab === "markets" && <Markets />}
+        {tab === "asset" && <Asset />}
+        {tab === "analytics" && <Analytics />}
+
+        <footer className="foot">
+          <span>Ledger Terminal · a microcharts instrument. Figures are simulated.</span>
+          <a href="https://microcharts.dev" rel="noreferrer">
+            @microcharts/react
+          </a>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/examples/ledger-finance/src/analytics.ts
+++ b/examples/ledger-finance/src/analytics.ts
@@ -1,0 +1,14 @@
+// Cloudflare Web Analytics — privacy-first, cookieless page-view/visit beacon.
+// Injected only when VITE_CF_BEACON_TOKEN is set at build time; otherwise a no-op.
+// Get a token: Cloudflare dashboard → Web Analytics → Add a site → copy the token
+// (or just enable Web Analytics on the Pages project, which auto-injects instead). See DEPLOY.md.
+const token = (import.meta as unknown as { env?: Record<string, string | undefined> }).env
+  ?.VITE_CF_BEACON_TOKEN;
+if (token) {
+  const s = document.createElement("script");
+  s.defer = true;
+  s.src = "https://static.cloudflareinsights.com/beacon.min.js";
+  s.setAttribute("data-cf-beacon", JSON.stringify({ token }));
+  document.head.appendChild(s);
+}
+export {};

--- a/examples/ledger-finance/src/app.css
+++ b/examples/ledger-finance/src/app.css
@@ -1,0 +1,1115 @@
+/* ============================================================
+   Ledger Terminal — a nocturnal trading instrument.
+   Deep amber-tinted ink, tabular mono numerals as the hero,
+   one gold signal accent used sparingly. Dark, pinned.
+   ============================================================ */
+
+:root {
+  color-scheme: dark;
+
+  /* Neutrals: near-black tinted toward the amber accent (OKLCH, no pure #000). */
+  --bg: oklch(0.155 0.007 82);
+  --bg-deep: oklch(0.135 0.006 82);
+  --elev: oklch(0.186 0.009 82);
+  --elev-2: oklch(0.216 0.011 82);
+  --panel: oklch(0.198 0.01 82);
+  --panel-hover: oklch(0.232 0.012 82);
+  --line: oklch(0.315 0.014 82);
+  --line-soft: oklch(0.262 0.012 82);
+
+  --text: oklch(0.945 0.009 88);
+  --text-dim: oklch(0.765 0.014 84);
+  --text-mute: oklch(0.605 0.017 82);
+  --text-faint: oklch(0.5 0.015 82);
+
+  /* One signal accent: electric-but-not-neon amber/gold. Rare by design. */
+  --accent: oklch(0.82 0.138 82);
+  --accent-soft: oklch(0.82 0.138 82 / 0.14);
+  --accent-line: oklch(0.82 0.138 82 / 0.4);
+  --accent-deep: oklch(0.68 0.115 78);
+
+  /* Valence: microcharts' own dark-theme green / vermillion — never re-tinted,
+     mirrored here so app chrome matches the chart marks exactly. */
+  --pos: #45a385;
+  --neg: #df7856;
+  --pos-soft: color-mix(in oklab, #45a385 14%, transparent);
+  --neg-soft: color-mix(in oklab, #df7856 14%, transparent);
+
+  --radius: 4px;
+  --radius-lg: 6px;
+
+  /* Type. Schibsted Grotesk = the voice; Azeret Mono = the numbers (the hero). */
+  --sans: "Schibsted Grotesk", ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --mono: "Azeret Mono", ui-monospace, "SF Mono", Menlo, monospace;
+
+  --fs-hero: clamp(2.6rem, 6vw, 3.6rem);
+  --fs-xl: 1.9rem;
+  --fs-lg: 1.375rem;
+  --fs-md: 1.0625rem;
+  --fs-base: 0.875rem;
+  --fs-sm: 0.8125rem;
+  --fs-xs: 0.6875rem;
+
+  /* 4pt spatial scale. */
+  --sp-1: 4px;
+  --sp-2: 8px;
+  --sp-3: 12px;
+  --sp-4: 16px;
+  --sp-5: 24px;
+  --sp-6: 32px;
+  --sp-7: 48px;
+  --sp-8: 64px;
+
+  --ease: cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+/* FONT TRAP: microcharts SVG text inherits these. Keep them legible sans/mono
+   so chart labels never fall back to a serif — numerals in Azeret Mono. */
+.ledger {
+  --mc-font: var(--sans);
+  --mc-font-numeric: var(--mono);
+  --mc-accent: var(--accent);
+}
+
+body {
+  margin: 0;
+  font-family: var(--sans);
+  font-size: var(--fs-base);
+  line-height: 1.5;
+  background: var(--bg-deep);
+  color: var(--text);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  font-feature-settings: "cv01", "ss01";
+}
+
+.ledger {
+  min-height: 100vh;
+  /* Faint warm vignette — an instrument glow at the top edge, not glassmorphism. */
+  background:
+    radial-gradient(120% 60% at 50% -8%, oklch(0.82 0.138 82 / 0.05), transparent 55%), var(--bg);
+}
+
+.num {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum" 1;
+  letter-spacing: -0.02em;
+}
+
+/* Terminal micro-label: the recurring voice of the chrome. */
+.kicker {
+  font-family: var(--mono);
+  font-size: var(--fs-xs);
+  font-weight: 500;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+}
+
+/* ---------- Top bar ---------- */
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  background: color-mix(in oklab, var(--bg-deep) 88%, transparent);
+  backdrop-filter: blur(12px) saturate(1.2);
+  border-bottom: 1px solid var(--line-soft);
+}
+.topbar-inner {
+  max-width: 1220px;
+  margin: 0 auto;
+  padding: var(--sp-3) var(--sp-5);
+  display: flex;
+  align-items: center;
+  gap: var(--sp-5);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  text-decoration: none;
+  color: inherit;
+  flex: none;
+}
+.brand-mark {
+  width: 22px;
+  height: 24px;
+  display: block;
+  color: var(--accent);
+}
+.brand-name {
+  font-family: var(--sans);
+  font-weight: 700;
+  font-size: 1rem;
+  letter-spacing: -0.01em;
+  color: var(--text);
+}
+.brand-tag {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--accent);
+  padding: 2px 5px 1px;
+  border: 1px solid var(--accent-line);
+  border-radius: 3px;
+  align-self: center;
+}
+
+.session {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-4);
+  flex: none;
+}
+.session-status {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--mono);
+  font-size: var(--fs-xs);
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+.session-clock {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  font-size: var(--fs-sm);
+  font-weight: 500;
+  color: var(--text-dim);
+  letter-spacing: 0.02em;
+}
+.session-clock b {
+  color: var(--text);
+  font-weight: 600;
+}
+.session-clock span {
+  color: var(--text-faint);
+  margin-left: 5px;
+  font-size: var(--fs-xs);
+  letter-spacing: 0.1em;
+}
+
+.tabs {
+  display: flex;
+  gap: var(--sp-1);
+  align-self: stretch;
+}
+.tab {
+  position: relative;
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--text-mute);
+  font-family: var(--sans);
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  padding: var(--sp-2) var(--sp-3) calc(var(--sp-2) + 1px);
+  cursor: pointer;
+  transition: color 0.16s var(--ease);
+}
+.tab::after {
+  content: "";
+  position: absolute;
+  left: var(--sp-3);
+  right: var(--sp-3);
+  bottom: -1px;
+  height: 2px;
+  background: var(--accent);
+  border-radius: 2px;
+  transform: scaleX(0);
+  transform-origin: center;
+  transition: transform 0.22s var(--ease);
+}
+.tab:hover {
+  color: var(--text-dim);
+}
+.tab:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+  border-radius: 3px;
+  color: var(--text);
+}
+.tab[aria-selected="true"] {
+  color: var(--text);
+}
+.tab[aria-selected="true"]::after {
+  transform: scaleX(1);
+}
+.tab:active {
+  transform: translateY(0.5px);
+}
+@media (prefers-reduced-motion: reduce) {
+  .tab::after {
+    transition: none;
+  }
+}
+
+/* ---------- Shell ---------- */
+.wrap {
+  max-width: 1220px;
+  margin: 0 auto;
+  padding: 0 var(--sp-5) var(--sp-8);
+}
+
+.view {
+  padding-top: var(--sp-6);
+  counter-reset: sec;
+}
+@media (prefers-reduced-motion: no-preference) {
+  .view {
+    animation: view-in 0.42s var(--ease) both;
+  }
+}
+@keyframes view-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+}
+
+/* ---------- Section heads (editorial numbered rules) ---------- */
+.section-head {
+  counter-increment: sec;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--sp-4);
+  margin: var(--sp-7) 0 var(--sp-4);
+  padding-bottom: var(--sp-3);
+  border-bottom: 1px solid var(--line-soft);
+}
+.section-head:first-child {
+  margin-top: 0;
+}
+.section-head h2 {
+  display: flex;
+  align-items: baseline;
+  gap: var(--sp-3);
+  margin: 0;
+  font-family: var(--sans);
+  font-size: var(--fs-md);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--text);
+}
+.section-head h2::before {
+  content: counter(sec, decimal-leading-zero);
+  font-family: var(--mono);
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  letter-spacing: 0;
+  color: var(--accent);
+}
+.section-head .aside {
+  font-family: var(--mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.06em;
+  color: var(--text-mute);
+  text-align: right;
+}
+
+.grid {
+  display: grid;
+  gap: var(--sp-4);
+}
+
+/* ---------- Panel ---------- */
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--line-soft);
+  border-radius: var(--radius-lg);
+  padding: var(--sp-5);
+}
+.panel.pad-lg {
+  padding: var(--sp-5) calc(var(--sp-5) + 2px);
+}
+
+.eyebrow {
+  font-family: var(--mono);
+  font-size: var(--fs-xs);
+  font-weight: 500;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+  margin: 0 0 var(--sp-3);
+}
+
+.panel-title {
+  font-family: var(--sans);
+  font-size: var(--fs-md);
+  font-weight: 650;
+  letter-spacing: -0.01em;
+  margin: 0 0 2px;
+  color: var(--text);
+}
+.panel-note {
+  font-size: var(--fs-sm);
+  color: var(--text-mute);
+  margin: 0 0 var(--sp-4);
+  max-width: 52ch;
+}
+
+.chip {
+  font-family: var(--mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.04em;
+  color: var(--text-mute);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 3px 9px;
+  white-space: nowrap;
+}
+
+/* ---------- Picker readouts (interactive chart scrub/pin state) ---------- */
+.scrub-chip {
+  font-family: var(--mono);
+  font-size: var(--fs-xs);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+  color: var(--accent);
+  background: var(--accent-soft);
+  border: 1px solid var(--accent-line);
+  border-radius: 999px;
+  padding: 3px 10px;
+  white-space: nowrap;
+  min-width: 14ch;
+  text-align: center;
+  box-sizing: border-box;
+}
+.scrub-chip.is-idle {
+  color: var(--text-mute);
+  background: transparent;
+  border-color: var(--line-soft);
+}
+.picker-readout {
+  display: block;
+  margin-top: 6px;
+  font-family: var(--mono);
+  font-size: var(--fs-xs);
+  font-variant-numeric: tabular-nums;
+  color: var(--text-mute);
+}
+
+/* ---------- Portfolio hero (instrument readout, not a metric card) ---------- */
+.hero {
+  grid-template-columns: minmax(0, 1.55fr) minmax(0, 1fr);
+}
+@media (max-width: 880px) {
+  .hero {
+    grid-template-columns: 1fr;
+  }
+}
+
+.hero-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--sp-4);
+  margin-bottom: var(--sp-4);
+}
+.hero-value {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  font-size: var(--fs-hero);
+  font-weight: 600;
+  letter-spacing: -0.035em;
+  line-height: 0.95;
+  color: var(--text);
+}
+.hero-sub {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--sp-3);
+  margin-top: var(--sp-3);
+  font-size: var(--fs-sm);
+  color: var(--text-dim);
+}
+.hero-sub .num {
+  color: var(--text-dim);
+}
+.hero-chart {
+  margin: var(--sp-5) 0 var(--sp-4);
+  padding-top: var(--sp-4);
+  border-top: 1px solid var(--line-soft);
+}
+
+/* Horizontal data strip — thin rules between readouts, no card-per-stat. */
+.strip {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  margin-top: var(--sp-4);
+  border-top: 1px solid var(--line-soft);
+}
+.strip .stat {
+  padding: var(--sp-4) var(--sp-4) 0 0;
+}
+.strip .stat + .stat {
+  padding-left: var(--sp-4);
+  border-left: 1px solid var(--line-soft);
+}
+@media (max-width: 520px) {
+  .strip {
+    grid-template-columns: 1fr 1fr;
+  }
+  .strip .stat:nth-child(3),
+  .strip .stat:nth-child(4) {
+    padding-top: var(--sp-4);
+  }
+  .strip .stat:nth-child(odd) {
+    border-left: 0;
+    padding-left: 0;
+  }
+}
+.stat .k {
+  font-family: var(--mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+}
+.stat .v {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  font-size: var(--fs-lg);
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  color: var(--text);
+  margin-top: var(--sp-1);
+}
+
+/* ---------- Allocation rail ---------- */
+.donut-wrap {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-5);
+}
+@media (max-width: 440px) {
+  .donut-wrap {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+.legend {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+  min-width: 0;
+  flex: 1;
+}
+.legend span {
+  display: grid;
+  grid-template-columns: 10px 1fr auto;
+  align-items: center;
+  gap: var(--sp-2);
+  font-size: var(--fs-sm);
+  color: var(--text-dim);
+}
+.legend b {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+  color: var(--text-mute);
+}
+.legend i {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  flex: none;
+}
+
+/* ---------- Flows bento (asymmetric footprint) ---------- */
+.bento-flows {
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+}
+.cell-flow,
+.cell-caps {
+  grid-column: span 4;
+}
+.cell-beam,
+.cell-rings {
+  grid-column: span 2;
+}
+@media (max-width: 900px) {
+  .bento-flows {
+    grid-template-columns: 1fr 1fr;
+  }
+  .cell-flow,
+  .cell-caps {
+    grid-column: 1 / -1;
+  }
+  .cell-beam,
+  .cell-rings {
+    grid-column: span 1;
+  }
+}
+@media (max-width: 560px) {
+  .bento-flows {
+    grid-template-columns: 1fr;
+  }
+  .cell-flow,
+  .cell-beam,
+  .cell-rings,
+  .cell-caps {
+    grid-column: 1 / -1;
+  }
+}
+
+.mini-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--sp-3);
+  margin-bottom: var(--sp-4);
+}
+.mini-head .panel-title,
+.mini-head .panel-note {
+  margin-bottom: 0;
+}
+.mini-head .panel-title {
+  margin-bottom: 2px;
+}
+
+.tag {
+  font-family: var(--mono);
+  font-size: var(--fs-xs);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+  color: var(--text-dim);
+  background: var(--elev);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 3px 10px;
+  white-space: nowrap;
+  flex: none;
+}
+.tag-pos {
+  color: var(--pos);
+  border-color: color-mix(in oklab, var(--pos) 40%, transparent);
+  background: var(--pos-soft);
+}
+
+.beam-hold {
+  max-width: 220px;
+  margin: var(--sp-2) auto var(--sp-4);
+}
+.beam-legend {
+  display: flex;
+  gap: var(--sp-4);
+  flex-wrap: wrap;
+  justify-content: center;
+  font-family: var(--mono);
+  font-size: var(--fs-xs);
+  color: var(--text-dim);
+}
+.beam-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-variant-numeric: tabular-nums;
+}
+.beam-legend i {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  flex: none;
+}
+
+.rings-hold {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-5);
+  margin-top: var(--sp-2);
+}
+.rings-facts {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-4);
+}
+
+/* ---------- Holdings & monitor tables ---------- */
+.table-wrap {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--fs-base);
+}
+.table thead th {
+  text-align: right;
+  font-family: var(--mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+  font-weight: 500;
+  padding: 0 0 var(--sp-3);
+  border-bottom: 1px solid var(--line-soft);
+}
+.table thead th:first-child {
+  text-align: left;
+}
+.table tbody td {
+  padding: var(--sp-3) 0;
+  border-bottom: 1px solid var(--line-soft);
+  text-align: right;
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
+  color: var(--text-dim);
+  vertical-align: middle;
+}
+.table tbody tr:last-child td {
+  border-bottom: 0;
+}
+.table tbody td:first-child {
+  text-align: left;
+}
+.table tbody tr {
+  transition: background 0.14s var(--ease);
+}
+.table tbody tr:hover {
+  background: color-mix(in oklab, var(--panel-hover) 70%, transparent);
+}
+.asset {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+}
+.badge {
+  width: 34px;
+  height: 34px;
+  border-radius: var(--radius);
+  display: grid;
+  place-items: center;
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  background: var(--elev-2);
+  border: 1px solid var(--line-soft);
+  color: var(--text-dim);
+  flex: none;
+}
+.asset .nm {
+  font-family: var(--mono);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: var(--text);
+}
+.asset .sub {
+  font-family: var(--sans);
+  font-size: var(--fs-xs);
+  color: var(--text-mute);
+  letter-spacing: 0;
+}
+.cell-spark {
+  width: 128px;
+}
+.cell-spark .mc-inline,
+.col-horizon .mc-inline {
+  display: inline-flex;
+  vertical-align: middle;
+}
+.monitor {
+  min-width: 560px;
+}
+.monitor .col-horizon {
+  width: 210px;
+  text-align: left;
+}
+.col-horizon .mc-inline {
+  width: 100%;
+}
+.badge-sm {
+  width: 30px;
+  height: 30px;
+  font-size: 9px;
+}
+@media (max-width: 640px) {
+  .table {
+    min-width: 480px;
+  }
+}
+
+/* ---------- Markets cards ---------- */
+.cards {
+  grid-template-columns: repeat(4, 1fr);
+}
+@media (max-width: 980px) {
+  .cards {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+@media (max-width: 520px) {
+  .cards {
+    grid-template-columns: 1fr;
+  }
+}
+.mkt {
+  transition:
+    border-color 0.16s var(--ease),
+    transform 0.16s var(--ease);
+}
+.mkt:hover {
+  border-color: var(--line);
+  transform: translateY(-2px);
+}
+.mkt-top {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--sp-2);
+}
+.mkt-name {
+  font-family: var(--sans);
+  font-weight: 650;
+  font-size: var(--fs-base);
+  letter-spacing: -0.01em;
+}
+.mkt-sub {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+  margin-top: 2px;
+}
+.mkt-last {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  font-size: var(--fs-xl);
+  font-weight: 500;
+  letter-spacing: -0.03em;
+  margin: var(--sp-3) 0 var(--sp-3);
+  color: var(--text);
+}
+.mkt-chart {
+  margin-top: var(--sp-1);
+}
+
+/* ---------- Markets pulse band ---------- */
+.pulse-band {
+  grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr) minmax(0, 1fr);
+}
+@media (max-width: 900px) {
+  .pulse-band {
+    grid-template-columns: 1fr 1fr;
+  }
+  .pulse-ticker {
+    grid-column: 1 / -1;
+  }
+}
+@media (max-width: 560px) {
+  .pulse-band {
+    grid-template-columns: 1fr;
+  }
+  .pulse-ticker {
+    grid-column: auto;
+  }
+}
+.pulse-cell {
+  display: flex;
+  flex-direction: column;
+}
+.pulse-value {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  font-size: clamp(1.5rem, 5vw, 1.75rem);
+  font-weight: 500;
+  letter-spacing: -0.03em;
+  margin-top: var(--sp-1);
+  color: var(--text);
+}
+.pulse-mini-note {
+  font-size: var(--fs-xs);
+  color: var(--text-mute);
+  margin: 2px 0 var(--sp-4);
+}
+
+/* ---------- Layout splits ---------- */
+.cols-2 {
+  grid-template-columns: 1fr 1fr;
+}
+.split-7-5 {
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+}
+@media (max-width: 860px) {
+  .cols-2,
+  .split-7-5 {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ---------- Asset detail ---------- */
+.asset-head {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--sp-5);
+  flex-wrap: wrap;
+  margin-bottom: var(--sp-5);
+}
+.asset-id {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-4);
+}
+.badge-lg {
+  width: 46px;
+  height: 46px;
+  border-radius: var(--radius-lg);
+  font-size: 12px;
+  color: var(--text);
+  background: var(--elev-2);
+}
+.asset-name {
+  font-family: var(--sans);
+  font-size: var(--fs-lg);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 0;
+}
+.asset-meta {
+  font-family: var(--mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+  margin: 3px 0 0;
+}
+.asset-quote {
+  text-align: right;
+}
+.asset-price {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  font-size: clamp(1.75rem, 6vw, 2.1rem);
+  font-weight: 600;
+  letter-spacing: -0.03em;
+  color: var(--text);
+}
+.asset-quote-sub {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+  justify-content: flex-end;
+  margin-top: var(--sp-2);
+}
+.asset-hero {
+  grid-template-columns: minmax(0, 1fr) 264px;
+}
+@media (max-width: 820px) {
+  .asset-hero {
+    grid-template-columns: 1fr;
+  }
+}
+.asset-hilo {
+  display: flex;
+  gap: var(--sp-4);
+  font-family: var(--mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.04em;
+  color: var(--text-mute);
+  font-variant-numeric: tabular-nums;
+}
+.asset-hilo b {
+  color: var(--text-dim);
+  font-weight: 600;
+  margin-left: 4px;
+}
+.vp-hold {
+  display: flex;
+  justify-content: center;
+}
+.asset-books {
+  grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr);
+}
+@media (max-width: 860px) {
+  .asset-books {
+    grid-template-columns: 1fr;
+  }
+}
+.book-facts {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--sp-4);
+  margin-top: var(--sp-4);
+  padding-top: var(--sp-4);
+  border-top: 1px solid var(--line-soft);
+}
+.scatter-axes {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--sp-3);
+  margin-top: var(--sp-3);
+  font-family: var(--mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.04em;
+  color: var(--text-mute);
+  font-variant-numeric: tabular-nums;
+}
+.phase-hold {
+  margin-top: var(--sp-1);
+}
+
+/* ---------- Analytics goals ---------- */
+.goal {
+  padding: var(--sp-4) 0;
+  border-bottom: 1px solid var(--line-soft);
+}
+.goal:last-child {
+  border-bottom: 0;
+  padding-bottom: 2px;
+}
+.goal:first-of-type {
+  padding-top: 2px;
+}
+.goal-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: var(--sp-3);
+  font-size: var(--fs-sm);
+}
+.goal-head .g-val {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  color: var(--text-mute);
+}
+.goal-head .g-val b {
+  color: var(--text);
+  font-weight: 600;
+}
+
+/* ---------- Live indicator (the one deliberate loop; live data only) ---------- */
+.live-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  margin-right: 8px;
+  box-shadow: 0 0 0 0 var(--accent-line);
+}
+@media (prefers-reduced-motion: no-preference) {
+  .live-dot {
+    animation: live-pulse 2.6s ease-out infinite;
+  }
+}
+@keyframes live-pulse {
+  0% {
+    box-shadow: 0 0 0 0 var(--accent-line);
+  }
+  70% {
+    box-shadow: 0 0 0 6px transparent;
+  }
+  100% {
+    box-shadow: 0 0 0 0 transparent;
+  }
+}
+
+/* ---------- Staggered panel entrances ---------- */
+@media (prefers-reduced-motion: no-preference) {
+  .cards .mkt,
+  .bento-flows .panel,
+  .pulse-band .panel {
+    animation: card-in 0.44s var(--ease) both;
+  }
+  .cards .mkt:nth-child(2),
+  .bento-flows .panel:nth-child(2),
+  .pulse-band .panel:nth-child(2) {
+    animation-delay: 0.05s;
+  }
+  .cards .mkt:nth-child(3),
+  .bento-flows .panel:nth-child(3),
+  .pulse-band .panel:nth-child(3) {
+    animation-delay: 0.1s;
+  }
+  .cards .mkt:nth-child(4),
+  .bento-flows .panel:nth-child(4) {
+    animation-delay: 0.15s;
+  }
+  .cards .mkt:nth-child(n + 5) {
+    animation-delay: 0.2s;
+  }
+  .cell-beam:hover,
+  .cell-rings:hover,
+  .cell-caps:hover {
+    border-color: var(--line);
+  }
+}
+@keyframes card-in {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+}
+
+/* ---------- Footer ---------- */
+.foot {
+  margin-top: var(--sp-7);
+  padding-top: var(--sp-5);
+  border-top: 1px solid var(--line-soft);
+  font-family: var(--mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.04em;
+  color: var(--text-mute);
+  display: flex;
+  justify-content: space-between;
+  gap: var(--sp-3);
+  flex-wrap: wrap;
+}
+.foot a {
+  color: var(--text-dim);
+  text-decoration: none;
+}
+.foot a:hover {
+  color: var(--accent);
+}
+
+/* ---------- Responsive chrome ---------- */
+@media (max-width: 720px) {
+  .session {
+    display: none;
+  }
+  .topbar-inner {
+    gap: var(--sp-4);
+  }
+  .tabs {
+    margin-left: auto;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+  .tabs::-webkit-scrollbar {
+    display: none;
+  }
+  .tab {
+    white-space: nowrap;
+  }
+}
+@media (max-width: 480px) {
+  .topbar-inner {
+    padding: var(--sp-3) var(--sp-4);
+  }
+  .wrap {
+    padding: 0 var(--sp-4) var(--sp-7);
+  }
+  .brand-tag {
+    display: none;
+  }
+}

--- a/examples/ledger-finance/src/components/Analytics.tsx
+++ b/examples/ledger-finance/src/components/Analytics.tsx
@@ -1,0 +1,258 @@
+import { HistogramStrip } from "@microcharts/react/histogram-strip/interactive";
+import { PercentileLadder } from "@microcharts/react/percentile-ladder/interactive";
+import { StackedArea } from "@microcharts/react/stacked-area/interactive";
+import { Bullet } from "@microcharts/react/bullet/interactive";
+import { EnsembleGhosts } from "@microcharts/react/ensemble-ghosts/interactive";
+import { WinProbWorm } from "@microcharts/react/win-prob-worm/interactive";
+import { SpreadBand } from "@microcharts/react/spread-band/interactive";
+import { BiasStrip } from "@microcharts/react/bias-strip/interactive";
+import { ForecastCone } from "@microcharts/react/forecast-cone/interactive";
+import {
+  monthlyReturns,
+  dailyReturns,
+  allocationOverTime,
+  goals,
+  forecastPaths,
+  millionOdds,
+  benchmarkSpread,
+  trackingPairs,
+  portfolioSeries,
+  portfolioForecast,
+  millionTarget,
+} from "../data";
+
+const pct = { style: "percent", maximumFractionDigits: 1 } as const;
+const pctPoints = (n: number) => `${n >= 0 ? "+" : ""}${n.toFixed(1)}%`;
+const usd = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0,
+});
+const usdOpts = {
+  style: "currency",
+  currency: "USD",
+  notation: "compact",
+  maximumFractionDigits: 2,
+} as const;
+
+const catColors = ["#6fb0e0", "#e2b45c", "#4fb08d"];
+const meanMonthly = monthlyReturns.reduce((s, v) => s + v, 0) / monthlyReturns.length;
+
+const finalOdds = millionOdds[millionOdds.length - 1];
+const lastSpread = benchmarkSpread[benchmarkSpread.length - 1];
+const spreadLead = Math.round((lastSpread.a - lastSpread.b) * 100) / 100;
+const historyTail = portfolioSeries.slice(-36);
+
+export function Analytics() {
+  return (
+    <section className="view" aria-label="Analytics">
+      <div className="section-head">
+        <h2>Analytics</h2>
+        <span className="aside">Will this book clear $1M — and is the path honest?</span>
+      </div>
+
+      <div className="panel pad-lg">
+        <p className="panel-title">Path to $1M</p>
+        <p className="panel-note">
+          36 months of NAV · 24-month median forecast with an 80% band · target at{" "}
+          {usd.format(millionTarget)}
+        </p>
+        <ForecastCone
+          data={historyTail}
+          forecast={portfolioForecast}
+          target={millionTarget}
+          unit="month"
+          label="landing"
+          format={usdOpts}
+          title="Portfolio value history and Monte-Carlo forecast against the one-million target"
+          animate
+          style={{ width: "100%", height: "auto" }}
+          width={1040}
+          height={200}
+        />
+        <p className="panel-note" style={{ marginTop: 10 }}>
+          Median clears the mark; the lower band still does not — the worm below is the probability
+          story behind that cone.
+        </p>
+      </div>
+
+      <div className="grid cols-2">
+        <div className="panel pad-lg">
+          <p className="panel-title">Monthly returns</p>
+          <p className="panel-note">36 months · marker at the mean ({pctPoints(meanMonthly)})</p>
+          <HistogramStrip
+            data={monthlyReturns}
+            bins={13}
+            markValue={meanMonthly}
+            format={pctPoints}
+            title="Distribution of monthly returns over three years"
+            animate
+            style={{ width: "100%", height: "auto" }}
+            width={520}
+            height={150}
+          />
+        </div>
+
+        <div className="panel pad-lg">
+          <p className="panel-title">Daily return percentiles</p>
+          <p className="panel-note">252 trading days · p10 / p50 / p90 / p99</p>
+          <PercentileLadder
+            data={dailyReturns}
+            ps={[10, 50, 90, 99]}
+            label="both"
+            marks="tick"
+            format={pctPoints}
+            title="Daily return percentiles over the trailing year"
+            animate
+            style={{ width: "100%", height: "auto" }}
+            width={520}
+            height={120}
+          />
+        </div>
+      </div>
+
+      <div className="section-head">
+        <h2>Forecast detail</h2>
+        <span className="aside">Monte-Carlo · {finalOdds!.toFixed(0)}% odds of clearing $1M</span>
+      </div>
+
+      <div className="grid split-7-5">
+        <div className="panel pad-lg">
+          <p className="panel-title">24-month projection</p>
+          <p className="panel-note">14 simulated paths · median emphasized, endpoints marked</p>
+          <EnsembleGhosts
+            data={forecastPaths}
+            ghosts={12}
+            emphasis="nearest-median"
+            endpoints
+            color="#6fb0e0"
+            title="Fourteen simulated portfolio paths over the next 24 months"
+            format={usdOpts}
+            animate
+            style={{ width: "100%", height: "auto" }}
+            width={620}
+            height={220}
+          />
+        </div>
+
+        <div className="panel pad-lg">
+          <p className="panel-title">Odds of clearing $1M</p>
+          <p className="panel-note">Model probability by year end · 50% line is the story</p>
+          <WinProbWorm
+            data={millionOdds}
+            sides={["On track", "Falls short"]}
+            label="last"
+            markSwing
+            title="Modelled probability of the portfolio clearing one million dollars"
+            format={(n) => `${Math.round(n)}%`}
+            animate
+            style={{ width: "100%", height: "auto" }}
+            width={410}
+            height={228}
+          />
+        </div>
+      </div>
+
+      <div className="section-head">
+        <h2>Benchmark</h2>
+        <span className="aside">
+          vs. 60/40 · {spreadLead >= 0 ? "leading" : "trailing"} by {pctPoints(spreadLead)}
+        </span>
+      </div>
+
+      <div className="grid split-7-5">
+        <div className="panel pad-lg">
+          <p className="panel-title">Portfolio vs. benchmark</p>
+          <p className="panel-note">Cumulative return · shaded where the lead flips</p>
+          <SpreadBand
+            data={benchmarkSpread}
+            seriesLabels={["Portfolio", "Benchmark"]}
+            positive="up"
+            label="gap"
+            title="Cumulative return of the portfolio against its 60/40 benchmark"
+            format={pctPoints}
+            animate
+            style={{ width: "100%", height: "auto" }}
+            width={620}
+            height={200}
+          />
+        </div>
+
+        <div className="panel pad-lg">
+          <p className="panel-title">Tracking agreement</p>
+          <p className="panel-note">Monthly return gaps · ±95% limits of agreement</p>
+          <BiasStrip
+            data={trackingPairs}
+            limits={1.96}
+            label="bias"
+            title="Monthly tracking difference between the portfolio and its benchmark"
+            format={pctPoints}
+            animate
+            style={{ width: "100%", height: "auto" }}
+            width={410}
+            height={228}
+          />
+        </div>
+      </div>
+
+      <div className="section-head">
+        <h2>Composition &amp; goals</h2>
+        <span className="aside">Allocation drift &amp; savings targets</span>
+      </div>
+
+      <div className="grid split-7-5">
+        <div className="panel pad-lg">
+          <p className="panel-title">Allocation over time</p>
+          <p className="panel-note">Share of portfolio · trailing 12 months</p>
+          <StackedArea
+            data={allocationOverTime}
+            colors={catColors}
+            curve="smooth"
+            label="last"
+            title="Allocation share by asset class over the trailing year"
+            format={pct}
+            animate
+            style={{ width: "100%", height: "auto" }}
+            width={620}
+            height={200}
+          />
+          <div className="legend">
+            {allocationOverTime.map((s, i) => (
+              <span key={s.label}>
+                <i style={{ background: catColors[i] }} />
+                {s.label}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <div className="panel pad-lg">
+          <p className="panel-title">Savings goals</p>
+          <p className="panel-note">Progress toward each target</p>
+          {goals.map((g) => (
+            <div className="goal" key={g.label}>
+              <div className="goal-head">
+                <span>{g.label}</span>
+                <span className="g-val">
+                  <b>{usd.format(g.value)}</b> / {usd.format(g.target)}
+                </span>
+              </div>
+              <Bullet
+                value={g.value}
+                target={g.target}
+                bands={g.bands}
+                domain={[0, g.target]}
+                format={(n) => usd.format(n)}
+                title={`${g.label}: ${usd.format(g.value)} of ${usd.format(g.target)}`}
+                animate
+                style={{ width: "100%", height: "auto" }}
+                width={410}
+                height={41}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/examples/ledger-finance/src/components/Asset.tsx
+++ b/examples/ledger-finance/src/components/Asset.tsx
@@ -1,0 +1,190 @@
+import { Ohlc } from "@microcharts/react/ohlc/interactive";
+import { VolumeProfile } from "@microcharts/react/volume-profile/interactive";
+import { DepthWedge } from "@microcharts/react/depth-wedge/interactive";
+import { MicroScatter } from "@microcharts/react/micro-scatter/interactive";
+import { PhaseTrace } from "@microcharts/react/phase-trace/interactive";
+import { Delta } from "@microcharts/react/delta/interactive";
+import {
+  nvdaCandles,
+  volumeAtPrice,
+  orderBook,
+  returnScatter,
+  priceVolumeTrace,
+  nvdaStats,
+} from "../data";
+
+const usd2 = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
+const usdOpts = { style: "currency", currency: "USD" } as const;
+
+const first = nvdaCandles[0];
+const latest = nvdaCandles[nvdaCandles.length - 1];
+const mid = latest.close;
+const bestBid = orderBook.demand[0].level;
+const bestAsk = orderBook.supply[0].level;
+const spread = Math.round((bestAsk - bestBid) * 100) / 100;
+
+const pctFmt = (n: number) => `${n >= 0 ? "+" : ""}${n.toFixed(1)}%`;
+
+export function Asset() {
+  return (
+    <section className="view" aria-label="Asset detail">
+      <div className="asset-head">
+        <div className="asset-id">
+          <div className="badge badge-lg">NVDA</div>
+          <div>
+            <p className="asset-name">NVIDIA Corp.</p>
+            <p className="asset-meta">NASDAQ · Semiconductors · Equity</p>
+          </div>
+        </div>
+        <div className="asset-quote">
+          <div className="asset-price">{usd2.format(latest.close)}</div>
+          <div className="asset-quote-sub">
+            <Delta value={latest.close} from={first.open} positive="up" summary={false} />
+            <span className="chip">30-session window</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid asset-hero">
+        <div className="panel pad-lg">
+          <div className="mini-head">
+            <div>
+              <p className="panel-title">Price action</p>
+              <p className="panel-note">Daily open / high / low / close · 30 sessions</p>
+            </div>
+            <div className="asset-hilo">
+              <span>
+                H <b>{usd2.format(nvdaStats.high)}</b>
+              </span>
+              <span>
+                L <b>{usd2.format(nvdaStats.low)}</b>
+              </span>
+            </div>
+          </div>
+          <Ohlc
+            data={nvdaCandles}
+            maxPeriods={30}
+            mode="candle"
+            label="last"
+            title="NVDA daily candles, last 30 sessions"
+            format={(n) => usd2.format(n)}
+            animate
+            style={{ width: "100%", height: "auto" }}
+            width={790}
+            height={356}
+          />
+        </div>
+
+        <div className="panel pad-lg">
+          <p className="panel-title">Volume at price</p>
+          <p className="panel-note">Where the window traded · POC marked</p>
+          <div className="vp-hold">
+            <VolumeProfile
+              data={volumeAtPrice}
+              align="left"
+              valueArea={0.7}
+              label="poc"
+              bins={14}
+              title="Volume traded at each price level across the window"
+              format={usdOpts}
+              animate
+              style={{ width: "100%", height: "auto" }}
+              width={240}
+              height={280}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="grid asset-books" style={{ marginTop: 16 }}>
+        <div className="panel pad-lg">
+          <div className="mini-head">
+            <div>
+              <p className="panel-title">Order book depth</p>
+              <p className="panel-note">Cumulative bids vs. asks around the mid</p>
+            </div>
+            <span className="tag">spread {usd2.format(spread)}</span>
+          </div>
+          <DepthWedge
+            data={orderBook}
+            label="spread"
+            normalize
+            title="Order-book depth: cumulative demand against supply around the mid price"
+            format={usdOpts}
+            animate
+            style={{ width: "100%", height: "auto" }}
+            width={580}
+            height={223}
+          />
+          <div className="book-facts">
+            <div className="stat">
+              <div className="k">Best bid</div>
+              <div className="v" style={{ color: "var(--pos)" }}>
+                {usd2.format(bestBid)}
+              </div>
+            </div>
+            <div className="stat">
+              <div className="k">Mid</div>
+              <div className="v">{usd2.format(mid)}</div>
+            </div>
+            <div className="stat">
+              <div className="k">Best ask</div>
+              <div className="v" style={{ color: "var(--neg)" }}>
+                {usd2.format(bestAsk)}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="panel pad-lg">
+          <p className="panel-title">Beta to the index</p>
+          <p className="panel-note">Daily return vs. S&amp;P 500 · trend fitted</p>
+          <MicroScatter
+            data={returnScatter}
+            trend
+            r={2}
+            color="#6fb0e0"
+            title="NVDA daily return against the S&P 500 daily return"
+            format={pctFmt}
+            animate
+            style={{ width: "100%", height: "auto" }}
+            width={420}
+            height={280}
+          />
+          <div className="scatter-axes">
+            <span>x · S&amp;P 500 daily %</span>
+            <span>y · NVDA daily %</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid" style={{ marginTop: 16 }}>
+        <div className="panel pad-lg">
+          <p className="panel-title">Price × volume phase</p>
+          <p className="panel-note">
+            How price and session volume move together across the window · recent motion accented
+          </p>
+          <div className="phase-hold">
+            <PhaseTrace
+              data={priceVolumeTrace}
+              xLabel="Close price"
+              yLabel="Volume (M sh)"
+              tail={0.3}
+              grid
+              startDot
+              title="Trajectory of NVDA close price against session volume over 30 sessions"
+              format={(n) => n.toFixed(1)}
+              animate
+              style={{ width: "100%", height: "auto" }}
+              width={1040}
+              height={402}
+            />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/examples/ledger-finance/src/components/Markets.tsx
+++ b/examples/ledger-finance/src/components/Markets.tsx
@@ -1,0 +1,197 @@
+import { useState } from "react";
+import { Sparkline } from "@microcharts/react/sparkline/interactive";
+import { Delta } from "@microcharts/react/delta/interactive";
+import { CometTrail } from "@microcharts/react/comet-trail/interactive";
+import { HeartbeatBlip } from "@microcharts/react/heartbeat-blip/interactive";
+import { TapeGauge } from "@microcharts/react/tape-gauge/interactive";
+import { Horizon } from "@microcharts/react/horizon/interactive";
+import {
+  markets,
+  spxTicks,
+  pulseEvents,
+  pulseWindow,
+  pulseNow,
+  vixValue,
+  vixRate,
+  vixZones,
+  monitorRows,
+} from "../data";
+
+const num2 = new Intl.NumberFormat("en-US", { maximumFractionDigits: 2 });
+
+const POS = "#45a385"; // microcharts dark-theme positive
+const NEG = "#df7856"; // microcharts dark-theme negative
+const ACCENT = "#e6b04a"; // gold signal accent — reserved for live data
+
+const spxLast = spxTicks[spxTicks.length - 1];
+const spxPrev = markets[0].prev;
+const printsPerMin = pulseEvents.length;
+
+export function Markets() {
+  const [pulse, setPulse] = useState<{ index: number; value: number | null } | null>(null);
+
+  return (
+    <section className="view" aria-label="Markets">
+      <div className="section-head">
+        <h2>Market pulse</h2>
+        <span className="aside">Live tape · {printsPerMin} prints / min</span>
+      </div>
+
+      <div className="grid pulse-band">
+        <div className="panel pad-lg pulse-ticker">
+          <div className="mini-head">
+            <div>
+              <p className="eyebrow" style={{ margin: 0 }}>
+                <span className="live-dot" aria-hidden="true" />
+                S&amp;P 500 · live
+              </p>
+              <div className="pulse-value">{num2.format(spxLast)}</div>
+            </div>
+            <Delta value={spxLast} from={spxPrev} positive="up" summary={false} />
+          </div>
+          <CometTrail
+            data={spxTicks}
+            trail={16}
+            label="last"
+            color={ACCENT}
+            title="S&P 500 recent ticks with a fading momentum trail"
+            format={{ maximumFractionDigits: 0 }}
+            style={{ width: "100%", height: "auto" }}
+            width={520}
+            height={96}
+            onActive={setPulse}
+          />
+          <span className="picker-readout">
+            {pulse?.value != null ? `Scrub · ${num2.format(pulse.value)}` : "Hover to scrub"}
+          </span>
+        </div>
+
+        <div className="panel pad-lg pulse-cell">
+          <p className="eyebrow" style={{ margin: 0 }}>
+            Tape activity
+          </p>
+          <p className="pulse-mini-note">Trade prints, last 60s</p>
+          <HeartbeatBlip
+            events={pulseEvents}
+            window={pulseWindow}
+            now={pulseNow}
+            label="count"
+            color="#6fb0e0"
+            title="Trade prints across the last sixty seconds"
+            style={{ width: "100%", height: "auto" }}
+            width={260}
+            height={72}
+          />
+        </div>
+
+        <div className="panel pad-lg pulse-cell">
+          <p className="eyebrow" style={{ margin: 0 }}>
+            VIX
+          </p>
+          <p className="pulse-mini-note">Volatility · calm / stress bands</p>
+          <TapeGauge
+            value={vixValue}
+            rate={vixRate}
+            zones={vixZones}
+            span={24}
+            orientation="horizontal"
+            label="value"
+            title="CBOE volatility index reading against its calm and stress bands"
+            format={{ maximumFractionDigits: 2 }}
+            animate
+            style={{ width: "100%", height: "auto" }}
+            width={260}
+            height={72}
+          />
+        </div>
+      </div>
+
+      <div className="section-head">
+        <h2>Markets</h2>
+        <span className="aside">Indices, crypto &amp; rates · intraday</span>
+      </div>
+
+      <div className="grid cards">
+        {markets.map((m) => {
+          const up = m.last >= m.prev;
+          return (
+            <div key={m.symbol} className="panel mkt">
+              <div className="mkt-top">
+                <div>
+                  <div className="mkt-name">{m.symbol}</div>
+                  <div className="mkt-sub">{m.name}</div>
+                </div>
+                <Delta value={m.last} from={m.prev} positive="up" summary={false} />
+              </div>
+              <div className="mkt-last">{num2.format(m.last)}</div>
+              <div className="mkt-chart">
+                <Sparkline
+                  data={m.spark}
+                  width={240}
+                  height={52}
+                  curve="smooth"
+                  color={up ? POS : NEG}
+                  title={`${m.symbol} intraday`}
+                  animate
+                  style={{ width: "100%", height: "auto" }}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="section-head">
+        <h2>Global monitor</h2>
+        <span className="aside">Intraday deviation from open · folded bands</span>
+      </div>
+
+      <div className="panel table-wrap" style={{ paddingTop: 8 }}>
+        <table className="table monitor">
+          <thead>
+            <tr>
+              <th>Instrument</th>
+              <th>Last</th>
+              <th className="col-horizon">Session</th>
+              <th>Day</th>
+            </tr>
+          </thead>
+          <tbody>
+            {monitorRows.map((r) => (
+              <tr key={r.symbol}>
+                <td>
+                  <div className="asset">
+                    <div className="badge badge-sm">{r.symbol}</div>
+                    <div>
+                      <div className="nm">{r.symbol}</div>
+                      <div className="sub">{r.name}</div>
+                    </div>
+                  </div>
+                </td>
+                <td>{num2.format(r.last)}</td>
+                <td className="col-horizon">
+                  <span className="mc-inline">
+                    <Horizon
+                      data={r.series}
+                      folds={2}
+                      mode="mirror"
+                      baseline={0}
+                      color={r.changePct >= 0 ? POS : NEG}
+                      title={`${r.name} intraday deviation from the open`}
+                      summary={false}
+                      width={200}
+                      height={26}
+                    />
+                  </span>
+                </td>
+                <td>
+                  <Delta value={100 + r.changePct} from={100} positive="up" summary={false} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/examples/ledger-finance/src/components/Portfolio.tsx
+++ b/examples/ledger-finance/src/components/Portfolio.tsx
@@ -1,0 +1,325 @@
+import { useState } from "react";
+import { Sparkline } from "@microcharts/react/sparkline/interactive";
+import { Delta } from "@microcharts/react/delta/interactive";
+import { MicroDonut } from "@microcharts/react/micro-donut/interactive";
+import { NetFlow } from "@microcharts/react/net-flow/interactive";
+import { BalanceBeam } from "@microcharts/react/balance-beam/interactive";
+import { TreeRings } from "@microcharts/react/tree-rings/interactive";
+import { BubbleRow } from "@microcharts/react/bubble-row/interactive";
+import {
+  holdings,
+  allocation,
+  portfolioSeries,
+  portfolioValue,
+  portfolioPrevValue,
+  cashFlow,
+  orderFlow,
+  accountRings,
+  accountOpenedYear,
+  marketCaps,
+} from "../data";
+
+const usd = {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0,
+} as const;
+const usd2 = { style: "currency", currency: "USD" } as const;
+const usdCompact = {
+  style: "currency",
+  currency: "USD",
+  notation: "compact",
+  maximumFractionDigits: 1,
+} as const;
+
+const fmtUsd = new Intl.NumberFormat("en-US", usd);
+const fmtUsd2 = new Intl.NumberFormat("en-US", usd2);
+const fmtCompact = new Intl.NumberFormat("en-US", usdCompact);
+
+// Allocation classes on the microcharts matte palette: equities steel-blue,
+// crypto gold, bonds sage, cash mauve. Gold (the accent) lands on crypto by design.
+const catColors = ["#6fb0e0", "#e2b45c", "#4fb08d", "#c486b0"];
+const POS = "#45a385"; // microcharts dark-theme positive — never re-tinted
+const NEG = "#df7856"; // microcharts dark-theme negative
+
+const accountAge = new Date().getFullYear() - accountOpenedYear;
+const lifetimeContrib = accountRings.reduce((s, v) => s + v, 0);
+const netThisMonth = cashFlow[cashFlow.length - 1];
+
+type Scrub = { index: number; value: number | null; formatted?: string } | null;
+
+export function Portfolio() {
+  const dayGain = portfolioValue - portfolioPrevValue;
+  const [active, setActive] = useState<Scrub>(null);
+  const [selected, setSelected] = useState<Scrub>(null);
+  const scrubbed = selected ?? active;
+  const heroValue =
+    scrubbed?.formatted ??
+    (scrubbed?.value != null ? fmtUsd2.format(scrubbed.value) : fmtUsd2.format(portfolioValue));
+
+  return (
+    <section className="view" aria-label="Portfolio">
+      <div className="grid hero">
+        <div className="panel pad-lg">
+          <div className="hero-head">
+            <p className="eyebrow" style={{ margin: 0 }}>
+              Total portfolio value
+            </p>
+            <span className="chip">
+              {scrubbed ? (active ? "scrubbing" : "pinned") : "vs. prior close"}
+            </span>
+          </div>
+          <div className="hero-value">{heroValue}</div>
+          <div className="hero-sub">
+            <Delta value={portfolioValue} from={portfolioPrevValue} positive="up" animate />
+            <span className="num">
+              {dayGain >= 0 ? "+" : "−"}
+              {fmtUsd2.format(Math.abs(dayGain))} today
+            </span>
+            <span className={`scrub-chip${scrubbed ? "" : " is-idle"}`}>
+              {scrubbed
+                ? `${selected && !active ? "Pinned" : "Scrub"} · day ${scrubbed.index + 1}`
+                : "Hover to scrub"}
+            </span>
+          </div>
+
+          <div className="hero-chart">
+            <Sparkline
+              data={portfolioSeries}
+              width={560}
+              height={132}
+              curve="smooth"
+              fill
+              dots="auto"
+              color={POS}
+              title="Portfolio value, last 90 days"
+              format={usd2}
+              animate
+              style={{ width: "100%", height: "auto" }}
+              readout={false}
+              onActive={setActive}
+              onSelect={setSelected}
+              selectedIndex={selected?.index ?? null}
+            />
+          </div>
+
+          <div className="strip">
+            <div className="stat">
+              <div className="k">Day change</div>
+              <div className="v">
+                <Delta
+                  value={portfolioValue}
+                  from={portfolioPrevValue}
+                  positive="up"
+                  summary={false}
+                />
+              </div>
+            </div>
+            <div className="stat">
+              <div className="k">Holdings</div>
+              <div className="v">{holdings.length} assets</div>
+            </div>
+            <div className="stat">
+              <div className="k">90-day low</div>
+              <div className="v">{fmtUsd.format(Math.min(...portfolioSeries))}</div>
+            </div>
+            <div className="stat">
+              <div className="k">90-day high</div>
+              <div className="v">{fmtUsd.format(Math.max(...portfolioSeries))}</div>
+            </div>
+          </div>
+        </div>
+
+        <div className="panel pad-lg">
+          <p className="eyebrow">Allocation by asset class</p>
+          <div className="donut-wrap">
+            <MicroDonut
+              data={allocation}
+              size={168}
+              colors={catColors}
+              title="Portfolio allocation by asset class"
+              format={usd}
+              animate
+            />
+            <div className="legend" style={{ marginTop: 0 }}>
+              {allocation.map((a, i) => {
+                const total = allocation.reduce((s, x) => s + x.value, 0);
+                return (
+                  <span key={a.label}>
+                    <i style={{ background: catColors[i] }} />
+                    {a.label}
+                    <b style={{ color: "var(--text-mute)", fontWeight: 500 }}>
+                      {" "}
+                      {Math.round((a.value / total) * 100)}%
+                    </b>
+                  </span>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="section-head">
+        <h2>Flows &amp; footprint</h2>
+        <span className="aside">Contributions, order flow &amp; tenure</span>
+      </div>
+
+      <div className="grid bento-flows">
+        <div className="panel pad-lg cell-flow">
+          <div className="mini-head">
+            <div>
+              <p className="panel-title">Cash in / out</p>
+              <p className="panel-note">Contributions vs. withdrawals · 12 months</p>
+            </div>
+            <span className={netThisMonth.in - netThisMonth.out >= 0 ? "tag tag-pos" : "tag"}>
+              {netThisMonth.in - netThisMonth.out >= 0 ? "+" : "−"}
+              {fmtUsd.format(Math.abs(netThisMonth.in - netThisMonth.out))} net
+            </span>
+          </div>
+          <NetFlow
+            data={cashFlow}
+            mode="bars"
+            net
+            positive="up"
+            label="last"
+            title="Monthly cash contributions against withdrawals over the past year"
+            format={usd}
+            animate
+            style={{ width: "100%", height: "auto" }}
+            width={640}
+            height={192}
+          />
+        </div>
+
+        <div className="panel pad-lg cell-beam">
+          <p className="panel-title">Order-flow pressure</p>
+          <p className="panel-note">Notional bought vs. sold, session</p>
+          <div className="beam-hold">
+            <BalanceBeam
+              data={orderFlow}
+              mode="difference"
+              label="none"
+              title="Buy pressure against sell pressure this session"
+              format={usdCompact}
+              animate
+              style={{ width: "100%", height: "auto" }}
+              width={220}
+              height={120}
+            />
+          </div>
+          <div className="beam-legend">
+            <span>
+              <i style={{ background: "var(--pos)" }} />
+              Buys {fmtCompact.format(orderFlow[0].value)}
+            </span>
+            <span>
+              <i style={{ background: "var(--neg)" }} />
+              Sells {fmtCompact.format(orderFlow[1].value)}
+            </span>
+          </div>
+        </div>
+
+        <div className="panel pad-lg cell-rings">
+          <p className="panel-title">Account tenure</p>
+          <p className="panel-note">Net contributed per year since {accountOpenedYear}</p>
+          <div className="rings-hold">
+            <TreeRings
+              data={accountRings}
+              highlight="last"
+              rings="fill"
+              periodWord="year"
+              unit="years"
+              color="#6fb0e0"
+              title={`Net contributions across ${accountAge} years since opening`}
+              format={usdCompact}
+              size={148}
+              animate
+            />
+            <div className="rings-facts">
+              <div className="stat">
+                <div className="k">Age</div>
+                <div className="v">{accountAge} yrs</div>
+              </div>
+              <div className="stat">
+                <div className="k">Lifetime in</div>
+                <div className="v">{fmtCompact.format(lifetimeContrib)}</div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="panel pad-lg cell-caps">
+          <p className="panel-title">Positions by market cap</p>
+          <p className="panel-note">Issuer capitalization behind each holding</p>
+          <BubbleRow
+            data={marketCaps}
+            align="baseline"
+            label="both"
+            color="#c486b0"
+            title="Held positions sized by their issuer's market capitalization"
+            format={usdCompact}
+            height={132}
+            animate
+            style={{ width: "100%", height: "auto" }}
+          />
+        </div>
+      </div>
+
+      <div className="section-head">
+        <h2>Holdings</h2>
+        <span className="aside">Live positions · sorted by market value</span>
+      </div>
+
+      <div className="panel table-wrap" style={{ paddingTop: 8 }}>
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Asset</th>
+              <th>Price</th>
+              <th>30-day</th>
+              <th>Market value</th>
+              <th>Day</th>
+            </tr>
+          </thead>
+          <tbody>
+            {[...holdings]
+              .sort((a, b) => b.value - a.value)
+              .map((h) => (
+                <tr key={h.ticker}>
+                  <td>
+                    <div className="asset">
+                      <div className="badge">{h.ticker.slice(0, 4)}</div>
+                      <div>
+                        <div className="nm">{h.ticker}</div>
+                        <div className="sub">
+                          {h.shares} · {h.name}
+                        </div>
+                      </div>
+                    </div>
+                  </td>
+                  <td>{fmtUsd2.format(h.price)}</td>
+                  <td className="cell-spark">
+                    <span className="mc-inline">
+                      <Sparkline
+                        data={h.spark}
+                        width={112}
+                        height={30}
+                        curve="smooth"
+                        color={h.price >= h.prevPrice ? POS : NEG}
+                        summary={false}
+                      />
+                    </span>
+                  </td>
+                  <td>{fmtUsd2.format(h.value)}</td>
+                  <td>
+                    <Delta value={h.price} from={h.prevPrice} positive="up" summary={false} />
+                  </td>
+                </tr>
+              ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/examples/ledger-finance/src/data.ts
+++ b/examples/ledger-finance/src/data.ts
@@ -1,0 +1,488 @@
+// Mock data for the "Ledger" portfolio tracker.
+// Deterministic seeded generation so figures never shift between renders.
+
+function mulberry32(seed: number): () => number {
+  let a = seed;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** A gently drifting random walk, rounded to 2dp. */
+function walk(seed: number, n: number, start: number, drift: number, vol: number): number[] {
+  const rnd = mulberry32(seed);
+  const out: number[] = [];
+  let v = start;
+  for (let i = 0; i < n; i++) {
+    v = v * (1 + drift + (rnd() - 0.5) * vol);
+    out.push(Math.round(v * 100) / 100);
+  }
+  return out;
+}
+
+export interface Holding {
+  ticker: string;
+  name: string;
+  kind: "Equity" | "Crypto" | "ETF";
+  shares: number;
+  price: number;
+  prevPrice: number;
+  value: number;
+  spark: number[];
+}
+
+function holding(
+  ticker: string,
+  name: string,
+  kind: Holding["kind"],
+  shares: number,
+  price: number,
+  dayPct: number,
+  seed: number,
+): Holding {
+  const prevPrice = Math.round((price / (1 + dayPct / 100)) * 100) / 100;
+  return {
+    ticker,
+    name,
+    kind,
+    shares,
+    price,
+    prevPrice,
+    value: Math.round(shares * price * 100) / 100,
+    spark: walk(seed, 30, price * 0.94, 0.002, 0.03),
+  };
+}
+
+export const holdings: Holding[] = [
+  holding("NVDA", "NVIDIA Corp.", "Equity", 180, 121.4, 2.34, 11),
+  holding("AAPL", "Apple Inc.", "Equity", 320, 229.87, 0.62, 12),
+  holding("MSFT", "Microsoft Corp.", "Equity", 140, 431.2, -0.41, 13),
+  holding("BTC", "Bitcoin", "Crypto", 1.85, 67240, 3.12, 14),
+  holding("ETH", "Ethereum", "Crypto", 14.2, 3180, 1.88, 15),
+  holding("VTI", "Vanguard Total Mkt", "ETF", 210, 278.55, 0.35, 16),
+  holding("TSLA", "Tesla Inc.", "Equity", 95, 248.5, -1.72, 17),
+];
+
+const cashUsd = 22840.15;
+const bondsUsd = 26120.5;
+
+export const portfolioValue =
+  Math.round((holdings.reduce((s, h) => s + h.value, 0) + cashUsd + bondsUsd) * 100) / 100;
+
+// Prior close: back out each holding's previous value plus static cash/bonds.
+const prevHoldingsValue = holdings.reduce((s, h) => s + h.shares * h.prevPrice, 0);
+export const portfolioPrevValue = Math.round((prevHoldingsValue + cashUsd + bondsUsd) * 100) / 100;
+
+// 90-day portfolio value series, ending exactly at today's value.
+const rawPortfolio = walk(7, 90, portfolioValue * 0.86, 0.0016, 0.02);
+const scale = portfolioValue / rawPortfolio[rawPortfolio.length - 1];
+export const portfolioSeries = rawPortfolio.map((v) => Math.round(v * scale * 100) / 100);
+
+export interface Allocation {
+  label: string;
+  value: number;
+}
+export const allocation: Allocation[] = [
+  {
+    label: "Equities",
+    value: Math.round(holdings.filter((h) => h.kind !== "Crypto").reduce((s, h) => s + h.value, 0)),
+  },
+  {
+    label: "Crypto",
+    value: Math.round(holdings.filter((h) => h.kind === "Crypto").reduce((s, h) => s + h.value, 0)),
+  },
+  { label: "Bonds", value: Math.round(bondsUsd) },
+  { label: "Cash", value: Math.round(cashUsd) },
+];
+
+// ---- Markets ----
+export interface MarketCard {
+  symbol: string;
+  name: string;
+  last: number;
+  prev: number;
+  spark: number[];
+}
+
+function market(
+  symbol: string,
+  name: string,
+  last: number,
+  dayPct: number,
+  seed: number,
+): MarketCard {
+  return {
+    symbol,
+    name,
+    last,
+    prev: Math.round((last / (1 + dayPct / 100)) * 100) / 100,
+    spark: walk(seed, 30, last * 0.97, 0.001, 0.02),
+  };
+}
+
+export const markets: MarketCard[] = [
+  market("S&P 500", "SPX Index", 5738.17, 0.51, 21),
+  market("Nasdaq", "IXIC Composite", 18119.6, 0.86, 22),
+  market("Dow Jones", "DJI Industrial", 42063.4, -0.22, 23),
+  market("Russell 2K", "RUT Smallcap", 2227.9, 0.34, 24),
+  market("BTC / USD", "Bitcoin", 67240, 3.12, 25),
+  market("Gold", "XAU spot / oz", 2648.3, -0.44, 26),
+  market("US 10Y", "Treasury yield", 3.74, 0.19, 27),
+  market("VIX", "Volatility", 16.42, -2.14, 28),
+];
+
+// ---- Detailed OHLC for NVDA (30 sessions, oldest first) ----
+export interface Candle {
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+}
+export const nvdaCandles: Candle[] = (() => {
+  const rnd = mulberry32(99);
+  const out: Candle[] = [];
+  let close = 104.5;
+  for (let i = 0; i < 30; i++) {
+    const open = Math.round(close * (1 + (rnd() - 0.48) * 0.02) * 100) / 100;
+    const drift = (rnd() - 0.42) * 0.045;
+    close = Math.round(open * (1 + drift) * 100) / 100;
+    const hi = Math.max(open, close) * (1 + rnd() * 0.018);
+    const lo = Math.min(open, close) * (1 - rnd() * 0.018);
+    out.push({
+      open,
+      close,
+      high: Math.round(hi * 100) / 100,
+      low: Math.round(lo * 100) / 100,
+    });
+  }
+  return out;
+})();
+
+// ---- Analytics ----
+// Monthly returns (%) over 3 years — raw observations for the histogram.
+export const monthlyReturns: number[] = walk(31, 36, 100, 0, 0.14).map(
+  (v) => Math.round((v - 100) * 100) / 100,
+);
+
+// Daily returns (%) over ~1 trading year — raw sample for the ladder.
+export const dailyReturns: number[] = (() => {
+  const rnd = mulberry32(41);
+  const out: number[] = [];
+  for (let i = 0; i < 252; i++) {
+    // roughly-normal via sum of uniforms, centered slightly positive
+    const z = (rnd() + rnd() + rnd() - 1.5) / 1.5;
+    out.push(Math.round((0.06 + z * 1.15) * 100) / 100);
+  }
+  return out;
+})();
+
+// Allocation drift over 12 months — 3 stacked series.
+export const allocationOverTime = [
+  { label: "Equities", values: walk(51, 12, 58, 0.006, 0.03) },
+  { label: "Crypto", values: walk(52, 12, 14, 0.02, 0.06) },
+  { label: "Bonds & Cash", values: walk(53, 12, 28, -0.004, 0.02) },
+];
+
+// Goal progress for the Bullet charts.
+export interface Goal {
+  label: string;
+  value: number;
+  target: number;
+  bands: number[];
+  unit: "usd";
+}
+export const goals: Goal[] = [
+  { label: "Emergency fund", value: 22840, target: 30000, bands: [15000, 24000], unit: "usd" },
+  {
+    label: "2024 retirement contribution",
+    value: 18500,
+    target: 23000,
+    bands: [11500, 20000],
+    unit: "usd",
+  },
+  { label: "House down payment", value: 61200, target: 120000, bands: [60000, 96000], unit: "usd" },
+];
+
+// ============================================================
+// Portfolio — added coverage
+// ============================================================
+
+// Order-flow pressure across the last session: notional bought vs sold.
+export const orderFlow: [{ label: string; value: number }, { label: string; value: number }] = [
+  { label: "Buys", value: 6_240_000 },
+  { label: "Sells", value: 4_105_000 },
+];
+
+// Monthly cash in/out — contributions vs withdrawals, trailing 12 months.
+export interface CashPeriod {
+  in: number;
+  out: number;
+}
+export const cashFlow: CashPeriod[] = (() => {
+  const rnd = mulberry32(61);
+  const months = 12;
+  const out: CashPeriod[] = [];
+  for (let i = 0; i < months; i++) {
+    const contrib = Math.round((2500 + rnd() * 6500) / 50) * 50;
+    // occasional larger withdrawals (rebalances, a tax bill)
+    const withdraw = Math.round((rnd() < 0.28 ? 2000 + rnd() * 7000 : rnd() * 1800) / 50) * 50;
+    out.push({ in: contrib, out: withdraw });
+  }
+  return out;
+})();
+
+// Account age — net contributions per year since opening (oldest first).
+export const accountRings: number[] = [7400, 10800, 9200, 14600, 17900, 21300, 19850];
+export const accountOpenedYear = 2018;
+
+// Positions sized by the issuer's market capitalization (USD).
+export interface CapDatum {
+  label: string;
+  value: number;
+}
+export const marketCaps: CapDatum[] = [
+  { label: "AAPL", value: 3.45e12 },
+  { label: "MSFT", value: 3.21e12 },
+  { label: "NVDA", value: 3.02e12 },
+  { label: "BTC", value: 1.33e12 },
+  { label: "TSLA", value: 0.79e12 },
+  { label: "ETH", value: 0.38e12 },
+];
+
+// ============================================================
+// Markets — added coverage
+// ============================================================
+
+// Featured live ticker (S&P 500) — recent ticks for the comet head + trail.
+export const spxTicks: number[] = walk(71, 44, 5731.4, 0.00018, 0.0016).map(
+  (v) => Math.round(v * 100) / 100,
+);
+
+// Market-pulse heartbeat: trade-print timestamps inside a 60s window.
+export const pulseWindow = 60_000;
+export const pulseNow = 60_000;
+export const pulseEvents: number[] = (() => {
+  const rnd = mulberry32(72);
+  const out: number[] = [];
+  let t = 0;
+  while (t < pulseWindow) {
+    // bursty arrivals: mostly tight, occasional lulls
+    t += rnd() < 0.8 ? 700 + rnd() * 1400 : 2600 + rnd() * 3800;
+    if (t < pulseWindow) out.push(Math.round(t));
+  }
+  return out;
+})();
+
+// VIX live reading for the tape gauge.
+export const vixValue = 16.42;
+export const vixRate = -0.34;
+export const vixZones = [
+  { from: 4, to: 18, tone: "pos" as const },
+  { from: 18, to: 28, tone: "warn" as const },
+  { from: 28, to: 45, tone: "neg" as const },
+];
+
+// Dense monitoring rows: intraday % deviation from open for many symbols.
+export interface HorizonRow {
+  symbol: string;
+  name: string;
+  last: number;
+  changePct: number;
+  series: number[];
+}
+export const monitorRows: HorizonRow[] = (() => {
+  const specs: [string, string, number, number, number][] = [
+    ["ES", "S&P 500 fut", 5741.5, 0.51, 81],
+    ["NQ", "Nasdaq 100 fut", 20118.0, 0.86, 82],
+    ["YM", "Dow fut", 42088.0, -0.22, 83],
+    ["RTY", "Russell 2K fut", 2229.4, 0.34, 84],
+    ["CL", "WTI crude", 71.84, -1.12, 85],
+    ["GC", "Gold", 2648.3, -0.44, 86],
+    ["ZN", "10Y note", 111.72, 0.19, 87],
+    ["6E", "EUR / USD", 1.0842, 0.08, 88],
+    ["BTC", "Bitcoin", 67240, 3.12, 89],
+    ["VX", "VIX fut", 16.42, -2.14, 90],
+  ];
+  return specs.map(([symbol, name, last, changePct, seed]) => {
+    const rnd = mulberry32(seed);
+    // deviation (%) from the open across ~48 intraday marks, ending at changePct
+    const raw: number[] = [];
+    let v = 0;
+    for (let i = 0; i < 48; i++) {
+      v += (rnd() - 0.5) * 0.34;
+      raw.push(v);
+    }
+    const drift = changePct - raw[raw.length - 1];
+    const series = raw.map((x, i) => Math.round((x + (drift * i) / (raw.length - 1)) * 100) / 100);
+    return { symbol, name, last, changePct, series };
+  });
+})();
+
+// ============================================================
+// Asset detail (NVDA) — added coverage
+// ============================================================
+
+const nvdaLast = nvdaCandles[nvdaCandles.length - 1].close;
+const nvdaHi = Math.max(...nvdaCandles.map((c) => c.high));
+const nvdaLo = Math.min(...nvdaCandles.map((c) => c.low));
+
+// Volume-at-price: mass concentrated around a point of control below spot.
+export interface VolLevel {
+  level: number;
+  weight: number;
+}
+export const volumeAtPrice: VolLevel[] = (() => {
+  const rnd = mulberry32(101);
+  const bins = 14;
+  const poc = nvdaLo + (nvdaHi - nvdaLo) * 0.42; // point of control
+  const out: VolLevel[] = [];
+  for (let i = 0; i < bins; i++) {
+    const level = Math.round((nvdaLo + ((nvdaHi - nvdaLo) * i) / (bins - 1)) * 100) / 100;
+    const dist = Math.abs(level - poc) / (nvdaHi - nvdaLo);
+    const mass = Math.exp(-(dist * dist) * 9) * (0.7 + rnd() * 0.6);
+    out.push({ level, weight: Math.round(mass * 1000) / 10 });
+  }
+  return out;
+})();
+
+// Order-book depth around the last trade.
+export interface DepthLevel {
+  level: number;
+  amount: number;
+}
+export const orderBook: { demand: DepthLevel[]; supply: DepthLevel[] } = (() => {
+  const rnd = mulberry32(102);
+  const mid = Math.round(nvdaLast * 100) / 100;
+  const tick = 0.25;
+  const demand: DepthLevel[] = [];
+  const supply: DepthLevel[] = [];
+  for (let i = 1; i <= 12; i++) {
+    const bid = Math.round((mid - i * tick) * 100) / 100;
+    const ask = Math.round((mid + i * tick) * 100) / 100;
+    demand.push({ level: bid, amount: Math.round((900 + rnd() * 2600) * (1 + i * 0.08)) });
+    supply.push({ level: ask, amount: Math.round((900 + rnd() * 2600) * (1 + i * 0.06)) });
+  }
+  return { demand, supply };
+})();
+
+// Return correlation: NVDA daily return (%) vs the S&P (beta > 1).
+export interface XY {
+  x: number;
+  y: number;
+}
+export const returnScatter: XY[] = (() => {
+  const rnd = mulberry32(103);
+  const out: XY[] = [];
+  for (let i = 0; i < 44; i++) {
+    const mkt = (rnd() + rnd() + rnd() - 1.5) * 1.4; // market return
+    const idio = (rnd() - 0.5) * 1.6; // idiosyncratic
+    out.push({
+      x: Math.round(mkt * 100) / 100,
+      y: Math.round((mkt * 1.65 + idio + 0.15) * 100) / 100,
+    });
+  }
+  return out;
+})();
+
+// Phase portrait: price (x) against session volume (y) across the window.
+export const priceVolumeTrace: XY[] = (() => {
+  const rnd = mulberry32(104);
+  return nvdaCandles.map((c) => ({
+    x: c.close,
+    y: Math.round((3.2 + Math.abs(c.high - c.low) * 0.9 + rnd() * 1.4) * 10) / 10,
+  }));
+})();
+
+export const nvdaStats = { last: nvdaLast, high: nvdaHi, low: nvdaLo };
+
+// ============================================================
+// Analytics — added coverage
+// ============================================================
+
+// Monte-Carlo projection: 14 portfolio paths over the next 24 months.
+export const forecastPaths: number[][] = (() => {
+  const members = 14;
+  const horizon = 24;
+  const start = portfolioValue;
+  const paths: number[][] = [];
+  for (let m = 0; m < members; m++) {
+    const rnd = mulberry32(200 + m);
+    const drift = 0.006 + (rnd() - 0.5) * 0.004;
+    const vol = 0.03 + rnd() * 0.02;
+    const p: number[] = [start];
+    let v = start;
+    for (let i = 1; i < horizon; i++) {
+      v = v * (1 + drift + (rnd() - 0.5) * vol);
+      p.push(Math.round(v));
+    }
+    paths.push(p);
+  }
+  return paths;
+})();
+
+// Probability (%) of clearing the $1M net-worth mark by year end — crosses 50.
+export const millionOdds: number[] = (() => {
+  const rnd = mulberry32(210);
+  const out: number[] = [];
+  let p = 34;
+  for (let i = 0; i < 26; i++) {
+    p += (rnd() - 0.42) * 7;
+    p = Math.max(6, Math.min(94, p));
+    out.push(Math.round(p * 10) / 10);
+  }
+  // land decisively above the line
+  out[out.length - 1] = 63.5;
+  return out;
+})();
+
+/** Median + p80 band from the Monte-Carlo paths, for ForecastCone. */
+export const portfolioForecast = (() => {
+  const horizon = forecastPaths[0]!.length;
+  const mid: number[] = [];
+  const p80: [number, number][] = [];
+  for (let i = 0; i < horizon; i++) {
+    const col = forecastPaths.map((p) => p[i]!).sort((a, b) => a - b);
+    mid.push(col[Math.floor(col.length / 2)]!);
+    p80.push([col[Math.floor(col.length * 0.1)]!, col[Math.floor(col.length * 0.9)]!]);
+  }
+  return { mid, p80 };
+})();
+export const millionTarget = 1_000_000;
+
+// Portfolio vs benchmark: cumulative return (%) — the lead flips mid-year.
+export interface SpreadRow {
+  a: number;
+  b: number;
+}
+export const benchmarkSpread: SpreadRow[] = (() => {
+  const rndA = mulberry32(220);
+  const rndB = mulberry32(221);
+  const out: SpreadRow[] = [];
+  let a = 0;
+  let b = 0;
+  for (let i = 0; i < 14; i++) {
+    a += (rndA() - 0.4) * 2.4;
+    b += (rndB() - 0.42) * 1.9;
+    out.push({ a: Math.round(a * 100) / 100, b: Math.round(b * 100) / 100 });
+  }
+  return out;
+})();
+
+// Tracking check: paired monthly returns, portfolio (a) vs benchmark (b).
+export const trackingPairs: SpreadRow[] = (() => {
+  const rnd = mulberry32(230);
+  const out: SpreadRow[] = [];
+  for (let i = 0; i < 30; i++) {
+    const mkt = (rnd() + rnd() - 1) * 2.6;
+    const bias = 0.18 + (rnd() - 0.5) * 0.9; // small persistent tracking bias
+    out.push({
+      a: Math.round((mkt + bias) * 100) / 100,
+      b: Math.round(mkt * 100) / 100,
+    });
+  }
+  return out;
+})();

--- a/examples/ledger-finance/src/main.tsx
+++ b/examples/ledger-finance/src/main.tsx
@@ -1,0 +1,16 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { MicroProvider } from "@microcharts/react";
+import "@microcharts/react/styles.css";
+import "@microcharts/react/motion";
+import "./app.css";
+import "./analytics";
+import { App } from "./App";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <MicroProvider theme="dark">
+      <App />
+    </MicroProvider>
+  </StrictMode>,
+);

--- a/examples/ledger-finance/tsconfig.json
+++ b/examples/ledger-finance/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "moduleDetection": "force",
+    "isolatedModules": true
+  },
+  "include": ["src"]
+}

--- a/examples/ledger-finance/vite.config.ts
+++ b/examples/ledger-finance/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: { port: 4002, strictPort: true, host: true },
+});

--- a/examples/pulse-analytics/app/accounts/page.tsx
+++ b/examples/pulse-analytics/app/accounts/page.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { CitySkyline } from "@microcharts/react/city-skyline/interactive";
+import { DataDiff } from "@microcharts/react/data-diff/interactive";
+import { SproutRow } from "@microcharts/react/sprout-row/interactive";
+import { MiniBar } from "@microcharts/react/mini-bar/interactive";
+import { Topbar, PageHead, Card, SectionHead } from "../components/ui";
+import { accounts, syncDiff, compact } from "../data";
+
+const fill = { width: "100%", height: "auto" } as const;
+// Cell-sized charts render at natural size (see page.tsx note) — stretching
+// them to 100% magnifies the viewBox and balloons their category labels.
+const centered = {
+  maxWidth: "100%",
+  height: "auto",
+  display: "block",
+  margin: "0 auto",
+} as const;
+
+export default function AccountsPage() {
+  const skyline = accounts.map((a) => ({
+    label: a.short,
+    value: a.mrr,
+    lit: a.activation,
+  }));
+  const maturity = accounts.map((a) => ({
+    label: a.short,
+    value: a.maturity,
+  }));
+  const active = [...accounts]
+    .sort((x, y) => y.wau - x.wau)
+    .map((a) => ({ label: a.short, value: a.wau }));
+
+  return (
+    <>
+      <Topbar title="Accounts" crumb="Pulse" />
+      <div className="content">
+        <PageHead
+          index="05"
+          eyebrow="Customer base"
+          title="Accounts"
+          sub="The book of business at a glance — who's big, who's activated, who's maturing, and what the sync jobs are moving."
+        />
+
+        <div className="grid two-col section">
+          <Card
+            title="Accounts by size & activation"
+            sub="MRR height · lit = activated"
+            className="hover reveal reveal-1"
+          >
+            <CitySkyline
+              animate
+              data={skyline}
+              labels
+              unit="accounts"
+              format={compact}
+              height={200}
+              bw={46}
+              gap={26}
+              style={centered}
+              title="Accounts by MRR, with lit windows showing activation"
+            />
+            <p className="chart-note">
+              Northwind towers on MRR <b>and</b> lights up nearly every window — big and deeply
+              adopted. Solace is the opposite read.
+            </p>
+          </Card>
+
+          <Card
+            title="Nightly sync churn"
+            sub="Rows added / removed per job"
+            className="hover reveal reveal-2"
+          >
+            <DataDiff
+              animate
+              data={syncDiff}
+              labels
+              net
+              label="totals"
+              format={compact}
+              width={480}
+              height={220}
+              style={fill}
+              title="Rows added and removed per dataset in the nightly import"
+            />
+            <p className="chart-note">
+              Events and Sessions dominate the churn — expected for high-volume streams. Watch{" "}
+              <b>Sessions</b>: removals are creeping up.
+            </p>
+          </Card>
+        </div>
+
+        <Card
+          title="Account maturity"
+          sub="Lifecycle stage · seed → established"
+          className="section hover reveal reveal-1"
+        >
+          <SproutRow
+            animate
+            data={maturity}
+            labels
+            height={72}
+            step={96}
+            style={centered}
+            title="Account maturity stage across the top accounts"
+          />
+          <p className="chart-note">
+            Two Enterprise accounts are fully established; the Starter pair are still seedlings —
+            prime targets for a success touch.
+          </p>
+        </Card>
+
+        <SectionHead index="§ 01" title="Most active accounts" sub="Weekly active users" />
+        <Card className="hover reveal reveal-2">
+          <MiniBar
+            animate
+            data={active}
+            orientation="horizontal"
+            highlight={active[0].label}
+            format={compact}
+            width={1040}
+            height={240}
+            style={fill}
+            title="Accounts ranked by weekly active users"
+          />
+        </Card>
+      </div>
+    </>
+  );
+}

--- a/examples/pulse-analytics/app/components/nav.tsx
+++ b/examples/pulse-analytics/app/components/nav.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+// Sidebar nav is a small client island purely for active-route highlighting.
+// The pages themselves stay Server Components.
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const items = [
+  { href: "/", label: "Overview", index: "01" },
+  { href: "/revenue", label: "Revenue", index: "02" },
+  { href: "/engagement", label: "Engagement", index: "03" },
+  { href: "/experiments", label: "Experiments", index: "04" },
+  { href: "/accounts", label: "Accounts", index: "05" },
+  { href: "/live", label: "Live", index: "06" },
+];
+
+export function Nav() {
+  const pathname = usePathname();
+  return (
+    <nav className="nav" aria-label="Primary">
+      <span className="nav-label">Contents</span>
+      {items.map((it) => {
+        const active = it.href === "/" ? pathname === "/" : pathname.startsWith(it.href);
+        return (
+          <Link key={it.href} href={it.href} aria-current={active ? "page" : undefined}>
+            <span className="nav-index" aria-hidden>
+              {it.index}
+            </span>
+            {it.label}
+            <span className="nav-tick" aria-hidden />
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/examples/pulse-analytics/app/components/ui.tsx
+++ b/examples/pulse-analytics/app/components/ui.tsx
@@ -1,0 +1,117 @@
+import type { ReactNode } from "react";
+
+// Server-safe presentational helpers (no "use client").
+
+export function Topbar({
+  title,
+  crumb,
+  badge,
+  window = "Last 30 days",
+}: {
+  title: string;
+  crumb?: string;
+  badge?: ReactNode;
+  window?: string;
+}) {
+  return (
+    <header className="topbar">
+      <span className="topbar-title">
+        {crumb && (
+          <>
+            <span className="topbar-crumb">{crumb}</span>
+            <span className="topbar-sep" aria-hidden>
+              /
+            </span>
+          </>
+        )}
+        {title}
+      </span>
+      <div className="topbar-actions">
+        {badge}
+        <span className="pill">{window}</span>
+      </div>
+    </header>
+  );
+}
+
+export function PageHead({
+  index,
+  eyebrow,
+  title,
+  sub,
+}: {
+  index?: string;
+  eyebrow?: string;
+  title: string;
+  sub: string;
+}) {
+  return (
+    <div className="page-head">
+      {(index || eyebrow) && (
+        <div className="page-head-top">
+          {index && <span className="page-index">{index}</span>}
+          {eyebrow && <span className="eyebrow">{eyebrow}</span>}
+        </div>
+      )}
+      <h1>{title}</h1>
+      <p className="lead">{sub}</p>
+      <div className="page-rule" aria-hidden />
+    </div>
+  );
+}
+
+export function SectionHead({
+  index,
+  title,
+  sub,
+}: {
+  index?: string;
+  title: string;
+  sub?: string;
+}) {
+  return (
+    <div className="section-head">
+      {index && <span className="section-index">{index}</span>}
+      <h2>{title}</h2>
+      {sub && <span className="section-note">{sub}</span>}
+      <span className="rule-fill" aria-hidden />
+    </div>
+  );
+}
+
+export function Card({
+  title,
+  sub,
+  children,
+  className,
+}: {
+  title?: string;
+  sub?: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <section className={className ? `card ${className}` : "card"}>
+      {(title || sub) && (
+        <div className="card-head">
+          {title && <span className="card-title">{title}</span>}
+          {sub && <span className="card-sub">{sub}</span>}
+        </div>
+      )}
+      {children}
+    </section>
+  );
+}
+
+export function Legend({ items }: { items: { label: string; color: string }[] }) {
+  return (
+    <div className="legend">
+      {items.map((it) => (
+        <span key={it.label} className="legend-item">
+          <span className="legend-swatch" style={{ background: it.color }} />
+          {it.label}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/examples/pulse-analytics/app/data.ts
+++ b/examples/pulse-analytics/app/data.ts
@@ -1,0 +1,614 @@
+// Mock product-analytics data for the "Pulse" example app.
+// Believable SaaS numbers: DAU counts, MRR dollars, funnel stages, feature usage.
+// Pure data module — safe to import from Server Components. Everything here is
+// authored or generated once at module load (seeded PRNG), never per render.
+
+export const usd = {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0,
+} as const;
+
+export const usdCents = {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 2,
+} as const;
+
+export const compact = { notation: "compact", maximumFractionDigits: 1 } as const;
+
+export const pct = { style: "percent", maximumFractionDigits: 1 } as const;
+
+export const pct0 = { style: "percent", maximumFractionDigits: 0 } as const;
+
+export const ms = { maximumFractionDigits: 0 } as const;
+
+// ---- Seeded deterministic generators (computed once) ----
+
+function mulberry32(seed: number): () => number {
+  let a = seed;
+  return function () {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function gaussian(rng: () => number): number {
+  let u = 0;
+  let v = 0;
+  while (u === 0) u = rng();
+  while (v === 0) v = rng();
+  return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v);
+}
+
+/** N normally-distributed samples, 2-dp rounded, from a fixed seed. */
+function sample(n: number, mean: number, sd: number, seed: number): number[] {
+  const rng = mulberry32(seed);
+  return Array.from({ length: n }, () => Math.round((mean + gaussian(rng) * sd) * 100) / 100);
+}
+
+// ---- Overview: KPI series ----
+
+/** ~20 weeks (140 days) of daily active users, gently trending up with a weekly rhythm. */
+export const dau: number[] = (() => {
+  const out: number[] = [];
+  let base = 4200;
+  for (let i = 0; i < 140; i++) {
+    base += 9 + Math.sin(i / 11) * 6;
+    const weekday = i % 7;
+    const weekendDip = weekday === 5 || weekday === 6 ? 0.72 : 1;
+    const wobble = Math.sin(i * 1.7) * 140 + Math.cos(i * 0.6) * 90;
+    out.push(Math.round((base + wobble) * weekendDip));
+  }
+  return out;
+})();
+
+/** Last-30-day sparkline windows for the KPI cards. */
+export const dauSpark = dau.slice(-30);
+
+export const mrrSpark = [
+  61200, 61800, 62400, 62100, 63300, 64000, 64600, 65200, 66100, 66800, 67400, 68200, 69000, 69800,
+  70600, 71500, 72400, 73200, 74100, 75000,
+];
+
+export const signupsSpark = [
+  180, 172, 195, 210, 188, 176, 204, 233, 219, 241, 256, 248, 267, 279, 262, 288, 301, 294, 312,
+  329,
+];
+
+export const churnSpark = [
+  3.4, 3.5, 3.3, 3.2, 3.4, 3.1, 3.0, 3.2, 2.9, 3.0, 2.8, 2.9, 2.7, 2.8, 2.6, 2.7, 2.5, 2.6, 2.4,
+  2.3,
+];
+
+export interface Kpi {
+  key: string;
+  label: string;
+  value: number;
+  display: string;
+  from: number;
+  positive: "up" | "down";
+  spark: number[];
+}
+
+export const kpis: Kpi[] = [
+  {
+    key: "dau",
+    label: "Daily active users",
+    value: dauSpark[dauSpark.length - 1],
+    display: dauSpark[dauSpark.length - 1].toLocaleString("en-US"),
+    from: dauSpark[0],
+    positive: "up",
+    spark: dauSpark,
+  },
+  {
+    key: "mrr",
+    label: "Monthly recurring revenue",
+    value: 75000,
+    display: "$75.0k",
+    from: 61200,
+    positive: "up",
+    spark: mrrSpark,
+  },
+  {
+    key: "signups",
+    label: "New signups",
+    value: 329,
+    display: "329",
+    from: 180,
+    positive: "up",
+    spark: signupsSpark,
+  },
+  {
+    key: "churn",
+    label: "Monthly churn",
+    value: 2.3,
+    display: "2.3%",
+    from: 3.4,
+    positive: "down",
+    spark: churnSpark,
+  },
+];
+
+/** Goal progress: MRR against the quarterly target. */
+export const mrrGoal = { value: 75000, target: 90000, bands: [60000, 80000] };
+
+/** Headline numeric for the FatDigits hero — events tracked this month. */
+export const eventsTracked = 48_216_400;
+
+/** Onboarding activation: activated of signed-up, this cohort. */
+export const activation = { value: 3980, max: 6420 };
+
+/** Share of active accounts that have adopted Alerts (for the IconArray). */
+export const alertsAdoption = 0.72;
+
+/** Weekly activation rate over its signup volume — for RateVolume. */
+export const activationRateVolume: { rate: number; volume: number }[] = [
+  { rate: 0.58, volume: 176 },
+  { rate: 0.6, volume: 188 },
+  { rate: 0.59, volume: 204 },
+  { rate: 0.61, volume: 219 },
+  { rate: 0.62, volume: 233 },
+  { rate: 0.6, volume: 241 },
+  { rate: 0.63, volume: 256 },
+  { rate: 0.64, volume: 248 },
+  { rate: 0.63, volume: 267 },
+  { rate: 0.65, volume: 279 },
+  { rate: 0.66, volume: 301 },
+  { rate: 0.67, volume: 329 },
+];
+
+/** Signups vs. churned users per week — for NetFlow (in = signups, out = churn). */
+export const userFlow: { in: number; out: number }[] = [
+  { in: 176, out: 62 },
+  { in: 188, out: 58 },
+  { in: 204, out: 71 },
+  { in: 219, out: 55 },
+  { in: 233, out: 64 },
+  { in: 241, out: 49 },
+  { in: 256, out: 58 },
+  { in: 248, out: 52 },
+  { in: 267, out: 47 },
+  { in: 279, out: 54 },
+  { in: 301, out: 44 },
+  { in: 329, out: 41 },
+];
+
+/** Why new users abandon onboarding — long-tail, for ParetoStrip. */
+export const dropoffReasons = [
+  { label: "Slow first value", value: 2840 },
+  { label: "Confusing setup", value: 2110 },
+  { label: "No team invited", value: 1520 },
+  { label: "Missing integration", value: 980 },
+  { label: "Priced out", value: 760 },
+  { label: "Import failed", value: 540 },
+  { label: "Chose competitor", value: 430 },
+  { label: "No clear use case", value: 320 },
+];
+
+/** Support backlog (open tickets) per day for 3 weeks, with a WIP capacity. */
+export const supportBacklog = [
+  34, 38, 41, 37, 44, 52, 49, 55, 61, 58, 53, 47, 44, 51, 62, 68, 71, 64, 55, 48, 42,
+];
+export const supportCapacity = 50;
+
+/** Traffic acquisition sources (share of new sessions). */
+export const trafficSources = [
+  { label: "Organic", value: 4820 },
+  { label: "Direct", value: 3110 },
+  { label: "Referral", value: 1640 },
+  { label: "Paid", value: 1180 },
+  { label: "Social", value: 720 },
+];
+
+// ---- Revenue route ----
+
+export interface AccountRow {
+  account: string;
+  short: string;
+  plan: string;
+  mrr: number;
+  from: number;
+  trend: number[];
+  /** Product-usage split for the in-row MiniBar. */
+  mix: { label: string; value: number }[];
+  /** Growth-stage 0–3 for the SproutRow maturity read. */
+  maturity: 0 | 1 | 2 | 3;
+  /** Activation fraction 0–1 — lit windows in the CitySkyline. */
+  activation: number;
+  /** Weekly active users in the account. */
+  wau: number;
+}
+
+export const accounts: AccountRow[] = [
+  {
+    account: "Northwind Labs",
+    short: "Northwind",
+    plan: "Enterprise",
+    mrr: 12400,
+    from: 11200,
+    trend: [11200, 11400, 11350, 11800, 12000, 12100, 12400],
+    mix: [
+      { label: "Dashboards", value: 61 },
+      { label: "Alerts", value: 27 },
+      { label: "Reports", value: 12 },
+    ],
+    maturity: 3,
+    activation: 0.86,
+    wau: 1840,
+  },
+  {
+    account: "Meridian Health",
+    short: "Meridian",
+    plan: "Enterprise",
+    mrr: 9800,
+    from: 10200,
+    trend: [10200, 10100, 9900, 9950, 9800, 9850, 9800],
+    mix: [
+      { label: "Dashboards", value: 44 },
+      { label: "Alerts", value: 38 },
+      { label: "Reports", value: 18 },
+    ],
+    maturity: 2,
+    activation: 0.63,
+    wau: 1210,
+  },
+  {
+    account: "Cobalt Studio",
+    short: "Cobalt",
+    plan: "Growth",
+    mrr: 4200,
+    from: 3600,
+    trend: [3600, 3700, 3850, 3900, 4050, 4100, 4200],
+    mix: [
+      { label: "Dashboards", value: 52 },
+      { label: "Alerts", value: 31 },
+      { label: "Reports", value: 17 },
+    ],
+    maturity: 3,
+    activation: 0.78,
+    wau: 690,
+  },
+  {
+    account: "Fernwood Co-op",
+    short: "Fernwood",
+    plan: "Growth",
+    mrr: 3100,
+    from: 3050,
+    trend: [3050, 3080, 3020, 3060, 3090, 3100, 3100],
+    mix: [
+      { label: "Dashboards", value: 58 },
+      { label: "Alerts", value: 22 },
+      { label: "Reports", value: 20 },
+    ],
+    maturity: 2,
+    activation: 0.55,
+    wau: 430,
+  },
+  {
+    account: "Atlas Freight",
+    short: "Atlas",
+    plan: "Growth",
+    mrr: 2750,
+    from: 2400,
+    trend: [2400, 2500, 2480, 2600, 2650, 2700, 2750],
+    mix: [
+      { label: "Dashboards", value: 47 },
+      { label: "Alerts", value: 41 },
+      { label: "Reports", value: 12 },
+    ],
+    maturity: 2,
+    activation: 0.6,
+    wau: 380,
+  },
+  {
+    account: "Solace Apps",
+    short: "Solace",
+    plan: "Starter",
+    mrr: 890,
+    from: 1200,
+    trend: [1200, 1150, 1080, 1010, 980, 940, 890],
+    mix: [
+      { label: "Dashboards", value: 71 },
+      { label: "Alerts", value: 14 },
+      { label: "Reports", value: 15 },
+    ],
+    maturity: 1,
+    activation: 0.34,
+    wau: 96,
+  },
+  {
+    account: "Brightpath EDU",
+    short: "Brightpath",
+    plan: "Starter",
+    mrr: 640,
+    from: 500,
+    trend: [500, 520, 560, 580, 600, 620, 640],
+    mix: [
+      { label: "Dashboards", value: 49 },
+      { label: "Alerts", value: 33 },
+      { label: "Reports", value: 18 },
+    ],
+    maturity: 1,
+    activation: 0.42,
+    wau: 128,
+  },
+];
+
+/** MRR movement — signed deltas from last month's close. */
+export const mrrMovement = [
+  { label: "New", value: 8200 },
+  { label: "Expansion", value: 5100 },
+  { label: "Reactivation", value: 1200 },
+  { label: "Contraction", value: -2400 },
+  { label: "Churn", value: -3900 },
+];
+
+export const mrrStart = 66800;
+
+/** MRR actual vs. plan over 12 months — for DualSparkline. */
+export const mrrActual = [
+  52000, 54200, 55800, 57100, 59400, 61200, 63000, 65200, 67400, 70600, 72400, 75000,
+];
+export const mrrPlan = [
+  52000, 53500, 55000, 56500, 58200, 60000, 62000, 64200, 66500, 69000, 71500, 74000,
+];
+
+/** Signup → paid conversion funnel. */
+export const signupFunnel = [
+  { label: "Visited", value: 24800 },
+  { label: "Signed up", value: 6420 },
+  { label: "Activated", value: 3980 },
+  { label: "Invited team", value: 2110 },
+  { label: "Paid", value: 1290 },
+];
+
+// ---- Engagement route ----
+
+/** Feature adoption over 16 weeks — three tracked features, stacked. */
+export const featureAdoption = {
+  labels: ["Dashboards", "Alerts", "Reports"],
+  // Prussian-ink accent (matches --mc-accent) + valence green + amber — three
+  // distinct categorical hues, legible in light and dark.
+  colors: ["#2b5f85", "#0e7a5f", "#c2701d"],
+  series: [
+    {
+      label: "Dashboards",
+      values: [
+        2400, 2500, 2650, 2720, 2810, 2900, 3050, 3160, 3240, 3350, 3480, 3560, 3690, 3780, 3900,
+        4020,
+      ],
+    },
+    {
+      label: "Alerts",
+      values: [
+        900, 980, 1040, 1120, 1180, 1260, 1310, 1400, 1470, 1540, 1620, 1700, 1780, 1860, 1940,
+        2030,
+      ],
+    },
+    {
+      label: "Reports",
+      values: [400, 430, 470, 500, 540, 590, 640, 700, 760, 820, 890, 960, 1030, 1110, 1190, 1280],
+    },
+  ],
+};
+
+/** Feature rank over 8 weeks (1 = most-used). Each row is a BumpStrip. */
+export const featureRanks: { name: string; ranks: number[] }[] = [
+  { name: "Dashboards", ranks: [1, 1, 1, 1, 1, 1, 1, 1] },
+  { name: "Alerts", ranks: [3, 3, 2, 2, 2, 2, 2, 2] },
+  { name: "Reports", ranks: [2, 2, 3, 4, 4, 3, 3, 3] },
+  { name: "API", ranks: [5, 4, 4, 3, 3, 4, 4, 4] },
+  { name: "Exports", ranks: [4, 5, 5, 5, 5, 5, 5, 5] },
+  { name: "Integrations", ranks: [6, 6, 6, 6, 6, 6, 6, 6] },
+];
+
+/** Monthly retention cohorts (ragged) — for CohortTriangle. */
+export const cohorts: { label: string; values: number[] }[] = [
+  { label: "Feb", values: [100, 68, 54, 47, 43, 41, 40] },
+  { label: "Mar", values: [100, 65, 52, 45, 41, 39] },
+  { label: "Apr", values: [100, 71, 58, 51, 47] },
+  { label: "May", values: [100, 69, 56, 49] },
+  { label: "Jun", values: [100, 74, 61] },
+  { label: "Jul", values: [100, 76] },
+];
+
+/** Weekly cohort retention — fraction of the signup cohort still active. */
+export const retention = [1.0, 0.62, 0.51, 0.45, 0.41, 0.39, 0.38, 0.375, 0.37];
+export const retentionBenchmark = [1.0, 0.55, 0.42, 0.35, 0.3, 0.27, 0.25, 0.24, 0.235];
+
+/** API p95 latency (ms), 24 hourly readings — a monitored metric for ControlStrip. */
+export const apiLatency = (() => {
+  const s = sample(24, 182, 9, 1337);
+  s[16] = 231;
+  s[17] = 224;
+  return s.map((n) => Math.round(n));
+})();
+
+/** Error rate (%) that stepped up after a bad deploy at index 14 — for ChangePoint. */
+export const errorRate = (() => {
+  const before = sample(14, 0.8, 0.14, 4242);
+  const after = sample(14, 1.9, 0.2, 9091);
+  return [...before, ...after].map((n) => Math.max(0, Math.round(n * 100) / 100));
+})();
+export const errorRateBreak = 14;
+
+export interface FeatureUsage {
+  name: string;
+  usage: number[];
+  weekly: number;
+  from: number;
+  positive: "up" | "down";
+}
+
+export const featureUsage: FeatureUsage[] = [
+  {
+    name: "Dashboards",
+    usage: [3350, 3480, 3560, 3690, 3780, 3900, 4020],
+    weekly: 4020,
+    from: 3350,
+    positive: "up",
+  },
+  {
+    name: "Alerts",
+    usage: [1540, 1620, 1700, 1780, 1860, 1940, 2030],
+    weekly: 2030,
+    from: 1540,
+    positive: "up",
+  },
+  {
+    name: "Reports",
+    usage: [820, 890, 960, 1030, 1110, 1190, 1280],
+    weekly: 1280,
+    from: 820,
+    positive: "up",
+  },
+  {
+    name: "Exports",
+    usage: [640, 700, 690, 720, 710, 705, 700],
+    weekly: 700,
+    from: 640,
+    positive: "up",
+  },
+  {
+    name: "API calls",
+    usage: [18200, 19100, 20400, 21800, 23100, 24600, 26200],
+    weekly: 26200,
+    from: 18200,
+    positive: "up",
+  },
+  {
+    name: "Integrations",
+    usage: [210, 224, 231, 240, 248, 259, 271],
+    weekly: 271,
+    from: 210,
+    positive: "up",
+  },
+];
+
+// ---- Experiments route ----
+
+export interface Experiment {
+  name: string;
+  hypothesis: string;
+  status: "shipped" | "running" | "inconclusive";
+  a: number[];
+  b: number[];
+  positive: "up" | "down";
+  unit: string;
+}
+
+/** A/B experiments — conversion / activation rates per arm (percent points). */
+export const experiments: Experiment[] = [
+  {
+    name: "Guided onboarding checklist",
+    hypothesis: "A step-by-step checklist lifts activation.",
+    status: "shipped",
+    a: sample(48, 58, 6, 21),
+    b: sample(48, 64, 6, 22),
+    positive: "up",
+    unit: "% activated",
+  },
+  {
+    name: "Sticky upgrade nudge",
+    hypothesis: "An in-app nudge lifts trial→paid conversion.",
+    status: "running",
+    a: sample(48, 4.2, 0.7, 31),
+    b: sample(48, 4.7, 0.7, 32),
+    positive: "up",
+    unit: "% converted",
+  },
+  {
+    name: "Simplified pricing page",
+    hypothesis: "Fewer plans reduce checkout drop-off.",
+    status: "inconclusive",
+    a: sample(48, 3.1, 0.8, 41),
+    b: sample(48, 3.2, 0.8, 42),
+    positive: "up",
+    unit: "% checkout",
+  },
+];
+
+/** Page-load time (ms) before/after the perf fix — for ShiftHistogram. */
+export const perfShift = {
+  before: sample(80, 2380, 360, 71).map((n) => Math.max(400, Math.round(n))),
+  after: sample(80, 1560, 280, 72).map((n) => Math.max(400, Math.round(n))),
+};
+
+/** Posterior draws of the activation uplift (pp) — QuantileDots ship decision. */
+export const upliftDraws = sample(200, 5.8, 3.6, 88);
+export const upliftThreshold = 0;
+
+/** Q4 MRR forecast: 12 weeks history + an 8-week cone, vs the $780k target. */
+export const q4History = [520, 540, 535, 560, 580, 590, 610, 625, 640, 660, 675, 690];
+export const q4Forecast = (() => {
+  const mid = [705, 720, 734, 747, 760, 772, 784, 796];
+  const p80 = mid.map((m, i): [number, number] => {
+    const hw = 8 + i * 5;
+    return [Math.round(m - hw), Math.round(m + hw)];
+  });
+  return { mid, p80 };
+})();
+export const q4Target = 780;
+
+// ---- Accounts route ----
+
+/** Dataset sync churn — rows added / removed per import job (DataDiff). */
+export const syncDiff = [
+  { key: "Contacts", added: 1240, removed: 320 },
+  { key: "Events", added: 8600, removed: 540 },
+  { key: "Accounts", added: 210, removed: 45 },
+  { key: "Deals", added: 430, removed: 180 },
+  { key: "Tickets", added: 620, removed: 90 },
+  { key: "Sessions", added: 5100, removed: 1420 },
+];
+
+// ---- Live route ----
+
+/** Rolling 24-point "requests / sec" stream for the live sparkline. */
+export const liveStream = [
+  820, 880, 910, 870, 940, 1020, 990, 1080, 1130, 1090, 1180, 1240, 1210, 1300, 1280, 1360, 1420,
+  1390, 1470, 1520, 1490, 1560, 1610, 1680,
+];
+
+/** Error-budget burn for the live SLO bullet. */
+export const sloBudget = { value: 62, target: 100, bands: [70, 90] };
+
+/** Session duration OHLC (minutes) over the last 14 days. */
+export const sessionOhlc = [
+  { open: 8.2, high: 9.1, low: 7.8, close: 8.9 },
+  { open: 8.9, high: 9.4, low: 8.4, close: 9.0 },
+  { open: 9.0, high: 9.2, low: 8.1, close: 8.4 },
+  { open: 8.4, high: 8.8, low: 8.0, close: 8.7 },
+  { open: 8.7, high: 9.6, low: 8.6, close: 9.5 },
+  { open: 9.5, high: 10.1, low: 9.2, close: 9.8 },
+  { open: 9.8, high: 10.0, low: 9.1, close: 9.3 },
+  { open: 9.3, high: 9.7, low: 8.9, close: 9.6 },
+  { open: 9.6, high: 10.4, low: 9.5, close: 10.2 },
+  { open: 10.2, high: 10.6, low: 9.8, close: 10.0 },
+  { open: 10.0, high: 10.3, low: 9.4, close: 9.7 },
+  { open: 9.7, high: 10.5, low: 9.6, close: 10.4 },
+  { open: 10.4, high: 11.0, low: 10.2, close: 10.8 },
+  { open: 10.8, high: 11.3, low: 10.5, close: 11.1 },
+];
+
+/** Streaming error rate (%) for the live CometTrail. */
+export const liveErrorRate = [
+  0.42, 0.38, 0.51, 0.47, 0.61, 0.55, 0.49, 0.72, 0.68, 0.58, 0.44, 0.39, 0.53, 0.62, 0.71, 0.66,
+  0.54, 0.48, 0.57, 0.63,
+];
+
+/** Ingest queue depth over ~1h for QueueDepth. */
+export const liveQueue = [
+  42, 48, 55, 61, 78, 92, 110, 128, 141, 136, 122, 108, 95, 88, 76, 69, 61, 54, 49, 44, 40, 37, 34,
+  31,
+];
+
+/** Raw throughput samples for DualWindowMeter (rps). */
+export const liveThroughput = [
+  1180, 1210, 1195, 1260, 1310, 1280, 1340, 1420, 1380, 1450, 1510, 1480, 1560, 1620, 1580, 1490,
+  1440, 1390, 1410, 1460, 1520, 1570, 1540, 1600,
+];

--- a/examples/pulse-analytics/app/engagement/page.tsx
+++ b/examples/pulse-analytics/app/engagement/page.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import { StackedArea } from "@microcharts/react/stacked-area/interactive";
+import { RetentionCurve } from "@microcharts/react/retention-curve/interactive";
+import { Sparkline } from "@microcharts/react/sparkline/interactive";
+import { Delta } from "@microcharts/react/delta/interactive";
+import { BumpStrip } from "@microcharts/react/bump-strip/interactive";
+import { CohortTriangle } from "@microcharts/react/cohort-triangle/interactive";
+import { ControlStrip } from "@microcharts/react/control-strip/interactive";
+import { ChangePoint } from "@microcharts/react/change-point/interactive";
+import { Threshold, TargetZone, Callout } from "@microcharts/react/annotations";
+import { Topbar, PageHead, Card, SectionHead, Legend } from "../components/ui";
+import {
+  featureAdoption,
+  featureRanks,
+  cohorts,
+  apiLatency,
+  errorRate,
+  errorRateBreak,
+  retention,
+  retentionBenchmark,
+  featureUsage,
+  compact,
+  ms,
+} from "../data";
+
+const fill = { width: "100%", height: "auto" } as const;
+// Cell-sized charts render at natural size (see page.tsx note) — stretching
+// them to 100% magnifies the viewBox and balloons the in-cell labels.
+const centered = {
+  maxWidth: "100%",
+  height: "auto",
+  display: "block",
+  margin: "0 auto",
+} as const;
+const rate1 = { maximumFractionDigits: 1 } as const;
+
+export default function EngagementPage() {
+  return (
+    <>
+      <Topbar title="Engagement" crumb="Pulse" />
+      <div className="content">
+        <PageHead
+          index="03"
+          eyebrow="Product usage"
+          title="Engagement"
+          sub="What people do after they sign up — which features win, how cohorts retain, and where the system strains."
+        />
+
+        <div className="grid two-col section">
+          <Card
+            title="Feature adoption"
+            sub="Weekly active · 16 weeks"
+            className="hover reveal reveal-1"
+          >
+            <StackedArea
+              animate
+              data={featureAdoption.series}
+              colors={featureAdoption.colors}
+              label="last"
+              width={480}
+              height={200}
+              format={compact}
+              style={fill}
+              title="Weekly active users by feature"
+            />
+            <Legend
+              items={featureAdoption.labels.map((label, i) => ({
+                label,
+                color: featureAdoption.colors[i],
+              }))}
+            />
+          </Card>
+
+          <Card
+            title="Cohort retention"
+            sub="vs. industry benchmark"
+            className="hover reveal reveal-2"
+          >
+            <RetentionCurve
+              animate
+              data={retention}
+              benchmark={retentionBenchmark}
+              label="last"
+              unit="week"
+              width={480}
+              height={200}
+              style={fill}
+              title="Weekly cohort retention against the industry benchmark"
+            />
+          </Card>
+        </div>
+
+        <SectionHead
+          index="§ 01"
+          title="Feature rank"
+          sub="Position by weekly active · last 8 weeks"
+        />
+        <Card className="section hover reveal reveal-1">
+          <div className="rank-list">
+            {featureRanks.map((f) => (
+              <div key={f.name} className="rank-row">
+                <span className="rank-name">{f.name}</span>
+                <BumpStrip
+                  animate
+                  data={f.ranks}
+                  maxRank={featureRanks.length}
+                  label="ends"
+                  dots="changes"
+                  width={960}
+                  height={34}
+                  style={fill}
+                  summary={`${f.name} rank over the last 8 weeks`}
+                />
+              </div>
+            ))}
+          </div>
+          <p className="chart-note">
+            Dashboards has held #1 all quarter; <b>Alerts overtook Reports</b> in week 3 and
+            hasn&apos;t given the spot back.
+          </p>
+        </Card>
+
+        <SectionHead
+          index="§ 02"
+          title="Under load"
+          sub="Where the system strains when usage climbs"
+        />
+        <div className="grid two-col section">
+          <Card
+            title="API p95 latency"
+            sub="Hourly · milliseconds"
+            className="hover reveal reveal-1"
+          >
+            <ControlStrip
+              animate
+              data={apiLatency}
+              format={ms}
+              width={480}
+              height={180}
+              style={fill}
+              title="API p95 latency with statistical process-control limits"
+            >
+              <Threshold y={200} label="SLO" />
+              <TargetZone y={[120, 180]} label="comfort" />
+            </ControlStrip>
+            <p className="chart-note">
+              Two readings breached the <b>±3σ control band</b> during the 09:00 deploy — inside the
+              200ms SLO, but worth a look.
+            </p>
+          </Card>
+
+          <Card
+            title="Error rate"
+            sub="Percent · stepped after deploy"
+            className="hover reveal reveal-2"
+          >
+            <ChangePoint
+              animate
+              data={errorRate}
+              breaks={[errorRateBreak]}
+              label="delta"
+              format={rate1}
+              width={480}
+              height={180}
+              style={fill}
+              title="Error rate with a detected regime shift after the deploy"
+            >
+              <Callout x={errorRateBreak} y={errorRate[errorRateBreak]} label="regime" />
+            </ChangePoint>
+            <p className="chart-note">
+              A bad deploy stepped the baseline error rate from <b>~0.8% to ~1.9%</b>. The regime
+              shift is the story, not any single spike.
+            </p>
+          </Card>
+        </div>
+
+        <SectionHead
+          index="§ 03"
+          title="Who stays"
+          sub="Retention by cohort, and usage per feature"
+        />
+        <Card
+          title="Retention cohorts"
+          sub="Monthly · % still active"
+          className="section hover reveal reveal-1"
+        >
+          <CohortTriangle
+            animate
+            data={cohorts}
+            unit="month"
+            highlight="Apr"
+            cell={38}
+            gap={5}
+            style={centered}
+            title="Monthly signup cohorts by retention age"
+          />
+          <p className="chart-note">
+            The <b>April cohort</b> retains best at equal maturity — it landed just after the guided
+            onboarding shipped.
+          </p>
+        </Card>
+
+        <Card
+          title="Feature usage"
+          sub="Weekly, per feature · own scale each"
+          className="hover reveal reveal-2"
+        >
+          <div className="grid feature-grid">
+            {featureUsage.map((f) => (
+              <div key={f.name} className="feature-cell">
+                <div className="feature-top">
+                  <span className="feature-name">{f.name}</span>
+                  <Delta value={f.weekly} from={f.from} positive={f.positive} summary={false} />
+                </div>
+                <span className="feature-num">{f.weekly.toLocaleString("en-US")}</span>
+                <Sparkline
+                  animate
+                  data={f.usage}
+                  dots="auto"
+                  width={320}
+                  height={40}
+                  style={fill}
+                  summary={`${f.name} weekly usage trend`}
+                />
+              </div>
+            ))}
+          </div>
+        </Card>
+      </div>
+    </>
+  );
+}

--- a/examples/pulse-analytics/app/experiments/page.tsx
+++ b/examples/pulse-analytics/app/experiments/page.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { ABStrips } from "@microcharts/react/ab-strips/interactive";
+import { ShiftHistogram } from "@microcharts/react/shift-histogram/interactive";
+import { QuantileDots } from "@microcharts/react/quantile-dots/interactive";
+import { ForecastCone } from "@microcharts/react/forecast-cone/interactive";
+import { Topbar, PageHead, Card, SectionHead } from "../components/ui";
+import {
+  experiments,
+  perfShift,
+  upliftDraws,
+  upliftThreshold,
+  q4History,
+  q4Forecast,
+  q4Target,
+  compact,
+  ms,
+} from "../data";
+
+const fill = { width: "100%", height: "auto" } as const;
+const rate1 = { maximumFractionDigits: 1 } as const;
+
+export default function ExperimentsPage() {
+  return (
+    <>
+      <Topbar title="Experiments" crumb="Pulse" />
+      <div className="content">
+        <PageHead
+          index="04"
+          eyebrow="Growth · testing"
+          title="Experiments"
+          sub="Every bet we're running, read honestly — the overlap is the answer, and the uncertainty is on the chart."
+        />
+
+        <Card
+          title="Will we hit the Q4 target?"
+          sub={`Target $${q4Target}k MRR`}
+          className="section hover reveal reveal-1"
+        >
+          <ForecastCone
+            animate
+            data={q4History}
+            forecast={q4Forecast}
+            target={q4Target}
+            unit="week"
+            label="landing"
+            format={compact}
+            width={1040}
+            height={250}
+            style={fill}
+            title="Q4 MRR forecast with an 80% prediction band against the target"
+          />
+          <p className="chart-note">
+            The median projection lands just above target, but the{" "}
+            <b>80% band still straddles it</b> — we clear Q4 only if expansion holds. Not a lock.
+          </p>
+        </Card>
+
+        <SectionHead
+          index="§ 01"
+          title="Running experiments"
+          sub="Control vs. variant · distribution, not a single number"
+        />
+        <div className="grid three-col section">
+          {experiments.map((e, i) => (
+            <Card key={e.name} className={`exp-card hover reveal reveal-${i + 1}`}>
+              <div className="exp-top">
+                <div>
+                  <p className="exp-name">{e.name}</p>
+                  <p className="exp-hyp">{e.hypothesis}</p>
+                </div>
+                <span className={`exp-status ${e.status}`}>{e.status}</span>
+              </div>
+              <ABStrips
+                animate
+                data={{ a: e.a, b: e.b }}
+                seriesLabels={["Control", "Variant"]}
+                positive={e.positive}
+                label="delta"
+                format={rate1}
+                width={360}
+                height={110}
+                style={fill}
+                title={`${e.name}: control versus variant, ${e.unit}`}
+              />
+            </Card>
+          ))}
+        </div>
+
+        <SectionHead
+          index="§ 02"
+          title="Ship decision"
+          sub="The perf fix, and the odds it's real"
+        />
+        <div className="grid two-col">
+          <Card
+            title="Page load time"
+            sub="Before vs. after the fix · ms"
+            className="hover reveal reveal-1"
+          >
+            <ShiftHistogram
+              animate
+              data={perfShift}
+              seriesLabels={["before", "after"]}
+              label="shift"
+              format={ms}
+              width={480}
+              height={200}
+              style={fill}
+              title="Page-load time distribution, before and after the perf fix"
+            />
+            <p className="chart-note">
+              The whole distribution moved left — a <b>~820ms median shift</b>, not a mean nudged by
+              outliers. That&apos;s a real win.
+            </p>
+          </Card>
+
+          <Card
+            title="Activation uplift"
+            sub="Posterior · will it beat zero?"
+            className="hover reveal reveal-2"
+          >
+            <QuantileDots
+              animate
+              data={upliftDraws}
+              threshold={upliftThreshold}
+              side="above"
+              count={20}
+              label="count"
+              format={rate1}
+              width={480}
+              height={200}
+              style={fill}
+              title="Posterior draws of the activation uplift versus the break-even line"
+            />
+            <p className="chart-note">
+              Count the dots past zero: roughly <b>19 in 20</b> draws show a positive uplift. Strong
+              evidence to ship.
+            </p>
+          </Card>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/examples/pulse-analytics/app/globals.css
+++ b/examples/pulse-analytics/app/globals.css
@@ -1,0 +1,1179 @@
+/* Pulse — a product-analytics instrument.
+   Design language: a "drafting-room instrument" — Swiss annual report crossed with
+   a measurement tool. Cool drafting paper, one prussian-ink accent used sparingly,
+   Zodiak serif mastheads, Switzer body, Spline Sans Mono figures.
+
+   FONT TRAP: --mc-font / --mc-font-numeric MUST be a clean sans / mono stack, else
+   SVG chart labels inherit the Zodiak serif. They are pinned in :root below.
+   VALENCE: never recolor --mc-pos / --mc-neg — only --mc-accent is retuned. */
+
+:root {
+  /* ---- Type stacks ---- */
+  --font-display: "Zodiak", Georgia, "Times New Roman", serif;
+  --font-sans: "Switzer", ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+  --font-mono: "Spline Sans Mono", ui-monospace, "SF Mono", Menlo, monospace;
+
+  /* charts: keep text legible (sans) and figures tabular (mono); retune accent only */
+  --mc-font: var(--font-sans);
+  --mc-font-numeric: var(--font-mono);
+  --mc-accent: oklch(0.44 0.104 244);
+
+  /* ---- Paper & ink (drafting-room, cool-neutral, tinted toward the prussian hue) ---- */
+  --paper: oklch(0.968 0.005 246);
+  --surface: oklch(0.995 0.0018 246);
+  --surface-2: oklch(0.978 0.004 246);
+  --ink: oklch(0.245 0.021 254);
+  --ink-soft: oklch(0.468 0.019 254);
+  --ink-faint: oklch(0.615 0.016 252);
+  --line: oklch(0.902 0.009 248);
+  --line-soft: oklch(0.938 0.006 248);
+
+  /* ---- The one accent: prussian ink, used at ~10% ---- */
+  --accent: oklch(0.44 0.104 244);
+  --accent-strong: oklch(0.36 0.108 244);
+  --accent-ink: oklch(0.42 0.108 244);
+  --accent-soft: oklch(0.945 0.028 244);
+  --accent-line: oklch(0.8 0.055 244);
+
+  /* ---- Valence (mirror microcharts — never used to recolor charts, only chrome accents) ---- */
+  --pos: #0e7a5f;
+  --neg: #bd4b2d;
+  --warn: oklch(0.56 0.11 62);
+  --pos-wash: oklch(0.95 0.035 165);
+  --warn-wash: oklch(0.945 0.04 74);
+
+  /* ---- The spine (constant dark rail, both schemes — the "book spine") ---- */
+  --spine: oklch(0.205 0.021 256);
+  --spine-2: oklch(0.245 0.02 256);
+  --spine-ink: oklch(0.8 0.012 250);
+  --spine-faint: oklch(0.556 0.017 252);
+  --spine-line: oklch(0.315 0.019 254);
+  --spine-accent: oklch(0.74 0.1 246);
+
+  /* ---- Type scale (fixed, editorial, ≥1.25 ratio) ---- */
+  --t-11: 11px;
+  --t-12: 12px;
+  --t-13: 13px;
+  --t-15: 15px;
+  --t-19: 19px;
+  --t-24: 24px;
+  --t-31: 31px;
+  --t-40: 40px;
+
+  /* ---- Space (4pt scale, semantic) ---- */
+  --space-2xs: 4px;
+  --space-xs: 8px;
+  --space-sm: 12px;
+  --space-md: 16px;
+  --space-lg: 24px;
+  --space-xl: 32px;
+  --space-2xl: 48px;
+
+  --radius: 10px;
+  --radius-sm: 7px;
+  --shadow-card: 0 1px 1px oklch(0.24 0.02 254 / 0.03), 0 1px 3px oklch(0.24 0.02 254 / 0.05);
+  --shadow-lift:
+    0 12px 30px -12px oklch(0.24 0.03 254 / 0.16), 0 2px 6px oklch(0.24 0.03 254 / 0.06);
+
+  --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-sans);
+  background: var(--paper);
+  color: var(--ink);
+  font-size: 14px;
+  line-height: 1.55;
+  font-feature-settings: "ss01", "cv01";
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+.num,
+.tnum {
+  font-variant-numeric: tabular-nums;
+}
+
+.mono {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
+}
+
+/* ============================================================
+   App shell — a book: dark spine + paper body
+   ============================================================ */
+
+.shell {
+  display: grid;
+  grid-template-columns: 244px 1fr;
+  min-height: 100vh;
+}
+
+.sidebar {
+  background: var(--spine);
+  color: var(--spine-ink);
+  display: flex;
+  flex-direction: column;
+  padding: 26px 20px 20px;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  z-index: 20;
+  border-right: 1px solid oklch(0 0 0 / 0.35);
+}
+
+/* ---- Nameplate: typographic, no gradient chip ---- */
+.brand {
+  display: block;
+  padding: 0 4px 22px;
+  margin-bottom: 4px;
+  border-bottom: 1px solid var(--spine-line);
+}
+.brand-mark {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+.brand-name {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 26px;
+  letter-spacing: -0.015em;
+  color: #fff;
+  line-height: 1;
+}
+.brand-reg {
+  font-size: 11px;
+  color: var(--spine-accent);
+  font-weight: 600;
+  transform: translateY(-2px);
+}
+.brand-sub {
+  display: block;
+  margin-top: 9px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--spine-faint);
+}
+
+/* ---- Contents: a numbered index, not a nav rail ---- */
+.nav {
+  display: flex;
+  flex-direction: column;
+  margin-top: 20px;
+}
+
+.nav-label {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--spine-faint);
+  padding: 0 4px 10px;
+}
+
+.nav a {
+  position: relative;
+  display: grid;
+  grid-template-columns: 22px 1fr auto;
+  align-items: baseline;
+  gap: 12px;
+  padding: 10px 4px;
+  color: var(--spine-ink);
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  border-top: 1px solid var(--spine-line);
+  transition:
+    color 0.16s ease,
+    padding-left 0.18s var(--ease-out);
+}
+.nav a:first-of-type {
+  border-top: none;
+}
+.nav-index {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--spine-faint);
+  font-variant-numeric: tabular-nums;
+  transition: color 0.16s ease;
+}
+.nav-tick {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: transparent;
+  align-self: center;
+  transition:
+    background 0.16s ease,
+    transform 0.2s var(--ease-out);
+  transform: scale(0.5);
+}
+
+.nav a:hover {
+  color: #fff;
+  padding-left: 8px;
+}
+.nav a:hover .nav-index {
+  color: var(--spine-accent);
+}
+.nav a:active {
+  padding-left: 5px;
+}
+.nav a:focus-visible {
+  outline: 2px solid var(--spine-accent);
+  outline-offset: 2px;
+  border-radius: 3px;
+}
+
+.nav a[aria-current="page"] {
+  color: #fff;
+}
+.nav a[aria-current="page"] .nav-index {
+  color: var(--spine-accent);
+  font-weight: 600;
+}
+.nav a[aria-current="page"] .nav-tick {
+  background: var(--spine-accent);
+  transform: scale(1);
+}
+
+.sidebar-foot {
+  margin-top: auto;
+  padding-top: 16px;
+  border-top: 1px solid var(--spine-line);
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  color: var(--spine-faint);
+  font-size: 12px;
+}
+.avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  background: var(--spine-2);
+  border: 1px solid var(--spine-line);
+  color: #fff;
+  display: grid;
+  place-items: center;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 500;
+  flex: none;
+}
+.sidebar-foot-name {
+  color: oklch(0.9 0.01 250);
+  font-weight: 600;
+}
+
+/* ============================================================
+   Main column
+   ============================================================ */
+
+.main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.topbar {
+  height: 56px;
+  border-bottom: 1px solid var(--line);
+  background: var(--paper);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 clamp(18px, 4vw, 40px);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+.topbar-title {
+  font-family: var(--font-mono);
+  font-size: var(--t-12);
+  letter-spacing: 0.02em;
+  color: var(--ink-soft);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.topbar-crumb {
+  color: var(--ink-faint);
+}
+.topbar-sep {
+  color: var(--line);
+}
+.topbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.pill {
+  font-family: var(--font-mono);
+  font-size: var(--t-11);
+  letter-spacing: 0.02em;
+  color: var(--ink-soft);
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 5px 10px;
+  white-space: nowrap;
+}
+.pill-accent {
+  border-color: var(--accent-line);
+  background: var(--accent-soft);
+  color: var(--accent-ink);
+  font-weight: 600;
+}
+
+.content {
+  padding: clamp(22px, 3.2vw, 44px) clamp(18px, 4vw, 48px) 64px;
+  max-width: 1240px;
+  width: 100%;
+}
+
+/* ---- Page masthead: index · eyebrow · serif title · lead · rule ---- */
+.page-head {
+  margin-bottom: var(--space-xl);
+}
+.page-head-top {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+.page-index {
+  font-family: var(--font-mono);
+  font-size: var(--t-12);
+  font-weight: 600;
+  color: var(--accent-ink);
+  font-variant-numeric: tabular-nums;
+  padding: 3px 7px;
+  border: 1px solid var(--accent-line);
+  border-radius: 5px;
+  line-height: 1;
+}
+.page-head .eyebrow {
+  font-family: var(--font-mono);
+  font-size: var(--t-11);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--ink-faint);
+}
+.page-head h1 {
+  font-family: var(--font-display);
+  font-size: clamp(31px, 4.6vw, 46px);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 0 0 10px;
+  line-height: 1.02;
+}
+.page-head .lead {
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: clamp(15px, 1.6vw, var(--t-19));
+  line-height: 1.5;
+  max-width: 62ch;
+}
+.page-rule {
+  height: 1px;
+  background: var(--ink);
+  opacity: 0.85;
+  margin-top: var(--space-lg);
+}
+
+/* ---- Section head: number · title · note · trailing hairline ---- */
+.section-head {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+  margin: var(--space-xl) 0 var(--space-md);
+}
+.section-index {
+  font-family: var(--font-mono);
+  font-size: var(--t-12);
+  color: var(--accent-ink);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  flex: none;
+}
+.section-head h2 {
+  font-family: var(--font-display);
+  font-size: var(--t-24);
+  font-weight: 700;
+  letter-spacing: -0.015em;
+  margin: 0;
+  flex: none;
+}
+.section-head .section-note {
+  font-family: var(--font-mono);
+  font-size: var(--t-11);
+  color: var(--ink-faint);
+  letter-spacing: 0.01em;
+  flex: none;
+  white-space: nowrap;
+}
+.section-head .rule-fill {
+  flex: 1;
+  height: 1px;
+  background: var(--line);
+  align-self: center;
+  min-width: 20px;
+}
+
+/* ============================================================
+   Cards & grids
+   ============================================================ */
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-card);
+  padding: 20px;
+  min-width: 0;
+  transition:
+    box-shadow 0.2s var(--ease-out),
+    transform 0.2s var(--ease-out),
+    border-color 0.2s var(--ease-out);
+}
+.card.hover:hover {
+  box-shadow: var(--shadow-lift);
+  border-color: var(--accent-line);
+}
+.card:focus-within {
+  box-shadow: var(--shadow-lift);
+  border-color: var(--accent-line);
+}
+
+.card-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 16px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--line-soft);
+}
+.card-title {
+  font-size: var(--t-13);
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+}
+.card-sub {
+  font-family: var(--font-mono);
+  font-size: var(--t-11);
+  letter-spacing: 0.01em;
+  color: var(--ink-faint);
+  white-space: nowrap;
+}
+
+.chart-note {
+  margin: 14px 0 0;
+  font-size: var(--t-13);
+  color: var(--ink-soft);
+  line-height: 1.5;
+  max-width: 68ch;
+}
+.chart-note b {
+  color: var(--ink);
+  font-weight: 600;
+}
+
+.grid {
+  display: grid;
+  gap: 18px;
+}
+.stack-gap {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  min-width: 0;
+}
+.two-col {
+  grid-template-columns: 1fr 1fr;
+}
+.three-col {
+  grid-template-columns: repeat(3, 1fr);
+}
+.section {
+  margin-bottom: var(--space-lg);
+}
+
+.bento {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 18px;
+}
+.c3 {
+  grid-column: span 3;
+}
+.c4 {
+  grid-column: span 4;
+}
+.c5 {
+  grid-column: span 5;
+}
+.c6 {
+  grid-column: span 6;
+}
+.c7 {
+  grid-column: span 7;
+}
+.c8 {
+  grid-column: span 8;
+}
+.c9 {
+  grid-column: span 9;
+}
+.c12 {
+  grid-column: span 12;
+}
+
+/* ============================================================
+   KPI strip — one instrument readout divided by hairlines,
+   not four identical cards
+   ============================================================ */
+
+.kpi-strip {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-card);
+  overflow: hidden;
+}
+.kpi-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 18px 20px;
+  border-left: 1px solid var(--line-soft);
+  transition: background 0.18s ease;
+}
+.kpi-cell:first-child {
+  border-left: none;
+}
+.kpi-cell:hover {
+  background: var(--surface-2);
+}
+.kpi-label {
+  font-size: var(--t-12);
+  color: var(--ink-soft);
+  font-weight: 500;
+  letter-spacing: -0.003em;
+}
+.kpi-value-row {
+  display: flex;
+  align-items: baseline;
+  gap: 9px;
+  flex-wrap: wrap;
+}
+.kpi-value {
+  font-family: var(--font-mono);
+  font-size: 27px;
+  font-weight: 500;
+  letter-spacing: -0.03em;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+.kpi-spark {
+  margin-top: 2px;
+}
+
+/* ---- Stat block (eyebrow + hero figure) ---- */
+.stat {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  justify-content: space-between;
+  min-height: 100%;
+}
+.stat-eyebrow {
+  font-family: var(--font-mono);
+  font-size: var(--t-11);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--ink-faint);
+}
+.stat-foot {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--t-12);
+  color: var(--ink-soft);
+}
+
+/* ============================================================
+   Tables
+   ============================================================ */
+
+.table-wrap {
+  overflow-x: auto;
+  margin: 0 -4px;
+  padding: 0 4px;
+}
+.rev-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-variant-numeric: tabular-nums;
+  min-width: 660px;
+}
+.rev-table th {
+  text-align: left;
+  font-family: var(--font-mono);
+  font-size: var(--t-11);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--ink-faint);
+  font-weight: 500;
+  padding: 0 12px 11px;
+  border-bottom: 1px solid var(--ink);
+  white-space: nowrap;
+}
+.rev-table th.num,
+.rev-table td.num {
+  text-align: right;
+}
+.rev-table td {
+  padding: 13px 12px;
+  border-bottom: 1px solid var(--line-soft);
+  font-size: var(--t-13);
+  vertical-align: middle;
+}
+.rev-table tbody tr {
+  transition: background 0.12s ease;
+}
+.rev-table tbody tr:hover {
+  background: var(--surface-2);
+}
+.rev-table tr:last-child td {
+  border-bottom: none;
+}
+.rev-account {
+  font-weight: 600;
+  letter-spacing: -0.005em;
+}
+
+.plan-tag {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: var(--t-11);
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  padding: 3px 8px;
+  border-radius: 5px;
+  border: 1px solid var(--accent-line);
+  background: var(--accent-soft);
+  color: var(--accent-ink);
+  white-space: nowrap;
+}
+.plan-tag.starter {
+  background: var(--surface-2);
+  border-color: var(--line);
+  color: var(--ink-soft);
+}
+.plan-tag.growth {
+  background: var(--pos-wash);
+  border-color: color-mix(in oklch, var(--pos) 34%, transparent);
+  color: var(--pos);
+}
+
+.cell-trend {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  justify-content: flex-end;
+}
+.cell-chart {
+  display: block;
+  min-width: 90px;
+}
+.mc-inline {
+  display: inline-flex;
+  vertical-align: middle;
+  line-height: 0;
+}
+
+/* ============================================================
+   Feature usage grid
+   ============================================================ */
+.feature-grid {
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1px;
+  background: var(--line-soft);
+  border: 1px solid var(--line-soft);
+  border-radius: var(--radius-sm);
+  /* Readout chips must escape the cell — don't clip hover tooltips. */
+  overflow: visible;
+}
+.feature-cell {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  background: var(--surface);
+  transition: background 0.15s ease;
+  min-width: 0;
+  overflow: visible;
+}
+.feature-cell:hover {
+  background: var(--surface-2);
+}
+.feature-top {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+}
+.feature-name {
+  font-size: var(--t-13);
+  font-weight: 600;
+}
+.feature-num {
+  font-family: var(--font-mono);
+  font-size: var(--t-19);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
+}
+.feature-spark-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1px;
+  background: var(--line-soft);
+  border: 1px solid var(--line-soft);
+  border-radius: 0 0 var(--radius-sm) var(--radius-sm);
+  overflow: hidden;
+}
+.feature-spark-item {
+  background: var(--surface);
+  padding: 2px 16px 14px;
+  box-sizing: border-box;
+}
+
+/* ============================================================
+   Rank / bump list
+   ============================================================ */
+.rank-list {
+  display: flex;
+  flex-direction: column;
+}
+.rank-row {
+  display: grid;
+  grid-template-columns: 108px 1fr;
+  align-items: center;
+  gap: 14px;
+  padding: 9px 0;
+  border-top: 1px solid var(--line-soft);
+}
+.rank-row:first-child {
+  border-top: none;
+}
+.rank-name {
+  font-size: var(--t-13);
+  font-weight: 600;
+}
+
+/* ============================================================
+   Experiment card
+   ============================================================ */
+.exp-card {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.exp-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+.exp-name {
+  font-size: var(--t-15);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0 0 4px;
+}
+.exp-hyp {
+  font-size: var(--t-12);
+  color: var(--ink-soft);
+  margin: 0;
+  max-width: 46ch;
+  line-height: 1.45;
+}
+.exp-status {
+  font-family: var(--font-mono);
+  font-size: var(--t-11);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 3px 9px;
+  border-radius: 5px;
+  border: 1px solid transparent;
+  white-space: nowrap;
+  flex: none;
+}
+.exp-status.shipped {
+  background: var(--pos-wash);
+  border-color: color-mix(in oklch, var(--pos) 30%, transparent);
+  color: var(--pos);
+}
+.exp-status.running {
+  background: var(--accent-soft);
+  border-color: var(--accent-line);
+  color: var(--accent-ink);
+}
+.exp-status.inconclusive {
+  background: var(--warn-wash);
+  border-color: color-mix(in oklch, var(--warn) 30%, transparent);
+  color: var(--warn);
+}
+
+/* ============================================================
+   Legend
+   ============================================================ */
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-top: 14px;
+}
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: var(--t-12);
+  color: var(--ink-soft);
+}
+.legend-swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  flex: none;
+}
+
+/* ============================================================
+   Live route
+   ============================================================ */
+.live-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--pos);
+  box-shadow: 0 0 0 0 color-mix(in oklch, var(--pos) 50%, transparent);
+}
+.live-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-family: var(--font-mono);
+  font-size: var(--t-11);
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--pos);
+}
+.big-metric {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+}
+.big-metric .num {
+  font-family: var(--font-mono);
+  font-size: 44px;
+  font-weight: 500;
+  letter-spacing: -0.035em;
+  font-variant-numeric: tabular-nums;
+}
+.picker-readout {
+  margin: 10px 0 0;
+  font-family: var(--font-mono);
+  font-size: var(--t-11);
+  color: var(--ink-faint);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ============================================================
+   Motion — staggered measured entrance
+   ============================================================ */
+@media (prefers-reduced-motion: no-preference) {
+  .reveal {
+    animation: reveal 0.6s var(--ease-out) both;
+  }
+  .reveal-1 {
+    animation-delay: 0.04s;
+  }
+  .reveal-2 {
+    animation-delay: 0.1s;
+  }
+  .reveal-3 {
+    animation-delay: 0.16s;
+  }
+  .reveal-4 {
+    animation-delay: 0.22s;
+  }
+  .reveal-5 {
+    animation-delay: 0.28s;
+  }
+  .reveal-6 {
+    animation-delay: 0.34s;
+  }
+
+  @keyframes reveal {
+    from {
+      opacity: 0;
+      transform: translateY(12px);
+    }
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
+
+  .page-rule {
+    transform-origin: left center;
+    animation: draw-rule 0.8s var(--ease-out) both;
+    animation-delay: 0.15s;
+  }
+  @keyframes draw-rule {
+    from {
+      transform: scaleX(0);
+    }
+    to {
+      transform: scaleX(1);
+    }
+  }
+
+  .live-dot {
+    animation: live-pulse 2s infinite;
+  }
+  @keyframes live-pulse {
+    0% {
+      box-shadow: 0 0 0 0 color-mix(in oklch, var(--pos) 42%, transparent);
+    }
+    70% {
+      box-shadow: 0 0 0 7px color-mix(in oklch, var(--pos) 0%, transparent);
+    }
+    100% {
+      box-shadow: 0 0 0 0 color-mix(in oklch, var(--pos) 0%, transparent);
+    }
+  }
+}
+
+/* ============================================================
+   Responsive: 1280 base → 900 tablet → 560 mobile
+   ============================================================ */
+@media (max-width: 900px) {
+  .shell {
+    grid-template-columns: 1fr;
+  }
+  .sidebar {
+    position: sticky;
+    top: 0;
+    height: auto;
+    flex-direction: row;
+    align-items: center;
+    gap: 4px;
+    padding: 10px 14px;
+    overflow-x: auto;
+    border-right: none;
+    border-bottom: 1px solid oklch(0 0 0 / 0.35);
+  }
+  .brand {
+    padding: 0 14px 0 4px;
+    margin: 0;
+    border-bottom: none;
+    border-right: 1px solid var(--spine-line);
+    flex: none;
+  }
+  .brand-sub {
+    display: none;
+  }
+  .brand-name {
+    font-size: 20px;
+  }
+  .nav {
+    flex: 1;
+    min-width: 0;
+    flex-direction: row;
+    align-items: center;
+    margin-top: 0;
+    gap: 2px;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+  .nav::-webkit-scrollbar {
+    display: none;
+  }
+  .nav-label,
+  .sidebar-foot,
+  .nav-tick {
+    display: none;
+  }
+  .nav a {
+    grid-template-columns: auto auto;
+    gap: 7px;
+    border-top: none;
+    padding: 8px 12px;
+    border-radius: 7px;
+    white-space: nowrap;
+  }
+  .nav a:hover {
+    padding-left: 12px;
+    background: rgba(255, 255, 255, 0.05);
+  }
+  .nav a[aria-current="page"] {
+    background: rgba(255, 255, 255, 0.08);
+  }
+
+  .kpi-strip {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .kpi-cell:nth-child(3) {
+    border-left: none;
+  }
+  .kpi-cell:nth-child(n + 3) {
+    border-top: 1px solid var(--line-soft);
+  }
+  .two-col,
+  .three-col,
+  .feature-grid {
+    grid-template-columns: 1fr;
+  }
+  .three-col.keep-2 {
+    grid-template-columns: 1fr 1fr;
+  }
+  .c3,
+  .c4,
+  .c5 {
+    grid-column: span 6;
+  }
+  .c6,
+  .c7,
+  .c8,
+  .c9 {
+    grid-column: span 12;
+  }
+}
+
+@media (max-width: 560px) {
+  .kpi-strip {
+    grid-template-columns: 1fr;
+  }
+  .kpi-cell {
+    border-left: none;
+    border-top: 1px solid var(--line-soft);
+  }
+  .kpi-cell:first-child {
+    border-top: none;
+  }
+  .three-col.keep-2 {
+    grid-template-columns: 1fr;
+  }
+  .bento > [class*="c"] {
+    grid-column: span 12;
+  }
+  .rank-row {
+    grid-template-columns: 88px 1fr;
+  }
+  .section-head {
+    flex-wrap: wrap;
+    row-gap: 6px;
+  }
+  .section-head .rule-fill {
+    display: none;
+  }
+  .card {
+    padding: 16px;
+  }
+  .feature-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+/* ============================================================
+   Dark mode — a blueprint at night. microcharts auto-adapts under
+   prefers-color-scheme:dark (zero-specificity :where), so the chrome
+   must adapt too, and --mc-accent must lighten to stay visible.
+   Kept last so equal-specificity overrides win.
+   ============================================================ */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --mc-accent: oklch(0.72 0.096 246);
+
+    --paper: oklch(0.185 0.016 256);
+    --surface: oklch(0.223 0.017 256);
+    --surface-2: oklch(0.248 0.017 256);
+    --ink: oklch(0.925 0.008 250);
+    --ink-soft: oklch(0.71 0.014 250);
+    --ink-faint: oklch(0.55 0.015 252);
+    --line: oklch(0.315 0.016 254);
+    --line-soft: oklch(0.268 0.015 254);
+
+    --accent: oklch(0.72 0.096 246);
+    --accent-strong: oklch(0.8 0.09 246);
+    --accent-ink: oklch(0.78 0.096 246);
+    --accent-soft: oklch(0.3 0.05 246);
+    --accent-line: oklch(0.42 0.07 246);
+
+    --pos-wash: oklch(0.32 0.05 165);
+    --warn-wash: oklch(0.33 0.05 74);
+
+    --spine: oklch(0.15 0.014 256);
+    --spine-2: oklch(0.22 0.016 256);
+    --spine-line: oklch(0.28 0.016 254);
+
+    --shadow-card: 0 1px 2px oklch(0 0 0 / 0.4), 0 1px 3px oklch(0 0 0 / 0.35);
+    --shadow-lift: 0 14px 34px -12px oklch(0 0 0 / 0.65), 0 2px 8px oklch(0 0 0 / 0.45);
+  }
+  .page-rule {
+    opacity: 0.6;
+  }
+  .avatar {
+    background: var(--spine-2);
+  }
+}
+
+/* ============================================================
+   Print — the report as it was always meant to be read
+   ============================================================ */
+@media print {
+  .sidebar,
+  .topbar {
+    display: none;
+  }
+  .shell {
+    grid-template-columns: 1fr;
+  }
+  body {
+    background: #fff;
+  }
+  .card {
+    box-shadow: none;
+    break-inside: avoid;
+  }
+  .reveal {
+    animation: none;
+  }
+}

--- a/examples/pulse-analytics/app/layout.tsx
+++ b/examples/pulse-analytics/app/layout.tsx
@@ -1,0 +1,67 @@
+import type { ReactNode } from "react";
+import "@microcharts/react/styles.css";
+import "./globals.css";
+import { Nav } from "./components/nav";
+import { MotionInit } from "./motion-init";
+
+export const metadata = {
+  title: "Pulse — Product Analytics",
+  description: "Example dashboard showcasing @microcharts/react in Next.js RSC.",
+  robots: { index: false, follow: false },
+};
+
+// Root layout is a Server Component. It renders the shared app shell and mounts
+// <MotionInit /> once so client-side `animate` works without importing motion
+// from any Server Component.
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link rel="preconnect" href="https://api.fontshare.com" />
+        <link rel="preconnect" href="https://cdn.fontshare.com" crossOrigin="anonymous" />
+        <link
+          rel="stylesheet"
+          href="https://api.fontshare.com/v2/css?f[]=zodiak@700,500,400&f[]=switzer@400,500,600,700&display=swap"
+        />
+        <link
+          rel="stylesheet"
+          href="https://fonts.googleapis.com/css2?family=Spline+Sans+Mono:wght@400;500;600&display=swap"
+        />
+      </head>
+      <body>
+        <div className="shell">
+          <aside className="sidebar">
+            <div className="brand">
+              <span className="brand-mark">
+                <span className="brand-name">Pulse</span>
+                <span className="brand-reg">®</span>
+              </span>
+              <span className="brand-sub">Product Analytics · FY26</span>
+            </div>
+            <Nav />
+            <div className="sidebar-foot">
+              <span className="avatar">JD</span>
+              <div>
+                <div className="sidebar-foot-name">Jordan Diaz</div>
+                <div>Acme Inc · Growth</div>
+              </div>
+            </div>
+          </aside>
+          <div className="main">{children}</div>
+        </div>
+        <MotionInit />
+        {/* Cloudflare Web Analytics — inlined at build when NEXT_PUBLIC_CF_BEACON_TOKEN is set
+            (or enable Web Analytics on the Pages project instead, which auto-injects). See DEPLOY.md. */}
+        {process.env.NEXT_PUBLIC_CF_BEACON_TOKEN ? (
+          <script
+            defer
+            src="https://static.cloudflareinsights.com/beacon.min.js"
+            data-cf-beacon={JSON.stringify({ token: process.env.NEXT_PUBLIC_CF_BEACON_TOKEN })}
+          />
+        ) : null}
+      </body>
+    </html>
+  );
+}

--- a/examples/pulse-analytics/app/live/page.tsx
+++ b/examples/pulse-analytics/app/live/page.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Sparkline } from "@microcharts/react/sparkline/interactive";
+import { Delta } from "@microcharts/react/delta/interactive";
+import { Ohlc } from "@microcharts/react/ohlc/interactive";
+import { Bullet } from "@microcharts/react/bullet/interactive";
+import { HeartbeatBlip } from "@microcharts/react/heartbeat-blip/interactive";
+import { CometTrail } from "@microcharts/react/comet-trail/interactive";
+import { DualWindowMeter } from "@microcharts/react/dual-window-meter/interactive";
+import { QueueDepth } from "@microcharts/react/queue-depth/interactive";
+import { Topbar, PageHead, Card } from "../components/ui";
+import {
+  liveStream,
+  sessionOhlc,
+  sloBudget,
+  liveErrorRate,
+  liveQueue,
+  liveThroughput,
+} from "../data";
+
+const fill = { width: "100%", height: "auto" } as const;
+
+type Picked = {
+  index: number;
+  value: number | null;
+  formatted?: string;
+} | null;
+
+function eventsFromRate(rate: number, now: number): number[] {
+  const count = Math.max(4, Math.min(40, Math.round(rate / 45)));
+  return Array.from({ length: count }, (_, i) => now - ((i + 0.5) / count) * 55_000);
+}
+
+export default function LivePage() {
+  const [stream, setStream] = useState<number[]>(liveStream);
+  const [errors, setErrors] = useState(liveErrorRate);
+  const [clock, setClock] = useState(() => Date.now());
+  const [events, setEvents] = useState(() => eventsFromRate(liveStream.at(-1)!, Date.now()));
+  const [active, setActive] = useState<Picked>(null);
+  const [selected, setSelected] = useState<Picked>(null);
+  const [candle, setCandle] = useState<Picked>(null);
+  const [errPick, setErrPick] = useState<Picked>(null);
+  const [queuePick, setQueuePick] = useState<Picked>(null);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setStream((prev) => {
+        const last = prev[prev.length - 1]!;
+        const next = Math.max(400, Math.round(last + (Math.random() - 0.45) * 160));
+        const now = Date.now();
+        setClock(now);
+        setEvents(eventsFromRate(next, now));
+        return [...prev.slice(-23), next];
+      });
+      setErrors((prev) => {
+        const last = prev[prev.length - 1]!;
+        const next = Math.max(0.1, Math.min(3.2, last + (Math.random() - 0.5) * 0.35));
+        return [...prev.slice(-19), Math.round(next * 100) / 100];
+      });
+    }, 2000);
+    return () => clearInterval(id);
+  }, []);
+
+  const current = stream[stream.length - 1]!;
+  const prev = stream[stream.length - 2]!;
+  const errNow = errors[errors.length - 1]!;
+  const shown = selected ?? active;
+  const metric =
+    shown?.formatted ??
+    (shown?.value != null ? shown.value.toLocaleString("en-US") : current.toLocaleString("en-US"));
+  const errMetric = errPick
+    ? `${errPick.formatted ?? errPick.value ?? "—"}%`
+    : `${errNow.toFixed(2)}%`;
+  const queueMetric =
+    queuePick?.formatted ??
+    (queuePick?.value != null ? String(queuePick.value) : String(liveQueue.at(-1)));
+
+  return (
+    <>
+      <Topbar
+        title="Live"
+        crumb="Pulse"
+        badge={
+          <span className="live-badge">
+            <span className="live-dot" aria-hidden />
+            Live
+          </span>
+        }
+        window="Refresh · 2s"
+      />
+      <div className="content">
+        <PageHead
+          index="06"
+          eyebrow="Ops floor · streaming"
+          title="Live telemetry"
+          sub="What the product is doing right now — request rate, error heat, queue pressure, and session quality. Scrub any chart; the KPI follows."
+        />
+
+        <div className="bento section">
+          <Card
+            title="Requests / sec"
+            sub="Streaming · scrub to inspect"
+            className="c8 hover reveal reveal-1"
+          >
+            <div className="big-metric" style={{ marginBottom: 14 }}>
+              <span className="num">{metric}</span>
+              {!shown && (
+                <Delta value={current} from={prev} positive="up" animate summary={false} />
+              )}
+            </div>
+            <Sparkline
+              data={stream}
+              fill
+              animate
+              width={720}
+              height={120}
+              label="minmax"
+              style={fill}
+              title="Requests per second over the last ~50 seconds"
+              readout={false}
+              onActive={setActive}
+              onSelect={setSelected}
+              selectedIndex={selected?.index ?? null}
+            />
+            <p className="picker-readout">
+              {shown
+                ? `${selected && !active ? "Pinned" : "Scrub"} · ${shown.formatted ?? shown.value ?? "—"}`
+                : "Hover or click — value lives in the KPI"}
+            </p>
+          </Card>
+
+          <Card
+            title="Event pulse"
+            sub="ECG of arrivals · 60s"
+            className="c4 hover reveal reveal-2"
+          >
+            <div style={{ display: "grid", placeItems: "center", padding: "18px 0 10px" }}>
+              <HeartbeatBlip
+                events={events}
+                now={clock}
+                window={60_000}
+                label="count"
+                width={220}
+                height={64}
+                title={`Request arrivals in the last minute at ~${current.toLocaleString()} rps`}
+              />
+            </div>
+            <p className="chart-note" style={{ textAlign: "center" }}>
+              Spike density tracks the live rate. An empty baseline would mean the service is quiet.
+            </p>
+          </Card>
+        </div>
+
+        <div className="grid two-col section">
+          <Card title="Error rate" sub="% · last ~40s" className="hover reveal reveal-1">
+            <div className="big-metric" style={{ marginBottom: 10 }}>
+              <span className="num">{errMetric}</span>
+            </div>
+            <CometTrail
+              data={errors}
+              width={480}
+              height={72}
+              format={{ maximumFractionDigits: 2 }}
+              title="Error rate percentage, streaming"
+              style={fill}
+              onActive={setErrPick}
+              onSelect={setErrPick}
+              selectedIndex={errPick?.index ?? null}
+            />
+            <p className="picker-readout">
+              {errPick
+                ? `Scrub · ${errPick.formatted ?? errPick.value ?? "—"}%`
+                : "Hover the trail — CometTrail has no chip; value lives in the KPI"}
+            </p>
+          </Card>
+
+          <Card title="Ingest queue" sub="Depth over time" className="hover reveal reveal-2">
+            <div className="big-metric" style={{ marginBottom: 10 }}>
+              <span className="num">{queueMetric}</span>
+            </div>
+            <QueueDepth
+              data={liveQueue}
+              width={480}
+              height={100}
+              label="last"
+              title="Ingest queue depth over the last hour"
+              animate
+              style={fill}
+              readout={false}
+              onActive={setQueuePick}
+              onSelect={setQueuePick}
+              selectedIndex={queuePick?.index ?? null}
+            />
+            <p className="picker-readout">
+              {queuePick
+                ? `Scrub · ${queuePick.formatted ?? queuePick.value}`
+                : "Hover or click a depth"}
+            </p>
+          </Card>
+        </div>
+
+        <div className="grid two-col">
+          <Card
+            title="Median session duration"
+            sub="Minutes · last 14 days"
+            className="reveal reveal-1"
+          >
+            <Ohlc
+              data={sessionOhlc}
+              label="last"
+              animate
+              width={480}
+              height={180}
+              format={{ maximumFractionDigits: 1 }}
+              style={fill}
+              title="Daily session duration open-high-low-close, in minutes"
+              readout={false}
+              onActive={setCandle}
+              onSelect={setCandle}
+              selectedIndex={candle?.index ?? null}
+            />
+            <p className="picker-readout">
+              {candle?.formatted ? `Session · ${candle.formatted}` : "Scrub a candle"}
+            </p>
+          </Card>
+
+          <div className="stack-gap">
+            <Card title="Error budget" sub="% consumed this period" className="reveal reveal-2">
+              <Bullet
+                value={sloBudget.value}
+                target={sloBudget.target}
+                bands={sloBudget.bands}
+                domain={[0, 100]}
+                animate
+                format={{ maximumFractionDigits: 0 }}
+                width={480}
+                height={48}
+                style={fill}
+                title="Error budget consumed against the monthly SLO allowance"
+              />
+              <p className="chart-note">
+                <b>62%</b> spent · 9 days left — room for one bad deploy, not two.
+              </p>
+            </Card>
+
+            <Card
+              title="Throughput vs. target"
+              sub="Fast & slow windows · target 1,400"
+              className="reveal reveal-3"
+            >
+              <DualWindowMeter
+                data={liveThroughput}
+                target={1400}
+                windows={[5, 20]}
+                label="last"
+                width={480}
+                height={72}
+                title="Short and long window throughput against the 1,400 rps target"
+                animate
+                style={fill}
+              />
+              <p className="chart-note">
+                Short window is hot; long window still calm — a spike, not a regime change. Scrub
+                for fast · slow at each sample.
+              </p>
+            </Card>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/examples/pulse-analytics/app/motion-init.tsx
+++ b/examples/pulse-analytics/app/motion-init.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+// Side-effect import of the motion engine so `animate` works on interactive
+// charts. Mounted once in the root layout — keeps the Server Component pages
+// free of any motion import.
+import "@microcharts/react/motion";
+
+export function MotionInit() {
+  return null;
+}

--- a/examples/pulse-analytics/app/page.tsx
+++ b/examples/pulse-analytics/app/page.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+import { Sparkline } from "@microcharts/react/sparkline/interactive";
+import { Delta } from "@microcharts/react/delta/interactive";
+import { Bullet } from "@microcharts/react/bullet/interactive";
+import { SegmentedBar } from "@microcharts/react/segmented-bar/interactive";
+import { ActivityGrid } from "@microcharts/react/activity-grid/interactive";
+import { FatDigits } from "@microcharts/react/fat-digits/interactive";
+import { Progress } from "@microcharts/react/progress/interactive";
+import { IconArray } from "@microcharts/react/icon-array/interactive";
+import { RateVolume } from "@microcharts/react/rate-volume/interactive";
+import { NetFlow } from "@microcharts/react/net-flow/interactive";
+import { ParetoStrip } from "@microcharts/react/pareto-strip/interactive";
+import { QueueDepth } from "@microcharts/react/queue-depth/interactive";
+import { Topbar, PageHead, Card, SectionHead } from "./components/ui";
+import {
+  kpis,
+  mrrGoal,
+  trafficSources,
+  dau,
+  usd,
+  compact,
+  pct,
+  eventsTracked,
+  activation,
+  alertsAdoption,
+  activationRateVolume,
+  userFlow,
+  dropoffReasons,
+  supportBacklog,
+  supportCapacity,
+} from "./data";
+
+const fill = { width: "100%", height: "auto" } as const;
+// Cell-sized charts (fixed px per cell) must NOT be stretched to 100% — that
+// magnifies the whole viewBox and balloons the labels. Render at natural size,
+// shrink only on narrow viewports, and center in the wide card.
+const centered = {
+  maxWidth: "100%",
+  height: "auto",
+  display: "block",
+  margin: "0 auto",
+} as const;
+
+export default function OverviewPage() {
+  return (
+    <>
+      <Topbar title="Overview" crumb="Pulse" />
+      <div className="content">
+        <PageHead
+          index="01"
+          eyebrow="This month · to date"
+          title="Overview"
+          sub="Everything moving through the product — acquisition, activation, revenue, and the support load carrying it."
+        />
+
+        <div className="kpi-strip section reveal reveal-1">
+          {kpis.map((k) => (
+            <div key={k.key} className="kpi-cell">
+              <span className="kpi-label">{k.label}</span>
+              <div className="kpi-value-row">
+                <span className="kpi-value">{k.display}</span>
+                <Delta value={k.value} from={k.from} positive={k.positive} summary={false} />
+              </div>
+              <div className="kpi-spark">
+                <Sparkline
+                  animate
+                  data={k.spark}
+                  fill
+                  width={220}
+                  height={40}
+                  dots="none"
+                  style={fill}
+                  summary={`${k.label} trend over the last 30 days`}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <SectionHead index="§ 01" title="Headline" sub="The three numbers we brief the team on" />
+        <div className="bento section">
+          <Card className="c5 hover reveal reveal-1">
+            <div className="stat">
+              <span className="stat-eyebrow">Events tracked · month to date</span>
+              <FatDigits
+                animate
+                value={eventsTracked}
+                format={compact}
+                fontSize={40}
+                summary="48.2 million analytics events tracked this month"
+              />
+              <span className="stat-foot">
+                <Delta value={eventsTracked} from={41_900_000} positive="up" summary={false} />
+                vs. last month
+              </span>
+            </div>
+          </Card>
+
+          <Card
+            title="Onboarding activation"
+            sub="Activated of signed-up"
+            className="c4 hover reveal reveal-2"
+          >
+            <Progress
+              animate
+              value={activation.value}
+              max={activation.max}
+              label="percent"
+              width={320}
+              height={30}
+              style={fill}
+              title="Onboarding activation rate"
+            />
+            <p className="chart-note">
+              <b>{activation.value.toLocaleString("en-US")}</b> of{" "}
+              {activation.max.toLocaleString("en-US")} new users reached the activation milestone.
+            </p>
+          </Card>
+
+          <Card title="Alerts adoption" sub="Active accounts" className="c3 hover reveal reveal-3">
+            <IconArray
+              animate
+              value={alertsAdoption}
+              total={20}
+              label="ratio"
+              width={220}
+              height={120}
+              style={fill}
+              title="Share of active accounts using Alerts"
+            />
+          </Card>
+        </div>
+
+        <SectionHead index="§ 02" title="Flow" sub="Where growth is really coming from" />
+        <div className="bento section">
+          <Card
+            title="Signups vs. churn"
+            sub="Weekly · net users"
+            className="c6 hover reveal reveal-1"
+          >
+            <NetFlow
+              animate
+              data={userFlow}
+              label="last"
+              width={520}
+              height={190}
+              style={fill}
+              title="Weekly signups against churned users, with the net line"
+            />
+            <p className="chart-note">
+              Net user growth held positive every week this quarter — the widening gap is churn
+              falling faster than signups slowed.
+            </p>
+          </Card>
+
+          <Card
+            title="Activation rate"
+            sub="On its signup volume"
+            className="c6 hover reveal reveal-2"
+          >
+            <RateVolume
+              animate
+              data={activationRateVolume}
+              unit="signups"
+              format={pct}
+              volumeFormat={compact}
+              width={520}
+              height={190}
+              style={fill}
+              title="Weekly activation rate over signup volume"
+            />
+            <p className="chart-note">
+              Rate is climbing <b>even as volume rises</b> — the onboarding changes are holding up
+              under load.
+            </p>
+          </Card>
+        </div>
+
+        <SectionHead
+          index="§ 03"
+          title="Friction"
+          sub="What slows new users, and the load it creates"
+        />
+        <div className="bento section">
+          <Card
+            title="Onboarding drop-off"
+            sub="Why new users churn"
+            className="c7 hover reveal reveal-1"
+          >
+            <ParetoStrip
+              animate
+              data={dropoffReasons}
+              unit="reasons"
+              metric="drop-offs"
+              width={560}
+              height={200}
+              style={fill}
+              title="Top reasons new users abandon onboarding, cumulative share"
+            />
+            <p className="chart-note">
+              The top three reasons account for <b>most</b> of all drop-off — fix time-to-value
+              first.
+            </p>
+          </Card>
+
+          <Card
+            title="Support backlog"
+            sub="Open tickets · 3 weeks"
+            className="c5 hover reveal reveal-2"
+          >
+            <QueueDepth
+              animate
+              data={supportBacklog}
+              capacity={supportCapacity}
+              width={420}
+              height={200}
+              style={fill}
+              title="Open support tickets per day against the team's WIP capacity"
+            />
+            <p className="chart-note">
+              Backlog crossed the <b>capacity line</b> for four days after the launch spike, now
+              draining.
+            </p>
+          </Card>
+        </div>
+
+        <SectionHead
+          index="§ 04"
+          title="Revenue & reach"
+          sub="The goal line, and where sessions originate"
+        />
+        <div className="grid two-col section">
+          <Card title="Quarterly MRR goal" sub="Target $90k" className="hover reveal reveal-1">
+            <Bullet
+              animate
+              value={mrrGoal.value}
+              target={mrrGoal.target}
+              bands={mrrGoal.bands}
+              domain={[0, 100000]}
+              format={usd}
+              width={480}
+              height={54}
+              style={fill}
+              title="Monthly recurring revenue against the quarterly goal"
+            />
+          </Card>
+
+          <Card title="Traffic sources" sub="New sessions" className="hover reveal reveal-2">
+            <SegmentedBar
+              animate
+              data={trafficSources}
+              label="percent"
+              width={480}
+              height={40}
+              style={fill}
+            />
+          </Card>
+        </div>
+
+        <SectionHead index="§ 05" title="Rhythm" sub="Daily active users, week by week" />
+        <Card title="Daily active users" sub="Last 20 weeks" className="hover reveal reveal-3">
+          <ActivityGrid
+            animate
+            data={dau}
+            anchor="2026-02-23"
+            weekStart={1}
+            cell={18}
+            gap={3}
+            style={centered}
+            title="Daily active users over the last 20 weeks"
+          />
+        </Card>
+      </div>
+    </>
+  );
+}

--- a/examples/pulse-analytics/app/revenue/page.tsx
+++ b/examples/pulse-analytics/app/revenue/page.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+// inline per-row mini-charts inside the table.
+import { Sparkline } from "@microcharts/react/sparkline/interactive";
+import { Delta } from "@microcharts/react/delta/interactive";
+import { MiniBar } from "@microcharts/react/mini-bar/interactive";
+import { BenchmarkStrip } from "@microcharts/react/benchmark-strip/interactive";
+import { DualSparkline } from "@microcharts/react/dual-sparkline/interactive";
+import { DotPlot } from "@microcharts/react/dot-plot/interactive";
+import { Waterfall } from "@microcharts/react/waterfall/interactive";
+import { Funnel } from "@microcharts/react/funnel/interactive";
+import { Topbar, PageHead, Card, SectionHead } from "../components/ui";
+import {
+  accounts,
+  mrrMovement,
+  mrrStart,
+  mrrActual,
+  mrrPlan,
+  signupFunnel,
+  usd,
+  usdCents,
+  compact,
+} from "../data";
+
+const fill = { width: "100%", height: "auto" } as const;
+const fmtUsd = (n: number) => n.toLocaleString("en-US", usd);
+
+function planClass(plan: string) {
+  return `plan-tag ${plan.toLowerCase()}`;
+}
+
+export default function RevenuePage() {
+  const total = accounts.reduce((s, a) => s + a.mrr, 0);
+  const peers = accounts.map((a) => a.mrr);
+  const leaderboard = [...accounts]
+    .sort((a, b) => b.mrr - a.mrr)
+    .map((a) => ({ label: a.short, value: a.mrr }));
+
+  return (
+    <>
+      <Topbar title="Revenue" crumb="Pulse" />
+      <div className="content">
+        <PageHead
+          index="02"
+          eyebrow="Recurring revenue"
+          title="Revenue"
+          sub="Where MRR sits against plan, how it moved this month, and which accounts carry it."
+        />
+
+        <div className="bento section">
+          <Card
+            title="MRR: actual vs. plan"
+            sub="Trailing 12 months"
+            className="c7 hover reveal reveal-1"
+          >
+            <DualSparkline
+              animate
+              data={mrrActual}
+              compare={mrrPlan}
+              label="last"
+              format={compact}
+              width={560}
+              height={190}
+              style={fill}
+              title="Monthly recurring revenue, actual against plan"
+            />
+            <p className="chart-note">
+              Actual has run <b>ahead of plan</b> since March — the gap is expansion revenue landing
+              early.
+            </p>
+          </Card>
+
+          <Card title="MRR leaderboard" sub="By account" className="c5 hover reveal reveal-2">
+            <DotPlot
+              animate
+              data={leaderboard}
+              stem
+              highlight={leaderboard[0].label}
+              label="value"
+              format={compact}
+              width={420}
+              height={240}
+              style={fill}
+              title="Accounts ranked by monthly recurring revenue"
+            />
+          </Card>
+        </div>
+
+        <SectionHead
+          index="§ 01"
+          title="Top accounts"
+          sub={`${fmtUsd(total)} MRR · ${accounts.length} accounts`}
+        />
+        <Card className="section hover reveal reveal-1">
+          <div className="table-wrap">
+            <table className="rev-table">
+              <thead>
+                <tr>
+                  <th>Account</th>
+                  <th>Plan</th>
+                  <th className="num">MRR</th>
+                  <th>Product mix</th>
+                  <th>vs. cohort</th>
+                  <th className="num">7-week trend</th>
+                </tr>
+              </thead>
+              <tbody>
+                {accounts.map((a) => (
+                  <tr key={a.account}>
+                    <td className="rev-account">{a.account}</td>
+                    <td>
+                      <span className={planClass(a.plan)}>{a.plan}</span>
+                    </td>
+                    <td className="num mono">{fmtUsd(a.mrr)}</td>
+                    <td>
+                      <span className="cell-chart">
+                        <MiniBar
+                          animate
+                          data={a.mix}
+                          orientation="horizontal"
+                          highlight={0}
+                          width={130}
+                          height={30}
+                          summary={false}
+                          title={`${a.account} product usage mix`}
+                          style={fill}
+                        />
+                      </span>
+                    </td>
+                    <td>
+                      <span className="cell-chart">
+                        <BenchmarkStrip
+                          animate
+                          data={peers}
+                          value={a.mrr}
+                          range="minmax"
+                          label="none"
+                          format={compact}
+                          width={130}
+                          height={30}
+                          summary={false}
+                          title={`${a.account} MRR against the account cohort`}
+                          style={fill}
+                        />
+                      </span>
+                    </td>
+                    <td className="num">
+                      <span className="cell-trend">
+                        <span className="mc-inline">
+                          <Sparkline
+                            animate
+                            data={a.trend}
+                            width={96}
+                            height={22}
+                            dots="none"
+                            summary={false}
+                          />
+                        </span>
+                        <Delta value={a.mrr} from={a.from} positive="up" summary={false} />
+                      </span>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Card>
+
+        <SectionHead
+          index="§ 02"
+          title="Movement & conversion"
+          sub="How the number changed, and how it's earned"
+        />
+        <div className="grid two-col">
+          <Card title="MRR movement" sub="Month over month" className="hover reveal reveal-1">
+            <Waterfall
+              animate
+              data={mrrMovement}
+              open={mrrStart}
+              totalBar
+              label="delta"
+              format={usdCents}
+              width={480}
+              height={200}
+              style={fill}
+              title="Monthly recurring revenue movement by category"
+            />
+          </Card>
+
+          <Card title="Signup → paid funnel" sub="Last 30 days" className="hover reveal reveal-2">
+            <Funnel
+              animate
+              data={signupFunnel}
+              label="percent"
+              highlight="Paid"
+              width={480}
+              height={200}
+              style={fill}
+              title="Conversion funnel from first visit to paid"
+            />
+          </Card>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/examples/pulse-analytics/next-env.d.ts
+++ b/examples/pulse-analytics/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/examples/pulse-analytics/next.config.mjs
+++ b/examples/pulse-analytics/next.config.mjs
@@ -1,0 +1,18 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.dirname(fileURLToPath(import.meta.url));
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  // Static HTML export → deployable to Cloudflare Pages as pure static assets.
+  // Server Components still render at build time, so the charts are baked into
+  // the HTML as pure SVG (the RSC/static-first story) with zero server runtime.
+  output: "export",
+  images: { unoptimized: true },
+  trailingSlash: true,
+  // Monorepo has a parent pnpm-lock; pin the tracing root so Next doesn't treat
+  // the package repo as the app and 404 every route in `next dev`.
+  outputFileTracingRoot: root,
+};
+export default nextConfig;

--- a/examples/pulse-analytics/package.json
+++ b/examples/pulse-analytics/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "example-pulse-analytics",
+  "private": true,
+  "scripts": {
+    "dev": "next dev -p 4001",
+    "build": "next build",
+    "start": "next start -p 4001"
+  },
+  "dependencies": {
+    "@microcharts/react": "^0.8.0",
+    "next": "^15.1.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/examples/pulse-analytics/public/robots.txt
+++ b/examples/pulse-analytics/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/examples/pulse-analytics/tsconfig.json
+++ b/examples/pulse-analytics/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/examples/shipyard-devops/index.html
+++ b/examples/shipyard-devops/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <meta name="description" content="Shipyard — a dense SRE service-health console built with microcharts." />
+    <meta name="color-scheme" content="dark light" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&family=Overpass+Mono:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <title>Shipyard · service health console</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/shipyard-devops/package.json
+++ b/examples/shipyard-devops/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "example-shipyard-devops",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite --port 4004 --strictPort",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview --port 4004 --strictPort"
+  },
+  "dependencies": {
+    "@microcharts/react": "^0.8.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^5.0.0",
+    "typescript": "^5.7.0",
+    "vite": "^7.0.0"
+  }
+}

--- a/examples/shipyard-devops/public/robots.txt
+++ b/examples/shipyard-devops/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/examples/shipyard-devops/src/App.tsx
+++ b/examples/shipyard-devops/src/App.tsx
@@ -1,0 +1,136 @@
+import { useMemo, useState } from "react";
+import { StatusDot } from "@microcharts/react/status-dot/interactive";
+import { Sparkline } from "@microcharts/react/sparkline/interactive";
+import { services, mttrTrend, type Health } from "./data";
+import { ServicesView } from "./components/ServicesView";
+import { SlosView } from "./components/SlosView";
+import { IncidentsView } from "./components/IncidentsView";
+import { FleetView } from "./components/FleetView";
+
+type Tab = "services" | "slos" | "incidents" | "fleet";
+type Scrub = { index: number; value: number | null; formatted?: string } | null;
+
+const TABS: { id: Tab; label: string; hint: string }[] = [
+  { id: "services", label: "Services", hint: "8 online" },
+  { id: "slos", label: "SLOs", hint: "6 objectives" },
+  { id: "incidents", label: "Incidents", hint: "28 · 20wk" },
+  { id: "fleet", label: "Fleet", hint: "7 nodes" },
+];
+
+export function App() {
+  const [tab, setTab] = useState<Tab>("services");
+  const [pulse, setPulse] = useState<Scrub>(null);
+
+  const hc = useMemo(
+    () =>
+      services.reduce((a, s) => ((a[s.status] += 1), a), { ok: 0, warn: 0, error: 0 } as Record<
+        Health,
+        number
+      >),
+    [],
+  );
+  const fleetPulse = useMemo(() => {
+    const n = services[0].latency.length;
+    return Array.from({ length: n }, (_, i) => {
+      const sum = services.reduce((a, s) => a + s.latency[i], 0);
+      return Math.round(sum / services.length);
+    });
+  }, []);
+
+  const p95 = pulse?.formatted ?? `${fleetPulse[fleetPulse.length - 1]}`;
+
+  return (
+    <div className="shipyard">
+      <header className="masthead">
+        <div className="masthead-rail">
+          <div className="brand">
+            <span className="brand-mark" aria-hidden="true">
+              ◇
+            </span>
+            <span className="brand-name">SHIPYARD</span>
+            <span className="brand-sub">service-health console</span>
+          </div>
+          <div className="rail-readout">
+            <div className="tally" role="group" aria-label="Service health tally">
+              <span className="tally-item ok">
+                <StatusDot status="ok" summary={false} />
+                <b>{hc.ok}</b>
+                <i>ok</i>
+              </span>
+              <span className="tally-item warn">
+                <StatusDot status="warn" summary={false} />
+                <b>{hc.warn}</b>
+                <i>warn</i>
+              </span>
+              <span className="tally-item error">
+                <StatusDot status="error" pulse summary={false} />
+                <b>{hc.error}</b>
+                <i>err</i>
+              </span>
+            </div>
+            <span className="coord">
+              <span className="live-dot" aria-hidden="true" />
+              us-east-1<span className="coord-sep">/</span>14:08 UTC
+            </span>
+          </div>
+        </div>
+
+        <div className="scope">
+          <div className="scope-chan">
+            <span className="chan-name">Fleet p95</span>
+            <span className="chan-unit">last 60 min · mean of 8 services</span>
+          </div>
+          <div className="scope-trace">
+            <Sparkline
+              data={fleetPulse}
+              width={700}
+              height={48}
+              fill
+              animate
+              readout={false}
+              onActive={setPulse}
+              summary="Fleet-wide p95 latency, last 60 minutes"
+              style={{ width: "100%", height: "auto" }}
+            />
+          </div>
+          <div className="scope-readout">
+            <span className="readout-v num">
+              {p95}
+              <i>ms</i>
+            </span>
+            <span className="readout-k">
+              mttr <b className="good">{mttrTrend[mttrTrend.length - 1]}m</b> · 24 inc
+            </span>
+          </div>
+        </div>
+      </header>
+
+      <nav className="tabs" role="tablist" aria-label="Console sections">
+        {TABS.map((t) => (
+          <button
+            key={t.id}
+            role="tab"
+            aria-selected={tab === t.id}
+            className={"tab" + (tab === t.id ? " is-active" : "")}
+            onClick={() => setTab(t.id)}
+          >
+            <span className="tab-label">{t.label}</span>
+            <span className="tab-hint">{t.hint}</span>
+          </button>
+        ))}
+      </nav>
+
+      <main className="view" key={tab}>
+        {tab === "services" && <ServicesView />}
+        {tab === "slos" && <SlosView />}
+        {tab === "incidents" && <IncidentsView />}
+        {tab === "fleet" && <FleetView />}
+      </main>
+
+      <footer className="footer">
+        <span>@microcharts/react · mono preset · zero runtime deps</span>
+        <span>p95 windows: last 60m · budgets: 30d rolling</span>
+      </footer>
+    </div>
+  );
+}

--- a/examples/shipyard-devops/src/analytics.ts
+++ b/examples/shipyard-devops/src/analytics.ts
@@ -1,0 +1,14 @@
+// Cloudflare Web Analytics — privacy-first, cookieless page-view/visit beacon.
+// Injected only when VITE_CF_BEACON_TOKEN is set at build time; otherwise a no-op.
+// Get a token: Cloudflare dashboard → Web Analytics → Add a site → copy the token
+// (or just enable Web Analytics on the Pages project, which auto-injects instead). See DEPLOY.md.
+const token = (import.meta as unknown as { env?: Record<string, string | undefined> }).env
+  ?.VITE_CF_BEACON_TOKEN;
+if (token) {
+  const s = document.createElement("script");
+  s.defer = true;
+  s.src = "https://static.cloudflareinsights.com/beacon.min.js";
+  s.setAttribute("data-cf-beacon", JSON.stringify({ token }));
+  document.head.appendChild(s);
+}
+export {};

--- a/examples/shipyard-devops/src/app.css
+++ b/examples/shipyard-devops/src/app.css
@@ -1,0 +1,1081 @@
+/* ─────────────────────────────────────────────────────────────────────────────
+   SHIPYARD — SRE service-health console.
+   Aesthetic: an industrial control-room / blueprint instrument. A precise
+   grotesque (Archivo) for signage labels, a mono (Overpass Mono, drawn from
+   Highway Gothic lineage) for machine data. Fine graph-paper substrate, colour
+   reserved strictly for status meaning. Charts run mono (grayscale); the chrome
+   is a tinted blueprint near-black that stays legible in either OS scheme.
+   ──────────────────────────────────────────────────────────────────────────── */
+
+:root {
+  color-scheme: dark light;
+
+  --font-label: "Archivo", "Archivo Fallback", system-ui, sans-serif;
+  --font-mono: "Overpass Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+
+  /* microcharts contract — keep chart SVG text on our clean legible faces. */
+  --mc-font: var(--font-label);
+  --mc-font-numeric: var(--font-mono);
+
+  /* 4pt spatial scale */
+  --sp-1: 4px;
+  --sp-2: 8px;
+  --sp-3: 12px;
+  --sp-4: 16px;
+  --sp-5: 24px;
+  --sp-6: 32px;
+  --sp-8: 48px;
+
+  /* ── LIGHT — blueprint on cool paper (blue-slate hue 256, neutrals tinted) ── */
+  --bg: oklch(0.962 0.006 256);
+  --grid-minor: oklch(0.93 0.009 256);
+  --grid-major: oklch(0.9 0.012 256);
+  --panel: oklch(0.987 0.004 256);
+  --panel-2: oklch(0.952 0.006 256);
+  --ink: oklch(0.26 0.02 256);
+  --ink-dim: oklch(0.47 0.017 256);
+  --ink-faint: oklch(0.62 0.013 256);
+  --edge: oklch(0.86 0.011 256);
+  --edge-soft: oklch(0.91 0.008 256);
+  --accent: oklch(0.26 0.02 256);
+  --row-hover: oklch(0.94 0.008 256);
+  --graticule: oklch(0.9 0.01 256);
+
+  /* Okabe-Ito semantic valence — meaning only, never decoration. */
+  --good: oklch(0.52 0.1 168);
+  --bad: oklch(0.54 0.16 38);
+  --warn: oklch(0.57 0.1 70);
+
+  --mc-accent: oklch(0.55 0.09 252);
+
+  --lift: 0 1px 0 oklch(0.26 0.02 256 / 0.04), 0 8px 22px oklch(0.26 0.03 256 / 0.09);
+
+  /* type scale — dense console keeps small steps for data; hierarchy lives in
+     the masthead readout + wordmark, which jump the scale. */
+  --t-9: 9px;
+  --t-10: 10px;
+  --t-11: 11px;
+  --t-12: 12px;
+  --t-13: 13px;
+  --t-15: 15px;
+  --t-readout: clamp(24px, 5vw, 30px);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: oklch(0.165 0.014 256);
+    --grid-minor: oklch(0.205 0.016 256);
+    --grid-major: oklch(0.245 0.02 256);
+    --panel: oklch(0.198 0.016 256);
+    --panel-2: oklch(0.228 0.018 256);
+    --ink: oklch(0.925 0.008 256);
+    --ink-dim: oklch(0.7 0.014 256);
+    --ink-faint: oklch(0.56 0.014 256);
+    --edge: oklch(0.31 0.019 256);
+    --edge-soft: oklch(0.26 0.016 256);
+    --accent: oklch(0.925 0.01 256);
+    --row-hover: oklch(0.235 0.018 256);
+    --graticule: oklch(0.27 0.017 256);
+
+    --good: oklch(0.72 0.1 168);
+    --bad: oklch(0.7 0.14 40);
+    --warn: oklch(0.79 0.1 75);
+
+    --mc-accent: oklch(0.68 0.11 252);
+
+    --lift: 0 0 0 1px oklch(0.31 0.02 256 / 0.6), 0 14px 34px oklch(0.1 0.02 256 / 0.55);
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: var(--t-13);
+  line-height: 1.5;
+  color: var(--ink);
+  background-color: var(--bg);
+  /* Graph-paper substrate: a fine minor grid with a heavier major every 5th.
+     This is the blueprint the instruments are drawn on. */
+  background-image:
+    linear-gradient(var(--grid-minor) 1px, transparent 1px),
+    linear-gradient(90deg, var(--grid-minor) 1px, transparent 1px),
+    linear-gradient(var(--grid-major) 1px, transparent 1px),
+    linear-gradient(90deg, var(--grid-major) 1px, transparent 1px);
+  background-size:
+    22px 22px,
+    22px 22px,
+    110px 110px,
+    110px 110px;
+  background-position: -1px -1px;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  font-feature-settings: "tnum" 1;
+}
+
+/* Subtle blueprint vignette — depth without chrome. */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background: radial-gradient(
+    120% 90% at 50% -10%,
+    transparent 55%,
+    oklch(0.1 0.02 256 / 0.28) 100%
+  );
+}
+@media (prefers-color-scheme: light) {
+  body::before {
+    background: radial-gradient(
+      120% 90% at 50% -10%,
+      transparent 62%,
+      oklch(0.6 0.02 256 / 0.08) 100%
+    );
+  }
+}
+
+::selection {
+  background: color-mix(in oklch, var(--accent) 22%, transparent);
+}
+
+.shipyard {
+  position: relative;
+  z-index: 1;
+  max-width: 1140px;
+  margin: 0 auto;
+  padding: clamp(16px, 3vw, 28px) clamp(12px, 3vw, 22px) var(--sp-8);
+}
+
+/* ── masthead ─────────────────────────────────────────────────────────────── */
+.masthead {
+  padding-bottom: var(--sp-5);
+}
+.masthead-rail {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-4);
+  flex-wrap: wrap;
+  padding-bottom: var(--sp-4);
+}
+.brand {
+  display: flex;
+  align-items: baseline;
+  gap: 11px;
+}
+.brand-mark {
+  font-size: 15px;
+  color: var(--ink);
+  transform: translateY(1px);
+}
+.brand-name {
+  font-family: var(--font-label);
+  font-weight: 800;
+  letter-spacing: 0.34em;
+  font-size: 16px;
+  padding-left: 2px;
+}
+.brand-sub {
+  font-family: var(--font-label);
+  color: var(--ink-faint);
+  font-size: var(--t-11);
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: lowercase;
+}
+
+.rail-readout {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-4);
+  flex-wrap: wrap;
+}
+.tally {
+  display: flex;
+  align-items: stretch;
+  gap: 0;
+  border: 1px solid var(--edge);
+  border-radius: 3px;
+  overflow: hidden;
+  background: var(--panel);
+}
+.tally-item {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 5px;
+  padding: 4px 10px;
+  font-family: var(--font-label);
+  font-size: var(--t-11);
+}
+.tally-item + .tally-item {
+  border-left: 1px solid var(--edge-soft);
+}
+.tally-item b {
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: var(--t-13);
+  font-variant-numeric: tabular-nums;
+}
+.tally-item i {
+  font-style: normal;
+  color: var(--ink-faint);
+  font-size: var(--t-10);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.tally-item span[role="img"] {
+  align-self: center;
+}
+.tally-item.ok b {
+  color: var(--good);
+}
+.tally-item.warn b {
+  color: var(--warn);
+}
+.tally-item.error b {
+  color: var(--bad);
+}
+.coord {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--ink-dim);
+  font-size: var(--t-11);
+  letter-spacing: 0.02em;
+}
+.coord-sep {
+  color: var(--ink-faint);
+  padding: 0 5px;
+}
+.live-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--good);
+}
+
+/* ── scope: the instrument spine — a labelled oscilloscope readout ────────── */
+.scope {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(120px, auto) minmax(0, 1fr) minmax(96px, auto);
+  align-items: center;
+  gap: clamp(16px, 3.5vw, 34px);
+  padding: 16px clamp(18px, 3vw, 26px);
+  background: var(--panel);
+  border: 1px solid var(--edge);
+  border-radius: 4px;
+}
+/* crop-mark corner ticks — the signature instrument bezel, used only here. */
+.scope::before,
+.scope::after {
+  content: "";
+  position: absolute;
+  width: 11px;
+  height: 11px;
+  border: 1.5px solid var(--ink-faint);
+  opacity: 0.7;
+}
+.scope::before {
+  top: 5px;
+  left: 5px;
+  border-right: 0;
+  border-bottom: 0;
+}
+.scope::after {
+  bottom: 5px;
+  right: 5px;
+  border-left: 0;
+  border-top: 0;
+}
+.scope-chan {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.chan-name {
+  font-family: var(--font-label);
+  font-weight: 700;
+  font-size: var(--t-13);
+  letter-spacing: 0.03em;
+}
+.chan-unit {
+  font-family: var(--font-label);
+  font-size: var(--t-10);
+  color: var(--ink-faint);
+  letter-spacing: 0.02em;
+}
+.scope-trace {
+  min-width: 0;
+  padding: 4px 0;
+  /* faint vertical graticule — time divisions behind the trace. */
+  background-image: repeating-linear-gradient(
+    90deg,
+    var(--graticule) 0 1px,
+    transparent 1px calc(100% / 8)
+  );
+  background-position: 0 50%;
+}
+.scope-readout {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+  text-align: right;
+}
+.readout-v {
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: var(--t-readout);
+  line-height: 0.95;
+  letter-spacing: -0.02em;
+}
+.readout-v i {
+  font-style: normal;
+  font-size: 0.44em;
+  font-weight: 500;
+  color: var(--ink-dim);
+  margin-left: 3px;
+}
+.readout-k {
+  font-family: var(--font-label);
+  font-size: var(--t-10);
+  color: var(--ink-faint);
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+.readout-k b {
+  font-family: var(--font-mono);
+  font-weight: 700;
+}
+
+/* ── tabs — channel selector ──────────────────────────────────────────────── */
+.tabs {
+  display: flex;
+  gap: 0;
+  margin: var(--sp-5) 0 var(--sp-5);
+  border-bottom: 1px solid var(--edge);
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+.tabs::-webkit-scrollbar {
+  display: none;
+}
+.tab {
+  appearance: none;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: 8px 18px 12px;
+  margin-bottom: -1px;
+  font: inherit;
+  font-family: var(--font-label);
+  color: var(--ink-dim);
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  white-space: nowrap;
+  min-height: 46px;
+  transition:
+    color 0.16s ease,
+    border-color 0.2s cubic-bezier(0.22, 0.61, 0.36, 1);
+}
+.tab + .tab {
+  border-left: 1px solid var(--edge-soft);
+}
+.tab:hover {
+  color: var(--ink);
+  background: color-mix(in oklch, var(--panel) 60%, transparent);
+}
+.tab:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -3px;
+  border-radius: 3px;
+}
+.tab.is-active {
+  color: var(--ink);
+  border-bottom-color: var(--accent);
+}
+.tab-label {
+  font-weight: 700;
+  font-size: var(--t-13);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+.tab-hint {
+  font-family: var(--font-mono);
+  font-size: var(--t-10);
+  color: var(--ink-faint);
+  letter-spacing: 0.01em;
+}
+
+/* ── layout primitives ────────────────────────────────────────────────────── */
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-4);
+}
+.grid-2 {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--sp-4);
+}
+.panel {
+  position: relative;
+  background: var(--panel);
+  border: 1px solid var(--edge);
+  border-radius: 3px;
+  padding: 14px var(--sp-4) var(--sp-4);
+  min-width: 0;
+  transition:
+    box-shadow 0.24s ease,
+    transform 0.24s cubic-bezier(0.22, 0.61, 0.36, 1),
+    border-color 0.24s ease;
+}
+/* the lead panel earns a heavier top hairline — a printed rule, not a stripe. */
+.panel-lead {
+  border-color: color-mix(in oklch, var(--ink) 24%, var(--edge));
+}
+.span-2 {
+  grid-column: 1 / -1;
+}
+.panel-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--sp-3);
+  margin-bottom: 13px;
+  padding-bottom: 9px;
+  border-bottom: 1px solid var(--edge-soft);
+}
+.panel-head h2 {
+  margin: 0;
+  font-family: var(--font-label);
+  font-size: var(--t-12);
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.panel-meta {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--ink-faint);
+  letter-spacing: 0.01em;
+  text-align: right;
+}
+
+/* annotation note — a drawing caption. Leading pointer glyph + hanging indent,
+   never a side stripe. */
+.note {
+  margin: var(--sp-3) 0 0;
+  padding-left: 16px;
+  text-indent: -16px;
+  font-family: var(--font-label);
+  font-size: var(--t-11);
+  color: var(--ink-dim);
+  line-height: 1.6;
+  max-width: 68ch;
+}
+.note::before {
+  content: "▸";
+  color: var(--ink-faint);
+  margin-right: 8px;
+  font-size: 9px;
+}
+.bad-note {
+  color: var(--bad);
+}
+.bad-note::before {
+  content: "▸";
+  color: var(--bad);
+}
+
+/* interactive readout — the pinned/hovered reading, printed like a channel tag */
+.picker-readout {
+  margin: var(--sp-2) 0 0;
+  font-family: var(--font-mono);
+  font-size: var(--t-11);
+  color: var(--ink-dim);
+  letter-spacing: 0.02em;
+  font-variant-numeric: tabular-nums;
+  min-height: 1.4em;
+}
+
+.mc-inline {
+  display: inline-flex;
+  align-items: center;
+  vertical-align: middle;
+}
+
+/* ── dense tables — scroll horizontally INSIDE the panel; body never scrolls ── */
+.svc-table,
+.inc-table {
+  display: flex;
+  flex-direction: column;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  scrollbar-width: thin;
+  scrollbar-color: var(--edge) transparent;
+}
+.svc-table::-webkit-scrollbar,
+.inc-table::-webkit-scrollbar {
+  height: 6px;
+}
+.svc-table::-webkit-scrollbar-thumb,
+.inc-table::-webkit-scrollbar-thumb {
+  background: var(--edge);
+  border-radius: 999px;
+}
+.svc-row {
+  display: grid;
+  grid-template-columns: 20px 150px 78px minmax(140px, 1fr) 62px 78px 66px 82px;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 4px;
+  min-width: 748px;
+  border-bottom: 1px solid var(--edge-soft);
+  transition: background 0.14s ease;
+}
+.svc-row:last-child {
+  border-bottom: none;
+}
+.svc-row:not(.svc-head):hover {
+  background: var(--row-hover);
+}
+.svc-head,
+.inc-head {
+  font-family: var(--font-label);
+  font-size: var(--t-10);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  border-bottom: 1px solid var(--edge);
+  padding-bottom: 9px;
+}
+.svc-name {
+  font-weight: 600;
+}
+.svc-zone {
+  color: var(--ink-faint);
+  font-size: var(--t-11);
+}
+.num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+.dim {
+  color: var(--ink-dim);
+}
+.good {
+  color: var(--good);
+}
+.bad {
+  color: var(--bad);
+}
+.warn-t {
+  color: var(--warn);
+}
+
+/* ── mini rows (label + strip) ────────────────────────────────────────────── */
+.row-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.mini-row {
+  display: grid;
+  grid-template-columns: 128px minmax(0, 1fr);
+  align-items: center;
+  gap: 12px;
+}
+.mini-row-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--t-11);
+  color: var(--ink-dim);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.mini-row-tag {
+  font-family: var(--font-label);
+  font-size: var(--t-9);
+  color: var(--ink-faint);
+  border: 1px solid var(--edge);
+  border-radius: 3px;
+  padding: 1px 4px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+/* ── dependency orbit grid ────────────────────────────────────────────────── */
+.dep-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 10px;
+}
+.dep-cell {
+  display: grid;
+  grid-template-columns: 44px minmax(0, 1fr);
+  grid-template-rows: auto auto;
+  column-gap: 10px;
+  align-items: center;
+  padding: 10px;
+  border: 1px solid var(--edge-soft);
+  border-radius: 3px;
+  background: var(--panel-2);
+  transition: border-color 0.2s ease;
+}
+.dep-cell:hover {
+  border-color: var(--edge);
+}
+.dep-cell > .mc-root,
+.dep-cell > span[role="img"],
+.dep-cell > svg {
+  grid-row: 1 / 3;
+}
+.dep-name {
+  font-size: var(--t-11);
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.dep-kind {
+  grid-column: 2;
+  font-family: var(--font-label);
+  font-size: var(--t-9);
+  color: var(--ink-faint);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+}
+.dep-lat,
+.dep-rate {
+  grid-column: 2;
+  font-size: var(--t-10);
+  text-align: left;
+}
+.dep-rate {
+  color: var(--ink-faint);
+}
+
+/* ── coverage list ────────────────────────────────────────────────────────── */
+.cov-list {
+  display: flex;
+  flex-direction: column;
+  gap: 11px;
+}
+.cov-row {
+  display: grid;
+  grid-template-columns: 108px 116px minmax(0, 1fr);
+  align-items: center;
+  gap: 12px;
+}
+.cov-metric {
+  font-size: var(--t-11);
+  font-weight: 600;
+}
+.cov-source {
+  font-family: var(--font-label);
+  font-size: var(--t-10);
+  color: var(--ink-faint);
+  letter-spacing: 0.02em;
+}
+
+/* ── fleet heat matrix ────────────────────────────────────────────────────── */
+.heat-matrix {
+  display: flex;
+  flex-direction: column;
+  overflow-x: auto;
+}
+.heat-mrow {
+  display: grid;
+  grid-template-columns: minmax(88px, 1.2fr) 96px repeat(5, minmax(30px, 34px));
+  align-items: center;
+  gap: 6px;
+  padding: 3px 2px;
+}
+.heat-mhead {
+  padding-bottom: 8px;
+  margin-bottom: 5px;
+  border-bottom: 1px solid var(--edge);
+}
+.heat-mhead .heat-col,
+.heat-mhead .heat-node,
+.heat-mhead .heat-zone {
+  font-family: var(--font-label);
+  font-size: var(--t-10);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+.heat-mhead .heat-col {
+  text-align: center;
+}
+.heat-mrow:not(.heat-mhead):hover {
+  background: var(--row-hover);
+  border-radius: 3px;
+}
+.heat-node {
+  font-size: var(--t-12);
+  font-weight: 600;
+}
+.heat-mrow.is-hot .heat-node {
+  color: var(--bad);
+}
+.heat-zone {
+  font-size: var(--t-10);
+  color: var(--ink-faint);
+}
+.heat-col {
+  display: flex;
+  justify-content: center;
+}
+
+/* ── capacity honeycombs ──────────────────────────────────────────────────── */
+.cap-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: var(--sp-4);
+}
+.cap-cell {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-4);
+  padding: 13px 15px;
+  border: 1px solid var(--edge-soft);
+  border-radius: 3px;
+  background: var(--panel-2);
+}
+.cap-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.cap-label {
+  font-family: var(--font-label);
+  font-size: var(--t-12);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+.cap-hint {
+  font-family: var(--font-label);
+  font-size: var(--t-10);
+  color: var(--ink-faint);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.cap-count {
+  font-size: var(--t-15);
+  margin-top: 5px;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+}
+.cap-count strong {
+  font-weight: 700;
+}
+.cap-pct {
+  font-size: var(--t-11);
+  margin-left: 4px;
+}
+
+/* ── incident calendar ────────────────────────────────────────────────────── */
+.cal-layout {
+  display: flex;
+  align-items: flex-start;
+  gap: clamp(18px, 4vw, 42px);
+  flex-wrap: wrap;
+}
+.cal-layout > span[role="img"],
+.cal-layout > .mc-root {
+  flex: 0 1 460px;
+}
+.cal-side {
+  flex: 1 1 240px;
+  min-width: 220px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+}
+.cal-side .legend {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 9px;
+  margin-top: 0;
+  padding-top: 0;
+  border-top: none;
+}
+/* Deploy-log lines driven by MinimapStrip window */
+.log-panel {
+  margin-top: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--edge-soft);
+  border-radius: 3px;
+  background: var(--panel-2);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  line-height: 1.55;
+  max-height: 220px;
+  overflow: auto;
+}
+.log-line {
+  display: grid;
+  grid-template-columns: 52px 44px minmax(0, 1fr);
+  gap: 10px;
+  padding: 2px 0;
+}
+.log-n {
+  color: var(--ink-faint);
+  text-align: right;
+}
+.log-lvl {
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+.log-lvl.info {
+  color: var(--ink-soft);
+}
+.log-lvl.warn {
+  color: var(--warn, #c9a227);
+}
+.log-lvl.debug {
+  color: var(--ink-faint);
+}
+.log-msg {
+  color: var(--ink);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cal-side .note {
+  margin: 0;
+  max-width: 44ch;
+}
+
+/* ── legend ───────────────────────────────────────────────────────────────── */
+.legend {
+  display: flex;
+  gap: 18px;
+  flex-wrap: wrap;
+  margin-top: var(--sp-3);
+  padding-top: var(--sp-3);
+  border-top: 1px solid var(--edge-soft);
+}
+.legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: var(--t-11);
+}
+.legend-label {
+  color: var(--ink-dim);
+}
+.legend-count {
+  color: var(--ink-faint);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── bullets ──────────────────────────────────────────────────────────────── */
+.bullets {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-4);
+}
+.bullet-row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.bullet-label {
+  font-family: var(--font-label);
+  font-size: var(--t-11);
+  color: var(--ink-dim);
+  letter-spacing: 0.02em;
+}
+
+/* ── incident table ───────────────────────────────────────────────────────── */
+.inc-row {
+  display: grid;
+  grid-template-columns: 20px 78px 132px minmax(160px, 1fr) 54px 62px;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 4px;
+  min-width: 560px;
+  border-bottom: 1px solid var(--edge-soft);
+  transition: background 0.14s ease;
+}
+.inc-row:last-child {
+  border-bottom: none;
+}
+.inc-row:not(.inc-head):hover {
+  background: var(--row-hover);
+}
+.inc-id {
+  font-weight: 600;
+}
+.inc-svc {
+  color: var(--ink-dim);
+  font-size: var(--t-11);
+}
+.inc-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ── footer ───────────────────────────────────────────────────────────────── */
+.footer {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--sp-3);
+  margin-top: var(--sp-6);
+  padding-top: var(--sp-3);
+  border-top: 1px solid var(--edge);
+  color: var(--ink-faint);
+  font-family: var(--font-label);
+  font-size: 10.5px;
+  letter-spacing: 0.04em;
+  flex-wrap: wrap;
+}
+
+/* ── motion — one orchestrated load, reduced-motion gated ─────────────────── */
+@media (prefers-reduced-motion: no-preference) {
+  .masthead {
+    animation: rise 0.5s cubic-bezier(0.16, 1, 0.3, 1) both;
+  }
+  .tabs {
+    animation: rise 0.5s cubic-bezier(0.16, 1, 0.3, 1) 0.05s both;
+  }
+  .view {
+    animation: rise 0.42s cubic-bezier(0.16, 1, 0.3, 1) both;
+  }
+  .view > .grid-2 > .panel,
+  .view > .stack > .panel,
+  .view > .stack > .grid-2 > .panel {
+    animation: panel-in 0.46s cubic-bezier(0.16, 1, 0.3, 1) both;
+  }
+  .view > * > .panel:nth-child(1),
+  .view > * > * > .panel:nth-child(1) {
+    animation-delay: 0.03s;
+  }
+  .view > * > .panel:nth-child(2),
+  .view > * > * > .panel:nth-child(2) {
+    animation-delay: 0.08s;
+  }
+  .view > * > .panel:nth-child(3),
+  .view > * > * > .panel:nth-child(3) {
+    animation-delay: 0.13s;
+  }
+  .view > * > .panel:nth-child(4),
+  .view > * > * > .panel:nth-child(4) {
+    animation-delay: 0.18s;
+  }
+  .view > * > .panel:nth-child(n + 5) {
+    animation-delay: 0.22s;
+  }
+  .panel:hover {
+    box-shadow: var(--lift);
+    transform: translateY(-1px);
+    border-color: color-mix(in oklch, var(--ink) 18%, var(--edge));
+  }
+  .live-dot {
+    animation: live-pulse 2.6s ease-out infinite;
+  }
+
+  @keyframes rise {
+    from {
+      opacity: 0;
+      transform: translateY(7px);
+    }
+  }
+  @keyframes panel-in {
+    from {
+      opacity: 0;
+      transform: translateY(11px);
+    }
+  }
+  @keyframes live-pulse {
+    0% {
+      box-shadow: 0 0 0 0 color-mix(in oklch, var(--good) 55%, transparent);
+    }
+    70%,
+    100% {
+      box-shadow: 0 0 0 6px transparent;
+    }
+  }
+}
+
+/* ── responsive ───────────────────────────────────────────────────────────── */
+@media (max-width: 900px) {
+  .scope {
+    grid-template-columns: 1fr auto;
+    grid-template-areas: "chan readout" "trace trace";
+    gap: 14px 18px;
+  }
+  .scope-chan {
+    grid-area: chan;
+  }
+  .scope-readout {
+    grid-area: readout;
+  }
+  .scope-trace {
+    grid-area: trace;
+  }
+}
+
+@media (max-width: 760px) {
+  .grid-2 {
+    grid-template-columns: 1fr;
+  }
+  .panel-head {
+    flex-direction: column;
+    gap: 4px;
+  }
+  .panel-meta {
+    text-align: left;
+  }
+  .mini-row {
+    grid-template-columns: 104px minmax(0, 1fr);
+    gap: 9px;
+  }
+  .cov-row {
+    grid-template-columns: 96px minmax(0, 1fr);
+  }
+  .cov-source {
+    display: none;
+  }
+}
+
+@media (max-width: 440px) {
+  body {
+    font-size: 12px;
+  }
+  .brand-sub {
+    display: none;
+  }
+  .rail-readout {
+    gap: 10px;
+  }
+  .mini-row {
+    grid-template-columns: 84px minmax(0, 1fr);
+  }
+  .readout-v {
+    font-size: 24px;
+  }
+  .tab {
+    padding: 8px 12px 12px;
+  }
+  .tab-hint {
+    display: none;
+  }
+}

--- a/examples/shipyard-devops/src/components/FleetView.tsx
+++ b/examples/shipyard-devops/src/components/FleetView.tsx
@@ -1,0 +1,208 @@
+import { useMemo, useState } from "react";
+import { HeatCell } from "@microcharts/react/heat-cell/interactive";
+import { Honeycomb } from "@microcharts/react/honeycomb/interactive";
+import { MinimapStrip } from "@microcharts/react/minimap-strip/interactive";
+import { QueueDepth } from "@microcharts/react/queue-depth/interactive";
+import {
+  fleetMetrics,
+  fleetNodes,
+  fleetDomain,
+  capacity,
+  deployLog,
+  deployLogLength,
+  fleetBacklog,
+} from "../data";
+
+const fill = { width: "100%", height: "auto" } as const;
+
+const LEVELS = ["DEBUG", "INFO", "INFO", "WARN", "INFO"] as const;
+
+function logLine(i: number): { n: number; level: string; msg: string } {
+  const dens = deployLog.content[i] ?? 1;
+  const isDeploy = deployLog.marks.some((m) => Math.abs(m - i) < 4);
+  if (isDeploy) {
+    return {
+      n: i,
+      level: "WARN",
+      msg: `deploy boundary · release tagged · scanner checkpoint`,
+    };
+  }
+  const kind = i % 5;
+  const msg =
+    kind === 0
+      ? `worker scanned chunk ${i} · density ${dens}`
+      : kind === 1
+        ? `heartbeat ok · lag ${Math.round(dens * 12)}ms`
+        : kind === 2
+          ? `index write · ${Math.round(dens * 40)} docs`
+          : kind === 3
+            ? `retry backlog · ${Math.round(dens * 3)} pending`
+            : `gc pause · ${Math.round(dens * 8)}ms`;
+  return { n: i, level: LEVELS[i % LEVELS.length]!, msg };
+}
+
+export function FleetView() {
+  const [win, setWin] = useState<[number, number]>(deployLog.window);
+
+  const lines = useMemo(() => {
+    const a = Math.max(0, Math.floor(win[0]));
+    const b = Math.min(deployLogLength - 1, Math.ceil(win[1]));
+    const span = Math.max(1, b - a);
+    const count = 14;
+    const step = Math.max(1, Math.floor(span / count));
+    const out: ReturnType<typeof logLine>[] = [];
+    for (let i = a; i <= b && out.length < count; i += step) out.push(logLine(i));
+    return out;
+  }, [win]);
+
+  return (
+    <div className="stack">
+      <section className="panel span-2">
+        <div className="panel-head">
+          <h2>Node × metric heat matrix</h2>
+          <span className="panel-meta">7 nodes · utilization % · one shared 0–100 scale</span>
+        </div>
+        <div className="heat-matrix" role="table">
+          <div className="heat-mrow heat-mhead" role="row">
+            <span className="heat-node" role="columnheader">
+              node
+            </span>
+            <span className="heat-zone" role="columnheader">
+              zone
+            </span>
+            {fleetMetrics.map((m) => (
+              <span className="heat-col" role="columnheader" key={m}>
+                {m}
+              </span>
+            ))}
+          </div>
+          {fleetNodes.map((n) => (
+            <div className={"heat-mrow" + (n.hot ? " is-hot" : "")} role="row" key={n.node}>
+              <span className="heat-node" role="cell">
+                {n.node}
+              </span>
+              <span className="heat-zone" role="cell">
+                {n.zone}
+              </span>
+              {n.metrics.map((v, i) => (
+                <span className="heat-col" role="cell" key={fleetMetrics[i]}>
+                  <HeatCell
+                    value={v}
+                    domain={fleetDomain}
+                    steps={5}
+                    label="value"
+                    format={(x) => `${Math.round(x)}`}
+                    summary={`${n.node} ${fleetMetrics[i]}: ${v}%`}
+                    style={{ width: 30, height: 30 }}
+                  />
+                </span>
+              ))}
+            </div>
+          ))}
+        </div>
+        <p className="note">
+          node-b1 and node-c2 are running hot across every metric — candidates for cordon &amp;
+          drain.
+        </p>
+      </section>
+
+      <div className="grid-2">
+        <section className="panel">
+          <div className="panel-head">
+            <h2>Capacity</h2>
+            <span className="panel-meta">taken of total · unit counting</span>
+          </div>
+          <div className="cap-grid">
+            {capacity.map((c) => {
+              const pct = Math.round((c.value / c.total) * 100);
+              return (
+                <div className="cap-cell" key={c.label}>
+                  <Honeycomb
+                    value={c.value}
+                    total={c.total}
+                    unit={c.unit}
+                    rows="auto"
+                    cell={5}
+                    summary={`${c.label}: ${c.value} of ${c.total} ${c.unit}`}
+                    animate
+                    style={{ width: "100%", height: "auto", maxWidth: 168 }}
+                  />
+                  <div className="cap-meta">
+                    <span className="cap-label">{c.label}</span>
+                    <span className="cap-hint">{c.hint}</span>
+                    <span className="cap-count num">
+                      <strong>{c.value}</strong>
+                      <span className="dim">/{c.total}</span>
+                      <span
+                        className={"cap-pct " + (pct >= 90 ? "bad" : pct >= 75 ? "warn-t" : "good")}
+                      >
+                        {pct}%
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+
+        <section className="panel">
+          <div className="panel-head">
+            <h2>Retry backlog</h2>
+            <span className="panel-meta">jobs waiting · last hour</span>
+          </div>
+          <QueueDepth
+            data={fleetBacklog}
+            capacity={200}
+            label="last"
+            width={480}
+            height={110}
+            title="Retry queue depth over the last hour against a 200-job capacity"
+            animate
+            style={fill}
+          />
+          <p className="note">
+            Backlog peaked with the hot nodes, then drained as workers came back online.
+          </p>
+        </section>
+      </div>
+
+      <section className="panel span-2">
+        <div className="panel-head">
+          <h2>Deploy-log position</h2>
+          <span className="panel-meta">
+            {deployLogLength.toLocaleString()} lines · drag the window · marks = deploys
+          </span>
+        </div>
+        <MinimapStrip
+          data={deployLog}
+          mode="heat"
+          markLane
+          height={40}
+          width={1040}
+          summary={false}
+          onWindowChange={setWin}
+          animate
+          style={fill}
+        />
+        <p className="picker-readout">
+          viewing lines {Math.round(win[0]).toLocaleString()}–{Math.round(win[1]).toLocaleString()}{" "}
+          of {deployLogLength.toLocaleString()}
+        </p>
+        <div className="log-panel" aria-label="Log lines in the selected window">
+          {lines.map((l) => (
+            <div className="log-line" key={l.n}>
+              <span className="log-n num">{l.n.toLocaleString()}</span>
+              <span className={"log-lvl " + l.level.toLowerCase()}>{l.level}</span>
+              <span className="log-msg">{l.msg}</span>
+            </div>
+          ))}
+        </div>
+        <p className="note">
+          The minimap drives this pane — scrub the window and the lines follow. Trailing lines past
+          the last deploy are not yet indexed by the scanner.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/examples/shipyard-devops/src/components/IncidentsView.tsx
+++ b/examples/shipyard-devops/src/components/IncidentsView.tsx
@@ -1,0 +1,210 @@
+import { StatusDot } from "@microcharts/react/status-dot/interactive";
+import { Sparkline } from "@microcharts/react/sparkline/interactive";
+import { HistogramStrip } from "@microcharts/react/histogram-strip/interactive";
+import { ActivityGrid } from "@microcharts/react/activity-grid/interactive";
+import { EventTimeline } from "@microcharts/react/event-timeline/interactive";
+import { EventRaster } from "@microcharts/react/event-raster/interactive";
+import { Constellation } from "@microcharts/react/constellation/interactive";
+import {
+  incidentGrid,
+  incidentGridStart,
+  mttrTrend,
+  responseTimes,
+  responseP95,
+  severityLegend,
+  incidentLog,
+  opsWindows,
+  opsWindowNow,
+  opsWindowDomain,
+  eventSources,
+  eventSourcesDomain,
+  majorOutages,
+  outageDomainX,
+  outageWeek,
+} from "../data";
+import { ms, mins, hhmm, kmin } from "../format";
+
+const fill = { width: "100%", height: "auto" } as const;
+const dayTime = new Intl.DateTimeFormat("en-GB", {
+  hour: "2-digit",
+  minute: "2-digit",
+  timeZone: "UTC",
+});
+
+export function IncidentsView() {
+  return (
+    <div className="grid-2">
+      <section className="panel span-2">
+        <div className="panel-head">
+          <h2>Incident calendar</h2>
+          <span className="panel-meta">20 weeks · severity as intensity</span>
+        </div>
+        <div className="cal-layout">
+          <ActivityGrid
+            data={incidentGrid}
+            anchor={incidentGridStart}
+            weekStart={1}
+            domain={[0, 4]}
+            cell={14}
+            gap={3}
+            title="Incidents per day, last 20 weeks"
+            summary={false}
+            style={{ width: "100%", maxWidth: 460, height: "auto" }}
+          />
+          <div className="cal-side">
+            <div className="legend">
+              {severityLegend.map((l) => (
+                <span className="legend-item" key={l.label}>
+                  <StatusDot status={l.status} summary={false} />
+                  <span className="legend-label">{l.label}</span>
+                  <span className="legend-count">{l.count}</span>
+                </span>
+              ))}
+            </div>
+            <p className="note">
+              28 incidents across 20 weeks — two SEV-1s, both traced to the media-transcode encoder
+              pool. Cell intensity tracks the day&apos;s worst severity.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="panel span-2">
+        <div className="panel-head">
+          <h2>On-call &amp; release windows</h2>
+          <span className="panel-meta">24h · shifts · deploys · now 14:08 UTC</span>
+        </div>
+        <EventTimeline
+          data={opsWindows}
+          domain={opsWindowDomain}
+          now={opsWindowNow}
+          label="spans"
+          format={(n: number) => dayTime.format(n)}
+          width={1040}
+          height={96}
+          summary={false}
+          animate
+          style={fill}
+        />
+        <p className="note">
+          Release 2026.7.3 landed inside the day shift; the SEV-1 point event fired ~2h later.
+        </p>
+      </section>
+
+      <section className="panel span-2">
+        <div className="panel-head">
+          <h2>Event sources</h2>
+          <span className="panel-meta">
+            deploys · alerts · autoscale · cron · pages — one lane each
+          </span>
+        </div>
+        <EventRaster
+          data={eventSources}
+          domain={eventSourcesDomain}
+          labels
+          format={hhmm}
+          width={1040}
+          height={150}
+          summary={false}
+          animate
+          style={fill}
+        />
+        <p className="note">
+          Alerts and autoscale fire together around 13:38 — hover a tick to pin the lane and time.
+          The SEV-1 signature sits in that cluster.
+        </p>
+      </section>
+
+      <section className="panel">
+        <div className="panel-head">
+          <h2>MTTR trend</h2>
+          <span className="panel-meta">mean time to resolve · last 24</span>
+        </div>
+        <Sparkline
+          data={mttrTrend}
+          fill
+          dots="minmax"
+          label="minmax"
+          format={mins}
+          color="var(--mc-positive)"
+          width={500}
+          height={104}
+          summary={false}
+          style={fill}
+        />
+        <p className="note">
+          MTTR down from 84m to 24m over the window — automation + runbook coverage.
+        </p>
+      </section>
+
+      <section className="panel">
+        <div className="panel-head">
+          <h2>Response-time distribution</h2>
+          <span className="panel-meta">600 samples · p95 marked</span>
+        </div>
+        <HistogramStrip
+          data={responseTimes}
+          markValue={responseP95}
+          format={ms}
+          width={500}
+          height={104}
+          summary={false}
+          style={fill}
+        />
+        <p className="note">Right-skewed; the marked bin holds the p95 ({responseP95} ms) tail.</p>
+      </section>
+
+      <section className="panel span-2">
+        <div className="panel-head">
+          <h2>Major outages</h2>
+          <span className="panel-meta">this quarter · dot area = customer-minutes lost</span>
+        </div>
+        <Constellation
+          data={majorOutages}
+          xDomain={outageDomainX}
+          xFormat={outageWeek}
+          label="max"
+          format={kmin}
+          width={1040}
+          height={120}
+          summary={false}
+          animate
+          style={fill}
+        />
+        <p className="note">
+          Seven customer-visible outages in 13 weeks; the week-8 transcode failure dominates the
+          quarter (120k min).
+        </p>
+      </section>
+
+      <section className="panel span-2">
+        <div className="panel-head">
+          <h2>Recent incidents</h2>
+          <span className="panel-meta">last 3 days</span>
+        </div>
+        <div className="inc-table" role="table">
+          <div className="inc-row inc-head" role="row">
+            <span />
+            <span>id</span>
+            <span>service</span>
+            <span>summary</span>
+            <span className="num">mttr</span>
+            <span className="num">when</span>
+          </div>
+          {incidentLog.map((i) => (
+            <div className="inc-row" role="row" key={i.id}>
+              <span>
+                <StatusDot status={i.sev} pulse={i.sev === "error"} summary={i.sev} />
+              </span>
+              <span className="inc-id">{i.id}</span>
+              <span className="inc-svc">{i.service}</span>
+              <span className="inc-title">{i.title}</span>
+              <span className="num">{i.mttr}m</span>
+              <span className="num dim">{i.when}</span>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/examples/shipyard-devops/src/components/ServicesView.tsx
+++ b/examples/shipyard-devops/src/components/ServicesView.tsx
@@ -1,0 +1,220 @@
+import { useState } from "react";
+import { StatusDot } from "@microcharts/react/status-dot/interactive";
+import { Sparkline } from "@microcharts/react/sparkline/interactive";
+import { Delta } from "@microcharts/react/delta/interactive";
+import { Seismogram } from "@microcharts/react/seismogram/interactive";
+import { HeatStrip } from "@microcharts/react/heat-strip/interactive";
+import { MicroBox } from "@microcharts/react/micro-box/interactive";
+import { OrbitStatus } from "@microcharts/react/orbit-status/interactive";
+import {
+  services,
+  serviceBursts,
+  tenantLoad,
+  tenantLoadDomain,
+  dependencies,
+  dependencyLatencyDomain,
+  dependencyRateDomain,
+} from "../data";
+import { ms, msTight, pct2, rps } from "../format";
+
+const fill = { width: "100%", height: "auto" } as const;
+
+export function ServicesView() {
+  const [boxReadout, setBoxReadout] = useState<string | null>(null);
+
+  return (
+    <div className="stack">
+      <section className="panel panel-lead">
+        <div className="panel-head">
+          <h2>Microservices</h2>
+          <span className="panel-meta">p95 latency · error-rate Δ · 30d uptime</span>
+        </div>
+        <div className="svc-table" role="table">
+          <div className="svc-row svc-head" role="row">
+            <span role="columnheader" />
+            <span role="columnheader">service</span>
+            <span role="columnheader">zone</span>
+            <span role="columnheader">p95 latency · 60m</span>
+            <span role="columnheader" className="num">
+              p95
+            </span>
+            <span role="columnheader" className="num">
+              err-rate Δ
+            </span>
+            <span role="columnheader" className="num">
+              rps
+            </span>
+            <span role="columnheader" className="num">
+              uptime
+            </span>
+          </div>
+          {services.map((s) => (
+            <div className="svc-row" role="row" key={s.id}>
+              <span role="cell">
+                <StatusDot status={s.status} pulse={s.status === "error"} summary={s.status} />
+              </span>
+              <span role="cell" className="svc-name">
+                {s.name}
+              </span>
+              <span role="cell" className="svc-zone">
+                {s.zone}
+              </span>
+              <span role="cell">
+                <span className="mc-inline">
+                  <Sparkline
+                    data={s.latency}
+                    width={132}
+                    height={26}
+                    dots="auto"
+                    color={s.status === "error" ? "var(--mc-negative)" : undefined}
+                    summary={false}
+                  />
+                </span>
+              </span>
+              <span role="cell" className="num">
+                {s.p95} ms
+              </span>
+              <span role="cell" className="num">
+                <span className="mc-inline">
+                  <Delta
+                    value={s.errRate - s.errRatePrev}
+                    positive="down"
+                    format={pct2}
+                    summary={false}
+                  />
+                </span>
+              </span>
+              <span role="cell" className="num dim">
+                {s.rps.toLocaleString()}
+              </span>
+              <span role="cell" className={"num " + (s.uptime < 99.9 ? "bad" : "good")}>
+                {s.uptime.toFixed(3)}%
+              </span>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <div className="grid-2">
+        <section className="panel">
+          <div className="panel-head">
+            <h2>Error bursts</h2>
+            <span className="panel-meta">alert density · 48× 60s · flares ≥ 6</span>
+          </div>
+          <div className="row-list">
+            {serviceBursts.map((b) => (
+              <div className="mini-row" key={b.id}>
+                <span className="mini-row-label">
+                  <StatusDot status={b.status} summary={false} /> {b.name}
+                </span>
+                <Seismogram
+                  data={b.data}
+                  anomaly={b.anomaly}
+                  positive="down"
+                  height={24}
+                  width={340}
+                  summary={false}
+                  style={fill}
+                />
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="panel">
+          <div className="panel-head">
+            <h2>Latency spread</h2>
+            <span className="panel-meta">p95 IQR · 60m samples · median tick</span>
+          </div>
+          <div className="row-list">
+            {services.slice(0, 6).map((s) => (
+              <div className="mini-row" key={s.id}>
+                <span className="mini-row-label">
+                  <StatusDot status={s.status} summary={false} /> {s.name}
+                </span>
+                <MicroBox
+                  data={s.latency}
+                  whiskers="tukey"
+                  outliers
+                  format={msTight}
+                  height={22}
+                  width={340}
+                  color={s.status === "error" ? "var(--mc-negative)" : undefined}
+                  summary={false}
+                  onActive={(d) =>
+                    setBoxReadout(d ? `${s.name} · ${d.label}: ${msTight(d.value ?? 0)}` : null)
+                  }
+                  animate
+                  style={fill}
+                />
+              </div>
+            ))}
+          </div>
+          <p className="picker-readout">
+            {boxReadout ?? "hover or focus a row for its five-number summary"}
+          </p>
+        </section>
+
+        <section className="panel">
+          <div className="panel-head">
+            <h2>Tenant load</h2>
+            <span className="panel-meta">shared cluster · 40× 90s · step-scaled</span>
+          </div>
+          <div className="row-list">
+            {tenantLoad.map((t) => (
+              <div className="mini-row" key={t.tenant}>
+                <span className="mini-row-label">
+                  {t.tenant}
+                  <span className="mini-row-tag">{t.plan}</span>
+                </span>
+                <HeatStrip
+                  data={t.data}
+                  domain={tenantLoadDomain}
+                  steps={6}
+                  height={22}
+                  width={340}
+                  format={(n) => `${Math.round(n)}%`}
+                  summary={false}
+                  animate
+                  style={fill}
+                />
+              </div>
+            ))}
+          </div>
+          <p className="note">
+            acme-corp ramping toward cluster saturation — right edge running hot.
+          </p>
+        </section>
+
+        <section className="panel">
+          <div className="panel-head">
+            <h2>Dependencies</h2>
+            <span className="panel-meta">latency = orbit · rate = spin · alert flags</span>
+          </div>
+          <div className="dep-grid">
+            {dependencies.map((d) => (
+              <div className="dep-cell" key={d.name}>
+                <OrbitStatus
+                  latency={d.latency}
+                  rate={d.rate}
+                  latencyDomain={dependencyLatencyDomain}
+                  rateDomain={dependencyRateDomain}
+                  threshold={d.alert}
+                  size={44}
+                  summary={`${d.name}: ${d.latency} ms, ${Math.round(d.rate).toLocaleString()} ops/s`}
+                  style={{ width: "100%", height: "auto" }}
+                />
+                <span className="dep-name">{d.name}</span>
+                <span className="dep-kind">{d.kind}</span>
+                <span className={"dep-lat num " + (d.latency >= d.alert ? "bad" : "dim")}>
+                  {ms(d.latency)}
+                </span>
+                <span className="dep-rate num dim">{rps(d.rate)}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/examples/shipyard-devops/src/components/SlosView.tsx
+++ b/examples/shipyard-devops/src/components/SlosView.tsx
@@ -1,0 +1,250 @@
+import { useState } from "react";
+import { Bullet } from "@microcharts/react/bullet/interactive";
+import { ErrorBudget } from "@microcharts/react/error-budget/interactive";
+import { GradedBand } from "@microcharts/react/graded-band/interactive";
+import { BurnChart } from "@microcharts/react/burn-chart/interactive";
+import { DualWindowMeter } from "@microcharts/react/dual-window-meter/interactive";
+import { CoverageStrip } from "@microcharts/react/coverage-strip/interactive";
+import {
+  availabilitySlos,
+  latencySlos,
+  gatewayBudget,
+  transcodeBudget,
+  latencyDraws,
+  latencyCurrent,
+  incidentBurn,
+  cpuHeadroom,
+  cpuTarget,
+  latencyMeter,
+  latencyTarget,
+  metricCoverage,
+} from "../data";
+import { ms, pct2, pct3, utilPct } from "../format";
+
+const fill = { width: "100%", height: "auto" } as const;
+
+export function SlosView() {
+  const [cpuPin, setCpuPin] = useState<number | null>(null);
+
+  return (
+    <div className="grid-2">
+      <section className="panel">
+        <div className="panel-head">
+          <h2>Availability SLOs</h2>
+          <span className="panel-meta">attained vs target · 30d</span>
+        </div>
+        <div className="bullets">
+          {availabilitySlos.map((s) => (
+            <div className="bullet-row" key={s.name}>
+              <span className="bullet-label">{s.name}</span>
+              <Bullet
+                value={s.value}
+                target={s.target}
+                bands={s.bands}
+                domain={s.domain}
+                format={pct3}
+                width={500}
+                height={34}
+                summary={false}
+                style={fill}
+              />
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="panel">
+        <div className="panel-head">
+          <h2>Latency SLOs</h2>
+          <span className="panel-meta">p95 vs budget · lower is better</span>
+        </div>
+        <div className="bullets">
+          {latencySlos.map((s) => (
+            <div className="bullet-row" key={s.name}>
+              <span className="bullet-label">{s.name}</span>
+              <Bullet
+                value={s.value}
+                target={s.target}
+                bands={s.bands}
+                domain={s.domain}
+                format={ms}
+                width={500}
+                height={34}
+                summary={false}
+                style={fill}
+              />
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="panel">
+        <div className="panel-head">
+          <h2>CPU headroom · api-gateway</h2>
+          <span className="panel-meta">fast/slow mean vs 80% ceiling</span>
+        </div>
+        <DualWindowMeter
+          data={cpuHeadroom}
+          target={cpuTarget}
+          windows={[5, 20]}
+          label="last"
+          domain={[0, 100]}
+          format={utilPct}
+          width={500}
+          height={108}
+          summary={false}
+          onSelect={(d) => setCpuPin(d?.value ?? null)}
+          animate
+          style={fill}
+        />
+        <p className="picker-readout">
+          {cpuPin != null ? `pinned · ${utilPct(cpuPin)}` : "click the trace to pin a reading"}
+        </p>
+        <p className="note">
+          Slow mean drifting toward the ceiling — provisioner will add a replica before breach.
+        </p>
+      </section>
+
+      <section className="panel">
+        <div className="panel-head">
+          <h2>Latency compliance · checkout</h2>
+          <span className="panel-meta">p95 metering vs 100 ms line</span>
+        </div>
+        <DualWindowMeter
+          data={latencyMeter}
+          target={latencyTarget}
+          windows={[4, 16]}
+          band={[85, 100]}
+          label="last"
+          domain={[0, 160]}
+          format={ms}
+          width={500}
+          height={108}
+          summary={false}
+          animate
+          style={fill}
+        />
+        <p className="note">
+          Fast window pierced the corridor twice; sustained read still inside budget.
+        </p>
+      </section>
+
+      <section className="panel">
+        <div className="panel-head">
+          <h2>Error budget · api-gateway</h2>
+          <span className="panel-meta">30d window · remaining</span>
+        </div>
+        <ErrorBudget
+          data={gatewayBudget}
+          window={30}
+          unit="day"
+          label="remaining"
+          format={pct2}
+          width={500}
+          height={96}
+          summary={false}
+          style={fill}
+        />
+        <p className="note">
+          Burn accelerated after day 18; ~34% of budget left with 12 days to reset.
+        </p>
+      </section>
+
+      <section className="panel">
+        <div className="panel-head">
+          <h2>Error budget · media-transcode</h2>
+          <span className="panel-meta">30d window · exhausted</span>
+        </div>
+        <ErrorBudget
+          data={transcodeBudget}
+          window={30}
+          unit="day"
+          label="remaining"
+          format={pct2}
+          width={500}
+          height={96}
+          summary={false}
+          style={fill}
+        />
+        <p className="note bad-note">
+          Budget burned by day 14 — SEV-1 freeze in effect on this service.
+        </p>
+      </section>
+
+      <section className="panel">
+        <div className="panel-head">
+          <h2>Latency budget</h2>
+          <span className="panel-meta">p95 distribution vs current</span>
+        </div>
+        <GradedBand
+          data={latencyDraws}
+          value={latencyCurrent}
+          levels={[50, 80, 95]}
+          label="median"
+          format={ms}
+          width={500}
+          height={82}
+          summary={false}
+          style={fill}
+        />
+        <p className="note">
+          Median of the posterior is labeled; current p95 ({latencyCurrent} ms) is the hollow
+          overlay — inside the 80% band, within budget.
+        </p>
+      </section>
+
+      <section className="panel">
+        <div className="panel-head">
+          <h2>Incident burn-down</h2>
+          <span className="panel-meta">response backlog · story points</span>
+        </div>
+        <BurnChart
+          data={incidentBurn}
+          mode="down"
+          work="points"
+          unit="day"
+          label="gap"
+          projection
+          width={500}
+          height={128}
+          summary={false}
+          style={fill}
+        />
+        <p className="note">
+          Actual trailing plan; projected to clear ~1 day past the review deadline.
+        </p>
+      </section>
+
+      <section className="panel span-2">
+        <div className="panel-head">
+          <h2>Metric coverage</h2>
+          <span className="panel-meta">
+            scrape presence · 48 slots expected · gaps = missed pulls
+          </span>
+        </div>
+        <div className="cov-list">
+          {metricCoverage.map((c) => (
+            <div className="cov-row" key={c.metric}>
+              <span className="cov-metric">{c.metric}</span>
+              <span className="cov-source">{c.source}</span>
+              <CoverageStrip
+                data={c.data}
+                expected={c.expected}
+                label="percent"
+                height={24}
+                width={780}
+                summary={false}
+                animate
+                style={fill}
+              />
+            </div>
+          ))}
+        </div>
+        <p className="note">
+          jvm-agent dropped a 3-slot window during a GC pause; node-exporter has a trailing gap
+          under investigation.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/examples/shipyard-devops/src/data.ts
+++ b/examples/shipyard-devops/src/data.ts
@@ -1,0 +1,540 @@
+// Mock data for the Shipyard SRE / service-health console.
+// Deterministic pseudo-random so the "visual test" renders identically each run.
+
+export type Health = "ok" | "warn" | "error";
+
+let seed = 0x5eed;
+function rnd(): number {
+  // Mulberry32 — deterministic, no deps.
+  seed |= 0;
+  seed = (seed + 0x6d2b79f5) | 0;
+  let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+  t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+}
+
+/** A 60-point p95 latency series (last 60 minutes), base + noise + optional spike. */
+function latencySeries(base: number, jitter: number, spikeAt?: number, spikeMag = 3): number[] {
+  const out: number[] = [];
+  for (let i = 0; i < 60; i++) {
+    let v = base + (rnd() - 0.5) * 2 * jitter;
+    if (spikeAt !== undefined && i >= spikeAt && i < spikeAt + 4) {
+      v += base * spikeMag * (1 - (i - spikeAt) / 4);
+    }
+    out.push(Math.max(1, Math.round(v)));
+  }
+  return out;
+}
+
+export interface Service {
+  id: string;
+  name: string;
+  zone: string;
+  status: Health;
+  latency: number[]; // p95 ms, last 60 min
+  p95: number; // current p95 ms (last point)
+  errRate: number; // current error rate, fraction 0..1
+  errRatePrev: number; // prior-window error rate
+  uptime: number; // % over 30d
+  rps: number;
+}
+
+function build(
+  id: string,
+  name: string,
+  zone: string,
+  status: Health,
+  base: number,
+  jitter: number,
+  errRate: number,
+  errRatePrev: number,
+  uptime: number,
+  rps: number,
+  spikeAt?: number,
+  spikeMag?: number,
+): Service {
+  const latency = latencySeries(base, jitter, spikeAt, spikeMag);
+  return {
+    id,
+    name,
+    zone,
+    status,
+    latency,
+    p95: latency[latency.length - 1],
+    errRate,
+    errRatePrev,
+    uptime,
+    rps,
+  };
+}
+
+export const services: Service[] = [
+  build("svc-01", "api-gateway", "us-east-1", "ok", 42, 6, 0.0008, 0.0011, 99.982, 8420),
+  build("svc-02", "auth", "us-east-1", "ok", 28, 4, 0.0004, 0.0005, 99.995, 3110),
+  build("svc-03", "billing-worker", "us-east-1", "warn", 88, 22, 0.0142, 0.0068, 99.94, 640, 46, 2),
+  build("svc-04", "checkout", "us-east-1", "ok", 64, 9, 0.0021, 0.0026, 99.977, 1980),
+  build(
+    "svc-05",
+    "search-index",
+    "eu-west-1",
+    "warn",
+    120,
+    30,
+    0.0089,
+    0.0091,
+    99.951,
+    1240,
+    38,
+    1.4,
+  ),
+  build("svc-06", "notifications", "us-east-1", "ok", 35, 7, 0.0012, 0.0015, 99.988, 2760),
+  build(
+    "svc-07",
+    "media-transcode",
+    "eu-west-1",
+    "error",
+    210,
+    70,
+    0.0631,
+    0.0187,
+    99.62,
+    410,
+    50,
+    4,
+  ),
+  build("svc-08", "analytics-ingest", "us-west-2", "ok", 52, 8, 0.0018, 0.0017, 99.973, 5230),
+];
+
+// ── SLO attainment (availability %, higher is better) ────────────────────────
+export interface SloRow {
+  name: string;
+  value: number; // attained %
+  target: number; // SLO target %
+  bands: number[]; // ascending qualitative thresholds
+  domain: [number, number];
+}
+
+export const availabilitySlos: SloRow[] = [
+  {
+    name: "api-gateway · availability",
+    value: 99.982,
+    target: 99.9,
+    bands: [99.5, 99.9],
+    domain: [99, 100],
+  },
+  {
+    name: "auth · availability",
+    value: 99.995,
+    target: 99.95,
+    bands: [99.9, 99.95],
+    domain: [99.5, 100],
+  },
+  {
+    name: "checkout · availability",
+    value: 99.977,
+    target: 99.95,
+    bands: [99.9, 99.95],
+    domain: [99.5, 100],
+  },
+  {
+    name: "media-transcode · availability",
+    value: 99.62,
+    target: 99.9,
+    bands: [99.5, 99.9],
+    domain: [99, 100],
+  },
+];
+
+// Latency SLO (p95 ms, lower is better — value under target is good)
+export const latencySlos: SloRow[] = [
+  { name: "api-gateway · p95 latency", value: 42, target: 75, bands: [75, 120], domain: [0, 150] },
+  {
+    name: "search-index · p95 latency",
+    value: 120,
+    target: 100,
+    bands: [100, 150],
+    domain: [0, 200],
+  },
+];
+
+// ── Error budget: fraction of the 30-day budget remaining, index 0 = 1.0 ──────
+function errorBudget(startBurn: number, dailyBurn: number, noise: number): number[] {
+  const out = [1];
+  let v = 1;
+  for (let d = 1; d < 30; d++) {
+    const burn = dailyBurn * (d > startBurn ? 1.8 : 1) + (rnd() - 0.5) * noise;
+    v = Math.max(0, v - Math.max(0, burn));
+    out.push(Number(v.toFixed(4)));
+  }
+  return out;
+}
+
+export const gatewayBudget = errorBudget(18, 0.012, 0.004);
+export const transcodeBudget = errorBudget(6, 0.05, 0.01);
+
+// ── Latency budget posterior (draws of p95 ms) for the GradedBand ─────────────
+export const latencyDraws: number[] = Array.from({ length: 240 }, () => {
+  // roughly log-normal around ~64ms
+  const g = (rnd() + rnd() + rnd() + rnd() - 2) / 2; // ~N(0,1)
+  return Math.round(64 * Math.exp(g * 0.28));
+});
+export const latencyCurrent = 71; // current p95 overlay
+
+// ── Incident burn-down (remaining incident-response work, story points) ───────
+export const incidentBurn = {
+  plan: [40, 36, 32, 28, 24, 20, 16, 12, 8, 4, 0],
+  actual: [40, 38, 35, 33, 26, 24, 21, 15, 11, 6],
+};
+
+// ── Incidents over 20 weeks (140 days), severity 0..4 as the value ────────────
+export const incidentGrid: number[] = Array.from({ length: 140 }, () => {
+  const r = rnd();
+  if (r > 0.9) return 4;
+  if (r > 0.82) return 3;
+  if (r > 0.68) return 2;
+  if (r > 0.45) return 1;
+  return 0;
+});
+export const incidentGridStart = "2026-02-24"; // a Monday
+
+// ── MTTR trend (minutes to resolve, last 24 incidents) ────────────────────────
+export const mttrTrend: number[] = [
+  84, 92, 76, 71, 68, 74, 63, 59, 66, 51, 48, 55, 44, 41, 47, 39, 36, 42, 33, 31, 29, 34, 27, 24,
+];
+
+// ── Response-time distribution: raw observations (ms) for the histogram ────────
+export const responseTimes: number[] = Array.from({ length: 600 }, () => {
+  const g = (rnd() + rnd() + rnd() + rnd() - 2) / 2;
+  return Math.max(4, Math.round(58 * Math.exp(g * 0.42)));
+});
+export const responseP95 = 128; // marked bin
+
+// ── Incident severity legend + recent incident log ───────────────────────────
+export const severityLegend: { status: Health; label: string; count: number }[] = [
+  { status: "error", label: "SEV-1 · critical", count: 2 },
+  { status: "warn", label: "SEV-2 · major", count: 7 },
+  { status: "ok", label: "SEV-3 · minor", count: 19 },
+];
+
+export interface IncidentRow {
+  id: string;
+  sev: Health;
+  service: string;
+  title: string;
+  mttr: number; // minutes
+  when: string;
+}
+
+export const incidentLog: IncidentRow[] = [
+  {
+    id: "INC-4471",
+    sev: "error",
+    service: "media-transcode",
+    title: "Encoder pool saturation",
+    mttr: 84,
+    when: "2h ago",
+  },
+  {
+    id: "INC-4468",
+    sev: "warn",
+    service: "billing-worker",
+    title: "Retry storm on ledger write",
+    mttr: 41,
+    when: "yda",
+  },
+  {
+    id: "INC-4465",
+    sev: "warn",
+    service: "search-index",
+    title: "Shard rebalance latency spike",
+    mttr: 33,
+    when: "1d ago",
+  },
+  {
+    id: "INC-4460",
+    sev: "ok",
+    service: "notifications",
+    title: "Elevated queue depth",
+    mttr: 24,
+    when: "2d ago",
+  },
+  {
+    id: "INC-4458",
+    sev: "warn",
+    service: "api-gateway",
+    title: "TLS handshake errors (region)",
+    mttr: 47,
+    when: "3d ago",
+  },
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  SERVICES · error bursts (Seismogram) — per-slot alert intensity, 0 = quiet
+// ─────────────────────────────────────────────────────────────────────────────
+function burstSeries(density: number, mag: number, spikeAt?: number): (number | null)[] {
+  const out: (number | null)[] = [];
+  for (let i = 0; i < 48; i++) {
+    let v = 0;
+    if (rnd() < density) v = Math.round((0.3 + rnd() * 0.7) * mag);
+    if (spikeAt !== undefined && i >= spikeAt && i < spikeAt + 3) {
+      v = Math.max(v, Math.round(mag * (1.5 - (i - spikeAt) * 0.35)));
+    }
+    out.push(v);
+  }
+  return out;
+}
+
+export interface BurstRow {
+  id: string;
+  name: string;
+  status: Health;
+  data: (number | null)[];
+  anomaly: number;
+}
+
+export const serviceBursts: BurstRow[] = [
+  {
+    id: "svc-07",
+    name: "media-transcode",
+    status: "error",
+    data: burstSeries(0.22, 9, 40),
+    anomaly: 6,
+  },
+  {
+    id: "svc-03",
+    name: "billing-worker",
+    status: "warn",
+    data: burstSeries(0.16, 6, 34),
+    anomaly: 6,
+  },
+  {
+    id: "svc-05",
+    name: "search-index",
+    status: "warn",
+    data: burstSeries(0.14, 5, 30),
+    anomaly: 6,
+  },
+  { id: "svc-01", name: "api-gateway", status: "ok", data: burstSeries(0.05, 4), anomaly: 6 },
+  { id: "svc-04", name: "checkout", status: "ok", data: burstSeries(0.04, 3), anomaly: 6 },
+  { id: "svc-08", name: "analytics-ingest", status: "ok", data: burstSeries(0.03, 3), anomaly: 6 },
+];
+
+// ── SERVICES · per-tenant load ribbon (HeatStrip), shared domain [0, 100] ─────
+export interface TenantRow {
+  tenant: string;
+  plan: string;
+  data: number[];
+}
+
+function loadRibbon(base: number, swing: number, rampTo?: number): number[] {
+  const out: number[] = [];
+  for (let i = 0; i < 40; i++) {
+    const ramp = rampTo !== undefined ? (rampTo - base) * (i / 39) : 0;
+    const v = base + ramp + Math.sin(i / 4) * swing * 0.4 + (rnd() - 0.5) * swing;
+    out.push(Math.max(0, Math.min(100, Math.round(v))));
+  }
+  return out;
+}
+
+export const tenantLoad: TenantRow[] = [
+  { tenant: "acme-corp", plan: "enterprise", data: loadRibbon(58, 24, 92) },
+  { tenant: "globex", plan: "enterprise", data: loadRibbon(44, 18) },
+  { tenant: "initech", plan: "business", data: loadRibbon(31, 14) },
+  { tenant: "umbrella", plan: "business", data: loadRibbon(22, 20, 68) },
+  { tenant: "hooli", plan: "startup", data: loadRibbon(14, 10) },
+];
+export const tenantLoadDomain: [number, number] = [0, 100];
+
+// ── SERVICES · dependency health dots (OrbitStatus): latency + rate together ──
+export interface DependencyDot {
+  name: string;
+  kind: string;
+  latency: number; // ms
+  rate: number; // ops/s
+  alert: number; // latency threshold
+}
+
+export const dependencies: DependencyDot[] = [
+  { name: "postgres-primary", kind: "database", latency: 8, rate: 12400, alert: 40 },
+  { name: "redis-cache", kind: "cache", latency: 2, rate: 48200, alert: 15 },
+  { name: "kafka-broker", kind: "queue", latency: 22, rate: 9100, alert: 60 },
+  { name: "s3-blob", kind: "object-store", latency: 54, rate: 2300, alert: 80 },
+  { name: "elasticsearch", kind: "search", latency: 118, rate: 1450, alert: 90 },
+  { name: "stripe-api", kind: "external", latency: 214, rate: 380, alert: 150 },
+];
+export const dependencyLatencyDomain: [number, number] = [0, 260];
+export const dependencyRateDomain: [number, number] = [0, 50000];
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  SLOs · CPU headroom + latency compliance (DualWindowMeter) — raw + target
+// ─────────────────────────────────────────────────────────────────────────────
+function meterSeries(base: number, jitter: number, drift: number): number[] {
+  const out: number[] = [];
+  for (let i = 0; i < 72; i++) {
+    const v = base + drift * (i / 71) + Math.sin(i / 6) * jitter * 0.5 + (rnd() - 0.5) * jitter;
+    out.push(Math.max(0, Math.round(v * 10) / 10));
+  }
+  return out;
+}
+
+export const cpuHeadroom = meterSeries(58, 12, 14); // CPU util %, climbing
+export const cpuTarget = 80; // saturation ceiling
+export const latencyMeter = meterSeries(72, 22, 26); // p95 ms, drifting up
+export const latencyTarget = 100; // SLO ceiling
+
+// ── SLOs · metric data-quality (CoverageStrip): scrape presence, nulls = gaps ─
+export interface CoverageRow {
+  metric: string;
+  source: string;
+  data: (number | null)[];
+  expected: number;
+}
+
+function coverage(gapAt: number[], trailingGap = 0): (number | null)[] {
+  const out: (number | null)[] = [];
+  for (let i = 0; i < 48; i++) {
+    if (gapAt.includes(i) || (trailingGap > 0 && i >= 48 - trailingGap)) out.push(null);
+    else out.push(Math.round((0.4 + rnd() * 0.6) * 100) / 100);
+  }
+  return out;
+}
+
+export const metricCoverage: CoverageRow[] = [
+  { metric: "cpu.util", source: "node-exporter", data: coverage([]), expected: 48 },
+  { metric: "http.p95", source: "envoy-stats", data: coverage([19, 20]), expected: 48 },
+  { metric: "gc.pause", source: "jvm-agent", data: coverage([7, 8, 9, 33]), expected: 48 },
+  { metric: "disk.io", source: "node-exporter", data: coverage([], 6), expected: 48 },
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  INCIDENTS · on-call & release windows (EventTimeline), epoch-ms over a day
+// ─────────────────────────────────────────────────────────────────────────────
+const DAY0 = Date.UTC(2026, 6, 16, 0, 0, 0);
+const H = 3_600_000;
+export const opsWindowNow = DAY0 + 14 * H + 8 * 60_000; // 14:08 UTC
+
+export interface OpsEvent {
+  start: number;
+  end?: number;
+  label?: string;
+  kind?: "neutral" | "positive" | "negative" | "accent";
+}
+
+export const opsWindows: OpsEvent[] = [
+  { start: DAY0, end: DAY0 + 8 * H, label: "on-call · night", kind: "neutral" },
+  { start: DAY0 + 8 * H, end: DAY0 + 16 * H, label: "on-call · day", kind: "neutral" },
+  { start: DAY0 + 16 * H, end: DAY0 + 24 * H, label: "on-call · swing", kind: "neutral" },
+  { start: DAY0 + 9.5 * H, end: DAY0 + 10.5 * H, label: "deploy freeze lift", kind: "positive" },
+  { start: DAY0 + 11 * H, end: DAY0 + 11.4 * H, label: "release 2026.7.3", kind: "accent" },
+  { start: DAY0 + 13.6 * H, label: "SEV-1 · transcode", kind: "negative" },
+  { start: DAY0 + 15 * H, end: DAY0 + 15.3 * H, label: "hotfix 2026.7.4", kind: "accent" },
+];
+export const opsWindowDomain: [number, number] = [DAY0, DAY0 + 24 * H];
+
+// ── INCIDENTS · event sources raster (EventRaster), minutes 0..1440 over a day ─
+export interface RasterLane {
+  label: string;
+  events: number[];
+}
+
+function fireLane(count: number, clusterAt?: number): number[] {
+  const out: number[] = [];
+  for (let i = 0; i < count; i++) {
+    let t = rnd() * 1440;
+    if (clusterAt !== undefined && rnd() < 0.5) t = clusterAt + (rnd() - 0.5) * 90;
+    out.push(Math.round(Math.max(0, Math.min(1440, t))));
+  }
+  return out.sort((a, b) => a - b);
+}
+
+export const eventSources: RasterLane[] = [
+  { label: "deploys", events: [130, 340, 570, 662, 905, 1088, 1290] },
+  { label: "alerts", events: fireLane(14, 818) },
+  { label: "autoscale", events: fireLane(20, 818) },
+  { label: "cron", events: [0, 240, 480, 720, 960, 1200, 1439, 360, 1080] },
+  { label: "on-call page", events: [512, 820, 826, 831, 1140] },
+];
+export const eventSourcesDomain: [number, number] = [0, 1440];
+
+// ── INCIDENTS · sparse major outages over the quarter (Constellation) ─────────
+export interface OutagePoint {
+  x: number; // day index in the quarter (0..91)
+  y?: number; // customer-minutes lost (thousands)
+  m?: number; // severity magnitude (1..4)
+}
+
+export const majorOutages: OutagePoint[] = [
+  { x: 6, y: 18, m: 2 },
+  { x: 19, y: 44, m: 3 },
+  { x: 31, y: 9, m: 1 },
+  { x: 48, y: 120, m: 4 },
+  { x: 57, y: 32, m: 2 },
+  { x: 73, y: 61, m: 3 },
+  { x: 88, y: 15, m: 2 },
+];
+export const outageDomainX: [number, number] = [0, 91];
+export const outageWeek = (x: number) => `wk ${Math.floor(x / 7) + 1}`;
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  FLEET · node × metric intensity matrix (HeatCell), shared domain [0, 100]
+// ─────────────────────────────────────────────────────────────────────────────
+export const fleetMetrics = ["cpu", "mem", "disk", "net", "iops"] as const;
+
+export interface FleetNode {
+  node: string;
+  zone: string;
+  metrics: number[]; // one per fleetMetrics column, 0..100
+  hot: boolean;
+}
+
+function nodeRow(bias: number, spread: number): number[] {
+  return fleetMetrics.map(() => {
+    const v = bias + (rnd() - 0.5) * 2 * spread;
+    return Math.max(2, Math.min(100, Math.round(v)));
+  });
+}
+
+export const fleetNodes: FleetNode[] = [
+  { node: "node-a1", zone: "us-east-1a", metrics: nodeRow(38, 22), hot: false },
+  { node: "node-a2", zone: "us-east-1a", metrics: nodeRow(46, 24), hot: false },
+  { node: "node-b1", zone: "us-east-1b", metrics: nodeRow(84, 16), hot: true },
+  { node: "node-b2", zone: "us-east-1b", metrics: nodeRow(52, 26), hot: false },
+  { node: "node-c1", zone: "eu-west-1a", metrics: nodeRow(30, 18), hot: false },
+  { node: "node-c2", zone: "eu-west-1a", metrics: nodeRow(71, 20), hot: true },
+  { node: "node-d1", zone: "us-west-2a", metrics: nodeRow(42, 22), hot: false },
+];
+export const fleetDomain: [number, number] = [0, 100];
+
+// ── FLEET · capacity honeycombs (seats / pods / runners taken of total) ───────
+export interface CapacityCell {
+  label: string;
+  hint: string;
+  value: number;
+  total: number;
+  unit: string;
+}
+
+export const capacity: CapacityCell[] = [
+  { label: "Pod slots", hint: "kubernetes · prod", value: 47, total: 60, unit: "pods" },
+  { label: "Build runners", hint: "ci fleet", value: 22, total: 24, unit: "runners" },
+  { label: "Seat licenses", hint: "observability", value: 38, total: 50, unit: "seats" },
+];
+
+// ── FLEET · position in a long deploy log (MinimapStrip) ──────────────────────
+export const deployLogLength = 2048;
+export const deployLog = {
+  content: Array.from({ length: deployLogLength }, (_, i) => {
+    // density of log lines; occasional bursts around deploys
+    const burst = [180, 512, 903, 1340, 1720].some((c) => Math.abs(i - c) < 22);
+    return Math.round((burst ? 6 : 1) * (0.4 + rnd()) * 10) / 10;
+  }) as number[],
+  window: [1290, 1470] as [number, number],
+  marks: [180, 512, 903, 1340, 1720], // deploy boundaries
+  known: [[0, 1580]] as [number, number][], // scanned range (trailing tail unindexed)
+};
+
+/** Retry backlog depth for the fleet QueueDepth panel. */
+export const fleetBacklog = [
+  28, 34, 41, 55, 72, 98, 124, 156, 178, 168, 149, 132, 118, 102, 88, 74, 61, 52, 44, 38, 33, 29,
+  26, 24,
+];

--- a/examples/shipyard-devops/src/format.ts
+++ b/examples/shipyard-devops/src/format.ts
@@ -1,0 +1,19 @@
+// Shared formatters. Passed to charts as `format` — never `new Intl` in a
+// component; either a plain fn or an Intl options object (both are valid Format).
+
+export const ms = (n: number) => `${Math.round(n)} ms`;
+export const msTight = (n: number) => `${Math.round(n)}ms`;
+export const pct0 = { style: "percent", maximumFractionDigits: 0 } as const;
+export const pct2 = { style: "percent", maximumFractionDigits: 2 } as const;
+export const pct3 = (n: number) => `${n.toFixed(3)}%`;
+export const utilPct = (n: number) => `${Math.round(n)}%`;
+export const mins = (n: number) => `${Math.round(n)}m`;
+export const kmin = (n: number) => `${Math.round(n)}k min`;
+export const rps = (n: number) => `${Math.round(n).toLocaleString()} rps`;
+
+/** Minutes-since-midnight → HH:MM (event-raster / timeline axes). */
+export const hhmm = (n: number) => {
+  const h = Math.floor(n / 60);
+  const m = Math.round(n % 60);
+  return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+};

--- a/examples/shipyard-devops/src/main.tsx
+++ b/examples/shipyard-devops/src/main.tsx
@@ -1,0 +1,16 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { MicroProvider } from "@microcharts/react";
+import "@microcharts/react/styles.css";
+import "@microcharts/react/motion";
+import "./app.css";
+import "./analytics";
+import { App } from "./App";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <MicroProvider theme="mono">
+      <App />
+    </MicroProvider>
+  </StrictMode>,
+);

--- a/examples/shipyard-devops/tsconfig.json
+++ b/examples/shipyard-devops/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "moduleDetection": "force",
+    "isolatedModules": true
+  },
+  "include": ["src"]
+}

--- a/examples/shipyard-devops/vite.config.ts
+++ b/examples/shipyard-devops/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: { port: 4004, strictPort: true, host: true },
+});

--- a/examples/vitals-health/index.html
+++ b/examples/vitals-health/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <meta
+      name="description"
+      content="Vitals — a warm, unclinical read on your day. Word-sized charts by @microcharts/react."
+    />
+    <meta name="theme-color" content="#f6efe2" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#1a1610" media="(prefers-color-scheme: dark)" />
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <!-- Literata: a warm humanist book serif (the almanac voice).
+         Hanken Grotesk: a clean humanist sans (the instrument / data face). -->
+    <link
+      href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:ital,wght@0,400;0,500;0,600;0,700;0,800;1,500&family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,500;0,7..72,600;0,7..72,700;1,7..72,400;1,7..72,500&display=swap"
+      rel="stylesheet"
+    />
+
+    <title>Vitals — a gentle read on your day</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/vitals-health/package.json
+++ b/examples/vitals-health/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "example-vitals-health",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite --port 4003 --strictPort",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview --port 4003 --strictPort"
+  },
+  "dependencies": {
+    "@microcharts/react": "^0.8.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^5.0.0",
+    "typescript": "^5.7.0",
+    "vite": "^7.0.0"
+  }
+}

--- a/examples/vitals-health/public/robots.txt
+++ b/examples/vitals-health/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/examples/vitals-health/src/App.tsx
+++ b/examples/vitals-health/src/App.tsx
@@ -1,0 +1,110 @@
+import { useState } from "react";
+import { TodayView } from "./components/TodayView";
+import { SleepView } from "./components/SleepView";
+import { MoveView } from "./components/MoveView";
+import { TrendsView } from "./components/TrendsView";
+
+type Tab = "today" | "sleep" | "move" | "trends";
+
+const TABS: { id: Tab; label: string }[] = [
+  { id: "today", label: "Today" },
+  { id: "sleep", label: "Sleep" },
+  { id: "move", label: "Move" },
+  { id: "trends", label: "Trends" },
+];
+
+export function App() {
+  const [tab, setTab] = useState<Tab>("today");
+
+  return (
+    <div className="app">
+      <header className="masthead">
+        <div className="brand">
+          {/* a small rising sun — gentle momentum, not a clinical logo */}
+          <svg className="brand__mark" viewBox="0 0 34 26" fill="none" aria-hidden="true">
+            <path
+              className="sun"
+              d="M8 20 A9 9 0 0 1 26 20"
+              strokeWidth="2.4"
+              strokeLinecap="round"
+            />
+            <line
+              className="horizon"
+              x1="2"
+              y1="20"
+              x2="32"
+              y2="20"
+              strokeWidth="2.4"
+              strokeLinecap="round"
+            />
+            <line
+              className="ray"
+              x1="17"
+              y1="3"
+              x2="17"
+              y2="7.5"
+              strokeWidth="2.2"
+              strokeLinecap="round"
+            />
+            <line
+              className="ray"
+              x1="5.5"
+              y1="8"
+              x2="8.5"
+              y2="10.5"
+              strokeWidth="2.2"
+              strokeLinecap="round"
+            />
+            <line
+              className="ray"
+              x1="28.5"
+              y1="8"
+              x2="25.5"
+              y2="10.5"
+              strokeWidth="2.2"
+              strokeLinecap="round"
+            />
+          </svg>
+          <span className="brand__word">
+            <span className="brand__name">Vitals</span>
+            <span className="brand__tag">your day, gently measured</span>
+          </span>
+        </div>
+
+        <div className="dateline">
+          <span className="dateline__greet">Good morning, Mara.</span>
+          <time className="dateline__date" dateTime="2026-07-15">
+            Wednesday, July 15
+          </time>
+        </div>
+      </header>
+
+      <nav className="tabs" aria-label="Views">
+        {TABS.map((t) => (
+          <button
+            key={t.id}
+            className={`tab${tab === t.id ? " tab--on" : ""}`}
+            onClick={() => setTab(t.id)}
+            aria-current={tab === t.id ? "page" : undefined}
+          >
+            {t.label}
+          </button>
+        ))}
+      </nav>
+
+      <main className="content" key={tab}>
+        {tab === "today" && <TodayView />}
+        {tab === "sleep" && <SleepView />}
+        {tab === "move" && <MoveView />}
+        {tab === "trends" && <TrendsView />}
+      </main>
+
+      <footer className="foot">
+        <span className="foot__name">Vitals</span>
+        <span className="foot__credit">
+          Charts rendered by <code>@microcharts/react</code>
+        </span>
+      </footer>
+    </div>
+  );
+}

--- a/examples/vitals-health/src/analytics.ts
+++ b/examples/vitals-health/src/analytics.ts
@@ -1,0 +1,14 @@
+// Cloudflare Web Analytics — privacy-first, cookieless page-view/visit beacon.
+// Injected only when VITE_CF_BEACON_TOKEN is set at build time; otherwise a no-op.
+// Get a token: Cloudflare dashboard → Web Analytics → Add a site → copy the token
+// (or just enable Web Analytics on the Pages project, which auto-injects instead). See DEPLOY.md.
+const token = (import.meta as unknown as { env?: Record<string, string | undefined> }).env
+  ?.VITE_CF_BEACON_TOKEN;
+if (token) {
+  const s = document.createElement("script");
+  s.defer = true;
+  s.src = "https://static.cloudflareinsights.com/beacon.min.js";
+  s.setAttribute("data-cf-beacon", JSON.stringify({ token }));
+  document.head.appendChild(s);
+}
+export {};

--- a/examples/vitals-health/src/app.css
+++ b/examples/vitals-health/src/app.css
@@ -1,0 +1,851 @@
+/* ═══════════════════════════════════════════════════════════════════════════
+   VITALS — a warm editorial-wellness read on your day.
+
+   Aesthetic: a personal health almanac printed on cream stock. A humanist book
+   serif (Literata) carries the voice; a clean humanist sans (Hanken Grotesk)
+   carries every number and chart label. One warm terracotta accent, neutrals
+   tinted toward clay, no pure black or white. Soft surfaces, high legibility,
+   generous vertical rhythm. Never clinical, never gamified.
+
+   FONT TRAP (do not break): --mc-font / --mc-font-numeric stay on the SANS so
+   SVG chart text never inherits the serif.
+   ═════════════════════════════════════════════════════════════════════════ */
+
+:root {
+  color-scheme: light;
+
+  /* ─── type ─────────────────────────────────────────────────────────── */
+  --font-display: "Literata", Georgia, "Iowan Old Style", serif;
+  --font-body: "Hanken Grotesk", system-ui, -apple-system, "Segoe UI", sans-serif;
+
+  /* charts inherit a clean sans, never the serif */
+  --mc-font: "Hanken Grotesk", system-ui, -apple-system, sans-serif;
+  --mc-font-numeric: "Hanken Grotesk", ui-monospace, "SF Mono", monospace;
+
+  /* fixed rem scale, ~1.25 ratio */
+  --fs-micro: 0.72rem;
+  --fs-label: 0.76rem;
+  --fs-sm: 0.86rem;
+  --fs-base: 1rem;
+  --fs-lg: 1.2rem;
+  --fs-xl: 1.5rem;
+  --fs-2xl: 1.9rem;
+
+  /* ─── space (4pt) ──────────────────────────────────────────────────── */
+  --sp-1: 4px;
+  --sp-2: 8px;
+  --sp-3: 12px;
+  --sp-4: 16px;
+  --sp-5: 24px;
+  --sp-6: 32px;
+  --sp-7: 48px;
+  --sp-8: 64px;
+
+  /* ─── warm clay/cream palette (OKLCH, neutrals tinted toward clay) ──── */
+  --bg: oklch(0.965 0.016 72);
+  --bg-2: oklch(0.945 0.023 70);
+  --surface: oklch(0.988 0.01 78);
+  --surface-2: oklch(0.968 0.016 74);
+  --line: oklch(0.9 0.02 68);
+  --line-strong: oklch(0.855 0.03 62);
+  --ink: oklch(0.29 0.024 52);
+  --ink-2: oklch(0.47 0.03 54);
+  --muted: oklch(0.615 0.028 58);
+  --accent: oklch(0.585 0.15 40); /* terracotta */
+  --accent-ink: oklch(0.5 0.16 38); /* accent text on cream, AA */
+  --accent-wash: oklch(0.94 0.04 55);
+  --gold: oklch(0.74 0.108 72); /* secondary warm, decoration only */
+
+  --radius: 20px;
+  --radius-sm: 13px;
+  --radius-pill: 999px;
+
+  --shadow: 0 1px 2px oklch(0.4 0.05 50 / 0.06), 0 12px 30px -18px oklch(0.4 0.06 45 / 0.22);
+  --shadow-lift: 0 2px 6px oklch(0.4 0.05 50 / 0.08), 0 22px 44px -20px oklch(0.4 0.06 45 / 0.3);
+
+  --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  -webkit-text-size-adjust: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-body);
+  font-size: var(--fs-base);
+  color: var(--ink);
+  background: var(--bg);
+  background-image: radial-gradient(145% 100% at 50% -18%, var(--bg-2) 0%, var(--bg) 60%);
+  background-attachment: fixed;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  line-height: 1.55;
+  overflow-x: hidden;
+}
+
+/* faint paper grain — the "cream stock" feel. static, decorative, non-blocking. */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  mix-blend-mode: multiply;
+  opacity: 0.5;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.35'/%3E%3C/svg%3E");
+}
+
+::selection {
+  background: var(--accent-wash);
+  color: var(--ink);
+}
+
+/* ─── shell ──────────────────────────────────────────────────────────── */
+
+.app {
+  position: relative;
+  z-index: 1;
+  max-width: 1060px;
+  margin: 0 auto;
+  padding: clamp(22px, 4vw, 52px) clamp(16px, 4vw, 34px) 80px;
+}
+
+/* ─── masthead ───────────────────────────────────────────────────────── */
+
+.masthead {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: end;
+  gap: var(--sp-4) var(--sp-5);
+  padding-bottom: var(--sp-5);
+  border-bottom: 1px solid var(--line-strong);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+}
+
+.brand__mark {
+  width: 34px;
+  height: 26px;
+  flex: 0 0 auto;
+  overflow: visible;
+}
+.brand__mark .horizon {
+  stroke: var(--line-strong);
+}
+.brand__mark .sun,
+.brand__mark .ray {
+  stroke: var(--accent);
+}
+
+.brand__word {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.brand__name {
+  font-family: var(--font-display);
+  font-size: var(--fs-wordmark, clamp(1.7rem, 4.5vw, 2.25rem));
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  line-height: 0.95;
+  color: var(--ink);
+}
+.brand__tag {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: var(--fs-sm);
+  color: var(--muted);
+  letter-spacing: 0.01em;
+}
+
+.dateline {
+  text-align: right;
+  display: grid;
+  gap: 2px;
+  justify-items: end;
+}
+.dateline__greet {
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  font-weight: 500;
+  color: var(--ink);
+  line-height: 1.1;
+}
+.dateline__date {
+  font-size: var(--fs-sm);
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.01em;
+}
+
+/* ─── section nav ────────────────────────────────────────────────────── */
+
+.tabs {
+  display: flex;
+  gap: clamp(18px, 4vw, 30px);
+  margin: var(--sp-5) 0 var(--sp-6);
+  border-bottom: 1px solid var(--line);
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+.tabs::-webkit-scrollbar {
+  display: none;
+}
+
+.tab {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--ink-2);
+  font-family: var(--font-body);
+  font-weight: 600;
+  font-size: var(--fs-label);
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+  padding: 0 0 var(--sp-3);
+  min-height: 40px;
+  cursor: pointer;
+  white-space: nowrap;
+  position: relative;
+  transition: color 0.2s var(--ease-out);
+}
+.tab::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -1px;
+  height: 2px;
+  background: var(--accent);
+  border-radius: 2px 2px 0 0;
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.28s var(--ease-out);
+}
+.tab:hover {
+  color: var(--ink);
+}
+.tab:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+  border-radius: 3px;
+}
+.tab--on {
+  color: var(--ink);
+}
+.tab--on::after {
+  transform: scaleX(1);
+}
+
+/* ─── view lede (editorial opener, not a card) ───────────────────────── */
+
+.lede {
+  grid-column: 1 / -1;
+  display: grid;
+  gap: var(--sp-2);
+  max-width: 60ch;
+  margin-bottom: var(--sp-1);
+}
+.lede__kicker {
+  margin: 0;
+  font-size: var(--fs-micro);
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--accent-ink);
+}
+.lede__text {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(1.15rem, 2.6vw, 1.45rem);
+  line-height: 1.4;
+  font-weight: 400;
+  color: var(--ink);
+  text-wrap: balance;
+}
+
+/* ─── editorial grid (6 cols → varied spans) ─────────────────────────── */
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: clamp(14px, 2vw, 22px);
+  align-items: start;
+}
+
+.card {
+  grid-column: span 3;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: var(--sp-5) clamp(18px, 2.2vw, 26px) var(--sp-5);
+  min-width: 0;
+  transition:
+    box-shadow 0.24s var(--ease-out),
+    transform 0.24s var(--ease-out),
+    border-color 0.24s var(--ease-out);
+}
+.card:hover {
+  box-shadow: var(--shadow-lift);
+  border-color: var(--line-strong);
+  transform: translateY(-3px);
+}
+.card--full {
+  grid-column: 1 / -1;
+}
+.card--wide {
+  grid-column: span 4;
+}
+.card--narrow {
+  grid-column: span 2;
+}
+
+.card--center {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.card--center .card__head {
+  width: 100%;
+}
+
+.card__head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--sp-3);
+  margin-bottom: var(--sp-4);
+}
+
+.card__title {
+  margin: 0;
+  font-size: var(--fs-label);
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-2);
+}
+
+.card__hint {
+  font-size: var(--fs-sm);
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  white-space: nowrap;
+}
+
+/* the feature card (activity rings) gets a warmer wash to lead the page */
+.card--rings {
+  background: linear-gradient(168deg, var(--surface) 0%, var(--surface-2) 100%);
+}
+
+/* ─── readings ribbon (was 4 identical KPI boxes) ────────────────────── */
+
+.kpi-row {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+
+.kpi {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--sp-1);
+  padding: var(--sp-4) clamp(14px, 1.8vw, 20px) var(--sp-4);
+  min-width: 0;
+  transition: background 0.24s var(--ease-out);
+}
+.kpi + .kpi {
+  border-left: 1px solid var(--line);
+}
+.kpi:hover {
+  background: var(--surface-2);
+}
+.kpi__label {
+  font-size: var(--fs-micro);
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.kpi__chart {
+  width: 100%;
+  min-height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: var(--sp-2) 0;
+}
+.kpi__chart svg {
+  max-width: 100%;
+}
+.kpi__value {
+  font-size: var(--fs-lg);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
+  line-height: 1.1;
+}
+.kpi__sub {
+  font-size: var(--fs-sm);
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ─── activity rings ─────────────────────────────────────────────────── */
+
+.rings {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-6) var(--sp-4);
+  justify-content: space-around;
+}
+
+.ring {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--sp-3);
+  flex: 1 1 130px;
+}
+.ring svg {
+  width: 116px;
+  height: 116px;
+}
+
+.ring__dial {
+  cursor: pointer;
+}
+
+.ring--dim {
+  opacity: 0.5;
+  transition: opacity 0.2s var(--ease-out);
+}
+.ring--selected .ring__cap {
+  transform: scale(1.04);
+  transition: transform 0.2s var(--ease-out);
+}
+.ring--selected .ring__name {
+  color: var(--accent-ink);
+}
+
+.ring__cap {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+}
+.ring__name {
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  color: var(--ink-2);
+  letter-spacing: 0.02em;
+}
+.ring__val {
+  font-size: 1.05rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
+}
+.ring__unit {
+  font-weight: 500;
+  color: var(--muted);
+  font-size: var(--fs-sm);
+}
+
+/* ─── donut + legend ─────────────────────────────────────────────────── */
+
+.donut {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-5);
+  flex-wrap: wrap;
+}
+.donut svg {
+  width: 132px;
+  height: 132px;
+  flex: 0 0 auto;
+}
+
+.legend {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--sp-3);
+  flex: 1 1 130px;
+}
+.legend li {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  font-size: var(--fs-sm);
+}
+.swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+  flex: 0 0 auto;
+}
+.legend__label {
+  color: var(--ink-2);
+}
+.legend__val {
+  margin-left: auto;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--ink);
+}
+
+/* ─── thermometer ────────────────────────────────────────────────────── */
+
+.therm {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-5);
+}
+.therm svg {
+  flex: 0 0 auto;
+}
+.card--eta .caption {
+  margin-top: var(--sp-4);
+}
+
+/* ─── live indicator ─────────────────────────────────────────────────── */
+
+.live {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  font-size: var(--fs-micro);
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--accent-ink);
+}
+.live__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 0 color-mix(in oklch, var(--accent) 55%, transparent);
+}
+
+/* ─── axis + captions ────────────────────────────────────────────────── */
+
+.axis {
+  display: flex;
+  justify-content: space-between;
+  margin: var(--sp-2) 2px 0;
+  font-size: var(--fs-micro);
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+}
+.axis--wide {
+  margin-top: var(--sp-3);
+}
+
+.caption {
+  margin: var(--sp-3) 0 0;
+  font-size: var(--fs-sm);
+  line-height: 1.5;
+  color: var(--ink-2);
+  max-width: 58ch;
+}
+.caption--center {
+  text-align: center;
+  max-width: 32ch;
+}
+.caption--tall {
+  margin-top: 0;
+  align-self: center;
+  max-width: 24ch;
+}
+
+/* ─── interactive readout (hover/focus state, below the chart) ───────────── */
+
+.picker-readout {
+  margin: var(--sp-2) 2px 0;
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  color: var(--accent-ink);
+  font-variant-numeric: tabular-nums;
+  min-height: 1.3em;
+}
+
+/* ─── inline prose stats ─────────────────────────────────────────────── */
+
+.card--prose {
+  background: var(--surface-2);
+}
+.prose {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(1.1rem, 2.4vw, 1.35rem);
+  line-height: 1.65;
+  color: var(--ink);
+  max-width: 60ch;
+}
+/* SVG marks only. No chip chrome — marks are words in the sentence. */
+.prose .mc-inline {
+  margin-inline: 0.12em;
+  padding: 0;
+  border: 0;
+  background: none;
+  border-radius: 0;
+  vertical-align: -0.18em;
+  --mc-inline-nudge: 0;
+}
+.prose .mc-inline .mc-root,
+.prose .mc-inline [data-mc-seated] {
+  translate: none;
+}
+/* Match surrounding prose exactly. Set size only on .mc-delta — never also on
+   .mc-delta-live, or the nested ems compound (0.92×0.92 ≈ tiny). */
+.prose .mc-delta-live {
+  font-size: inherit;
+  padding: 0;
+  border: 0;
+  background: none;
+}
+.prose .mc-delta {
+  font-size: 1em;
+  font-weight: 600;
+  padding: 0;
+  border: 0;
+  background: none;
+}
+
+/* ─── bullets ────────────────────────────────────────────────────────── */
+
+.bullets {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--sp-5);
+}
+@media (min-width: 720px) {
+  .bullets {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: var(--sp-6);
+  }
+}
+.bullet {
+  display: grid;
+  gap: var(--sp-2);
+  align-content: start;
+}
+.bullet__label {
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  color: var(--ink-2);
+  letter-spacing: 0.01em;
+}
+
+/* ─── footer ─────────────────────────────────────────────────────────── */
+
+.foot {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-2) var(--sp-4);
+  align-items: baseline;
+  justify-content: space-between;
+  margin-top: var(--sp-8);
+  padding-top: var(--sp-5);
+  border-top: 1px solid var(--line);
+  font-size: var(--fs-sm);
+  color: var(--muted);
+}
+.foot__name {
+  font-family: var(--font-display);
+  font-weight: 600;
+  color: var(--ink-2);
+  font-size: var(--fs-base);
+}
+.foot__credit {
+  font-variant-numeric: tabular-nums;
+}
+.foot__credit code {
+  font-family: var(--mc-font-numeric);
+  color: var(--ink-2);
+}
+
+/* ─── motion ─────────────────────────────────────────────────────────── */
+
+@media (prefers-reduced-motion: no-preference) {
+  .masthead {
+    animation: rise 0.6s var(--ease-out) both;
+  }
+  .tabs {
+    animation: rise 0.6s var(--ease-out) 0.05s both;
+  }
+  .content > .grid > * {
+    animation: rise 0.55s var(--ease-out) both;
+  }
+  .content > .grid > *:nth-child(1) {
+    animation-delay: 0.04s;
+  }
+  .content > .grid > *:nth-child(2) {
+    animation-delay: 0.09s;
+  }
+  .content > .grid > *:nth-child(3) {
+    animation-delay: 0.14s;
+  }
+  .content > .grid > *:nth-child(4) {
+    animation-delay: 0.19s;
+  }
+  .content > .grid > *:nth-child(5) {
+    animation-delay: 0.24s;
+  }
+  .content > .grid > *:nth-child(6) {
+    animation-delay: 0.29s;
+  }
+  .content > .grid > *:nth-child(n + 7) {
+    animation-delay: 0.33s;
+  }
+
+  @keyframes rise {
+    from {
+      opacity: 0;
+      transform: translateY(14px);
+    }
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
+
+  /* one deliberate pulse — it means a workout is in progress right now */
+  .live__dot {
+    animation: live-pulse 2.4s ease-out infinite;
+  }
+  @keyframes live-pulse {
+    0% {
+      box-shadow: 0 0 0 0 color-mix(in oklch, var(--accent) 55%, transparent);
+    }
+    70% {
+      box-shadow: 0 0 0 8px color-mix(in oklch, var(--accent) 0%, transparent);
+    }
+    100% {
+      box-shadow: 0 0 0 0 color-mix(in oklch, var(--accent) 0%, transparent);
+    }
+  }
+}
+
+/* ─── responsive ─────────────────────────────────────────────────────── */
+
+@media (max-width: 880px) {
+  .grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .card,
+  .card--wide,
+  .card--narrow {
+    grid-column: span 1;
+  }
+  .card--full {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 720px) {
+  .kpi-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  /* row-2 tiles need a top divider once wrapped, and no stray left edge */
+  .kpi:nth-child(odd) {
+    border-left: 0;
+  }
+  .kpi:nth-child(n + 3) {
+    border-top: 1px solid var(--line);
+  }
+}
+
+@media (max-width: 560px) {
+  .masthead {
+    grid-template-columns: 1fr;
+    align-items: start;
+  }
+  .dateline {
+    text-align: left;
+    justify-items: start;
+  }
+  .grid {
+    grid-template-columns: 1fr;
+  }
+  .card,
+  .card--full,
+  .card--wide,
+  .card--narrow {
+    grid-column: 1 / -1;
+  }
+  .therm {
+    gap: var(--sp-4);
+  }
+}
+
+@media (max-width: 380px) {
+  .app {
+    padding-left: 14px;
+    padding-right: 14px;
+  }
+}
+
+/* ─── dark mode (warm bark, hand-tuned; placed last to win the cascade) ──
+   microcharts tokens auto-adapt under this same query, so the chrome must
+   flip too — otherwise dark strokes would sit on a cream surface. */
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    color-scheme: dark;
+
+    --bg: oklch(0.185 0.014 58);
+    --bg-2: oklch(0.212 0.017 56);
+    --surface: oklch(0.228 0.018 58);
+    --surface-2: oklch(0.258 0.02 58);
+    --line: oklch(0.32 0.022 56);
+    --line-strong: oklch(0.4 0.026 54);
+    --ink: oklch(0.93 0.016 76);
+    --ink-2: oklch(0.78 0.024 66);
+    --muted: oklch(0.62 0.028 60);
+    --accent: oklch(0.7 0.14 44);
+    --accent-ink: oklch(0.78 0.13 48);
+    --accent-wash: oklch(0.34 0.06 46);
+    --gold: oklch(0.78 0.1 74);
+
+    --shadow: 0 1px 2px oklch(0 0 0 / 0.4), 0 14px 34px -20px oklch(0 0 0 / 0.72);
+    --shadow-lift: 0 2px 8px oklch(0 0 0 / 0.46), 0 24px 48px -22px oklch(0 0 0 / 0.82);
+  }
+
+  body {
+    background-image: radial-gradient(145% 100% at 50% -18%, oklch(0.24 0.02 56) 0%, var(--bg) 60%);
+  }
+
+  body::before {
+    mix-blend-mode: soft-light;
+    opacity: 0.35;
+  }
+
+  .card--rings {
+    background: linear-gradient(168deg, var(--surface) 0%, var(--surface-2) 100%);
+  }
+}

--- a/examples/vitals-health/src/components/MoveView.tsx
+++ b/examples/vitals-health/src/components/MoveView.tsx
@@ -1,0 +1,110 @@
+import { ActivityGrid } from "@microcharts/react/activity-grid/interactive";
+import { StreakSpark } from "@microcharts/react/streak-spark/interactive";
+import { CyclePlot } from "@microcharts/react/cycle-plot/interactive";
+import { SpiralYear } from "@microcharts/react/spiral-year/interactive";
+import { GradeProfile } from "@microcharts/react/grade-profile/interactive";
+
+import { Card, Lede, fluid } from "./ui";
+import {
+  workoutStreak,
+  workoutStart,
+  workoutDone,
+  weekdayMinutes,
+  weekdayNames,
+  yearActivity,
+  yearStart,
+  runRoute,
+  C,
+} from "../data";
+
+export function MoveView() {
+  const active = workoutStreak.filter((m) => m > 0).length;
+
+  return (
+    <div className="grid">
+      <Lede kicker="In motion">
+        Sixteen steady weeks. Saturdays carry the long run; Mondays and Fridays stay kind on
+        purpose.
+      </Lede>
+
+      <Card title="Workout minutes" hint={`${active} active days`} span="full">
+        <ActivityGrid
+          data={workoutStreak}
+          layout="grid"
+          shape="round"
+          anchor={workoutStart}
+          weekStart={1}
+          cell={13}
+          color={C.green}
+          title="Workout minutes per day, last 16 weeks"
+          style={fluid}
+        />
+      </Card>
+
+      <Card title="Training consistency" hint="Did I train? · 9 weeks" span="full">
+        <StreakSpark
+          data={workoutDone}
+          positive="up"
+          label="both"
+          color={C.green}
+          width={920}
+          height={58}
+          title="Pass/fail workout days — current run versus record"
+          animate
+          style={fluid}
+        />
+        <p className="caption">
+          Each block is a run of days. The bright block on the right is your current streak.
+        </p>
+      </Card>
+
+      <Card title="The shape of your week" hint="12 weeks" span="narrow">
+        <CyclePlot
+          data={weekdayMinutes}
+          period={7}
+          slots={weekdayNames}
+          center="mean"
+          cycleUnit="weeks"
+          color={C.green}
+          width={460}
+          height={136}
+          format={{ maximumFractionDigits: 0 }}
+          title="Workout minutes by weekday, averaged across 12 weeks"
+          animate
+          style={fluid}
+        />
+        <p className="caption">Saturdays carry the long run; Mondays and Fridays stay easy.</p>
+      </Card>
+
+      <Card title="The year in one square" hint="365 days" span="wide" className="card--center">
+        <SpiralYear
+          data={yearActivity}
+          startDate={yearStart}
+          size={188}
+          color={C.coral}
+          title="A full year of daily active minutes on a calendar spiral"
+          animate
+        />
+        <p className="caption caption--center">
+          Denser through spring and late summer; a quieter mid-winter stretch.
+        </p>
+      </Card>
+
+      <Card title="Saturday's route" hint="10 km · +148 m climb" span="full">
+        <GradeProfile
+          data={runRoute}
+          label="max"
+          width={920}
+          height={140}
+          title="Elevation and grade along the 10 km long run"
+          animate
+          style={fluid}
+        />
+        <p className="caption">
+          Colour marks how steep each pitch is. The hard climb lands just past halfway, then
+          it&rsquo;s downhill home.
+        </p>
+      </Card>
+    </div>
+  );
+}

--- a/examples/vitals-health/src/components/SleepView.tsx
+++ b/examples/vitals-health/src/components/SleepView.tsx
@@ -1,0 +1,159 @@
+import { useState } from "react";
+import { Hypnogram } from "@microcharts/react/hypnogram/interactive";
+import { Sparkline } from "@microcharts/react/sparkline/interactive";
+import { CalendarStrip } from "@microcharts/react/calendar-strip/interactive";
+import { PolarClock } from "@microcharts/react/polar-clock/interactive";
+import { FoldedDayBand } from "@microcharts/react/folded-day-band/interactive";
+import { MoonPhase } from "@microcharts/react/moon-phase/interactive";
+
+import { Card, Lede, fluid } from "./ui";
+import {
+  sleepStages,
+  sleepStates,
+  sleepStateColors,
+  sleepDuration,
+  sleepConsistency,
+  TODAY,
+  dayCycle,
+  dayCycleNow,
+  foldedHr,
+  foldedHrToday,
+  cyclePhase,
+  C,
+} from "../data";
+
+/** Compact "9p" / "6a" style hour label, matching the app's axis voice. */
+const hourLabel = (h: number): string => `${h % 12 === 0 ? 12 : h % 12}${h < 12 ? "a" : "p"}`;
+
+export function SleepView() {
+  const avg = sleepDuration.reduce((a, b) => a + b, 0) / sleepDuration.length;
+  const [stage, setStage] = useState<{
+    label?: string;
+    value: number | null;
+    formatted?: string;
+  } | null>(null);
+
+  return (
+    <div className="grid">
+      <Lede kicker="Overnight">
+        Seven and a half restful hours, and your heart found its usual quiet trough right on
+        schedule.
+      </Lede>
+
+      <Card title="Last night" hint="7h 35m asleep" span="full">
+        <Hypnogram
+          data={sleepStages}
+          states={sleepStates}
+          mode="lanes"
+          colors={sleepStateColors}
+          connectors
+          labels
+          width={920}
+          height={140}
+          title="Sleep stages overnight"
+          onActive={setStage}
+          readout={false}
+          animate
+          style={fluid}
+        />
+        <p className="axis axis--wide">
+          <span>11p</span>
+          <span>1a</span>
+          <span>3a</span>
+          <span>5a</span>
+          <span>7a</span>
+        </p>
+        <p className="picker-readout">
+          {stage
+            ? (stage.formatted ?? `${stage.label} · ${Math.round(stage.value ?? 0)} min`)
+            : "Hover or focus a stage — reading lives here"}
+        </p>
+      </Card>
+
+      <Card title="Duration" hint={`${avg.toFixed(1)}h avg`}>
+        <Sparkline
+          data={sleepDuration}
+          band={[7, 9]}
+          dots="auto"
+          label="last"
+          color={C.blue}
+          width={460}
+          height={72}
+          format={{ maximumFractionDigits: 1 }}
+          title="Sleep duration, last 14 nights"
+          animate
+          style={fluid}
+        />
+        <p className="caption">Shaded band marks the 7&ndash;9h target range.</p>
+      </Card>
+
+      <Card title="Consistency" hint="8 weeks">
+        <CalendarStrip
+          data={sleepConsistency}
+          weeks={8}
+          end={TODAY}
+          weekStart={1}
+          cell={11}
+          color={C.blue}
+          title="Sleep-consistency score by day"
+          style={fluid}
+        />
+        <p className="caption">Darker cells are more restful nights.</p>
+      </Card>
+
+      <Card title="Day rhythm" hint="24 hours" span="wide" className="card--center">
+        <PolarClock
+          data={dayCycle}
+          now={dayCycleNow}
+          size={168}
+          color={C.blue}
+          segmentFormat={hourLabel}
+          title="Movement around the 24-hour clock"
+          animate
+        />
+        <p className="caption caption--center">
+          Two waking peaks, a long quiet trough. You wind down around 9pm.
+        </p>
+      </Card>
+
+      <Card title="Recovery cycle" hint="Day 19 of 28" span="narrow" className="card--center">
+        <MoonPhase
+          value={cyclePhase}
+          mode="cycle"
+          size={132}
+          color={C.plum}
+          title="Where you are in the 28-day wellness cycle"
+        />
+        <p className="caption caption--center">
+          Past the peak of this block. Energy usually eases from here.
+        </p>
+      </Card>
+
+      <Card title="Your night, most nights" hint="Resting HR, folded over 14 nights" span="full">
+        <FoldedDayBand
+          data={foldedHr}
+          today={foldedHrToday}
+          period={24}
+          bins={24}
+          width={920}
+          height={140}
+          format={{ maximumFractionDigits: 0 }}
+          title="Circadian resting heart rate — typical band with last night overlaid"
+          animate
+          style={fluid}
+        />
+        <p className="axis axis--wide">
+          <span>12a</span>
+          <span>6a</span>
+          <span>12p</span>
+          <span>6p</span>
+          <span>12a</span>
+        </p>
+        <p className="caption">
+          The darker line is last night. Your heart settles into the same overnight trough almost
+          every night.
+        </p>
+      </Card>
+    </div>
+  );
+}

--- a/examples/vitals-health/src/components/TodayView.tsx
+++ b/examples/vitals-health/src/components/TodayView.tsx
@@ -1,0 +1,260 @@
+import { useState } from "react";
+import { ProgressRing } from "@microcharts/react/progress-ring/interactive";
+import { SparkBar } from "@microcharts/react/sparkbar/interactive";
+import { MicroDonut } from "@microcharts/react/micro-donut/interactive";
+import { Delta } from "@microcharts/react/delta/interactive";
+import { BreathingDot } from "@microcharts/react/breathing-dot/interactive";
+import { TimeInRange } from "@microcharts/react/time-in-range/interactive";
+import { PictogramRow } from "@microcharts/react/pictogram-row/interactive";
+import { TallyMarks } from "@microcharts/react/tally-marks/interactive";
+import { Thermometer } from "@microcharts/react/thermometer/interactive";
+import { EtaBar } from "@microcharts/react/eta-bar/interactive";
+
+import { Card, Kpi, Lede, fluid } from "./ui";
+import {
+  rings,
+  hourlySteps,
+  totalStepsToday,
+  macros,
+  macroColors,
+  restingHrDelta,
+  activeCalDelta,
+  recovery,
+  hrZones,
+  water,
+  streakDays,
+  energyGoal,
+  activeWorkout,
+  C,
+} from "../data";
+
+const hrZoneStrings = {
+  noData: "No data.",
+  tirNames: ["rest", "light", "fat-burn", "cardio", "peak"] as [
+    string,
+    string,
+    string,
+    string,
+    string,
+  ],
+  tirClause: (pct: string, name: string) => `${pct} ${name}`,
+  timeInRange: (list: string) => `${list}.`,
+  tirZone: (name: string, pct: string) => `${name}: ${pct}.`,
+};
+
+const hrZoneKeys = (["severeBelow", "below", "in", "above", "severeAbove"] as const).filter(
+  (k) => typeof hrZones[k as keyof typeof hrZones] === "number",
+);
+
+export function TodayView() {
+  const [selectedRing, setSelectedRing] = useState<string | null>(null);
+  const [hrFocus, setHrFocus] = useState<{ name: string; minutes: number } | null>(null);
+
+  return (
+    <div className="grid">
+      <Lede kicker="The morning read">
+        You&rsquo;re moving well and resting easy: 88&nbsp;kcal from a closed Move ring, with room
+        to spare before the day even warms up.
+      </Lede>
+
+      <Card title="Activity" hint="Daily goals" span="full" className="card--rings">
+        <div className="rings">
+          {rings.map((r) => {
+            const selected = selectedRing === r.key;
+            return (
+              <figure
+                className={`ring${selected ? " ring--selected" : selectedRing ? " ring--dim" : ""}`}
+                key={r.key}
+              >
+                <ProgressRing
+                  value={r.value}
+                  max={r.max}
+                  label="percent"
+                  color={r.color}
+                  size={112}
+                  weight={12}
+                  title={`${r.label} goal`}
+                  className="ring__dial"
+                  onSelect={() => setSelectedRing(selected ? null : r.key)}
+                  animate
+                />
+                <figcaption className="ring__cap">
+                  <span className="ring__name">{r.label}</span>
+                  <span className="ring__val" style={{ color: r.color }}>
+                    {r.value.toLocaleString()}
+                    <span className="ring__unit">
+                      {" "}
+                      / {r.max} {r.unit}
+                    </span>
+                  </span>
+                </figcaption>
+              </figure>
+            );
+          })}
+        </div>
+      </Card>
+
+      <div className="kpi-row">
+        <Kpi label="Recovery" value="Well rested" sub="31% strain" accent={C.green}>
+          <BreathingDot
+            value={recovery}
+            size={58}
+            title="Recovery — how strained your body is right now"
+          />
+        </Kpi>
+
+        <Kpi
+          label="Heart zones"
+          value={hrFocus ? `${hrFocus.minutes} min` : "486 min"}
+          sub={hrFocus ? hrFocus.name : "in fat-burn today"}
+        >
+          <TimeInRange
+            data={hrZones}
+            orientation="vertical"
+            label="none"
+            width={34}
+            height={92}
+            title="Time in each heart-rate zone today"
+            strings={hrZoneStrings}
+            animate
+            onActive={(d) => {
+              if (!d?.label) {
+                setHrFocus(null);
+                return;
+              }
+              const key = hrZoneKeys[d.index];
+              const minutes = key ? hrZones[key as keyof typeof hrZones] : undefined;
+              setHrFocus(typeof minutes === "number" ? { name: d.label, minutes } : null);
+            }}
+          />
+        </Kpi>
+
+        <Kpi label="Hydration" value={`${water.value} / ${water.total}`} sub="2 glasses to go">
+          <PictogramRow
+            value={water.value}
+            total={water.total}
+            shape="dot"
+            color={C.blue}
+            height={26}
+            title="Water intake — glasses toward the daily goal"
+            animate
+          />
+        </Kpi>
+
+        <Kpi label="Streak" value={`${streakDays} days`} sub="best: 18" accent={C.coral}>
+          <TallyMarks value={streakDays} pen="drawn" height={40} title="Logged-workout streak" />
+        </Kpi>
+      </div>
+
+      <Card title="Steps" hint={`${totalStepsToday.toLocaleString()} today`}>
+        <SparkBar
+          data={hourlySteps}
+          color={C.coral}
+          title="Steps per hour"
+          width={480}
+          height={60}
+          style={fluid}
+        />
+        <p className="axis">
+          <span>12a</span>
+          <span>6a</span>
+          <span>12p</span>
+          <span>6p</span>
+          <span>11p</span>
+        </p>
+      </Card>
+
+      <Card title="Fuel" hint="Macros">
+        <div className="donut">
+          <MicroDonut
+            data={macros}
+            colors={macroColors}
+            size={128}
+            weight={18}
+            title="Macronutrient split"
+            animate
+          />
+          <ul className="legend">
+            {macros.map((m, i) => (
+              <li key={m.label}>
+                <span className="swatch" style={{ background: macroColors[i] }} />
+                <span className="legend__label">{m.label}</span>
+                <span className="legend__val">{m.value}g</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </Card>
+
+      <Card title="Daily energy" hint="512 / 600 kcal" span="wide" className="card--therm">
+        <div className="therm">
+          <Thermometer
+            value={energyGoal.value}
+            target={energyGoal.target}
+            domain={energyGoal.domain}
+            ticks={[0, 200, 400, 600, 800]}
+            orientation="vertical"
+            label="value"
+            color={C.coral}
+            width={68}
+            height={188}
+            format={{ maximumFractionDigits: 0 }}
+            title="Active energy burned toward today's 600 kcal goal"
+            animate
+          />
+          <p className="caption caption--tall">
+            88 kcal from closing your Move ring. A brisk walk after dinner does it.
+          </p>
+        </div>
+      </Card>
+
+      <Card
+        title="Active workout"
+        hint={
+          <span className="live">
+            <span className="live__dot" aria-hidden="true" />
+            Live
+          </span>
+        }
+        span="narrow"
+        className="card--eta"
+      >
+        <EtaBar
+          progress={activeWorkout.progress}
+          elapsed={activeWorkout.elapsed}
+          rate={activeWorkout.rate}
+          label="eta"
+          etaFormat={(t) => `${Math.round(t)} min`}
+          width={480}
+          height={48}
+          title="Evening run progress and estimated time remaining"
+          animate
+          style={fluid}
+        />
+        <p className="caption">
+          Evening run, 22 min in. About 13 minutes left at your current pace.
+        </p>
+      </Card>
+
+      <Card span="full" className="card--prose">
+        <p className="prose">
+          Nice pace today. Your resting heart rate is{" "}
+          <Delta
+            value={restingHrDelta}
+            positive="down"
+            format={(n) => `${Math.round(n)} bpm`}
+            summary={false}
+          />{" "}
+          versus last week, and you&rsquo;ve burned{" "}
+          <Delta
+            value={activeCalDelta.value}
+            from={activeCalDelta.from}
+            positive="up"
+            summary={false}
+          />{" "}
+          more active calories than yesterday. Keep it rolling.
+        </p>
+      </Card>
+    </div>
+  );
+}

--- a/examples/vitals-health/src/components/TrendsView.tsx
+++ b/examples/vitals-health/src/components/TrendsView.tsx
@@ -1,0 +1,141 @@
+import { Bullet } from "@microcharts/react/bullet/interactive";
+import { Sparkline as StaticSparkline } from "@microcharts/react/sparkline";
+import { RugStrip } from "@microcharts/react/rug-strip/interactive";
+import { PercentileTrace } from "@microcharts/react/percentile-trace/interactive";
+import { ForecastCone } from "@microcharts/react/forecast-cone/interactive";
+import { Delta } from "@microcharts/react/delta";
+
+import { Card, Lede, fluid } from "./ui";
+import {
+  goals,
+  weightTrend,
+  weightDomain,
+  weightForecast,
+  weightTarget,
+  stepDistribution,
+  stepDistributionDomain,
+  totalStepsToday,
+  avgDailySteps,
+  fitnessPercentile,
+  C,
+} from "../data";
+
+export function TrendsView() {
+  return (
+    <div className="grid">
+      <Lede kicker="The slow lines">
+        Weight easing toward the target, fitness climbing the pack, and today&rsquo;s steps already
+        better than most days. The question is whether the next eight weeks clear 72&nbsp;kg.
+      </Lede>
+
+      <Card title="Weekly goals" hint="This week" span="full">
+        <ul className="bullets">
+          {goals.map((g) => (
+            <li key={g.label} className="bullet">
+              <span className="bullet__label">{g.label}</span>
+              <Bullet
+                value={g.value}
+                target={g.target}
+                bands={g.bands}
+                domain={g.domain}
+                color={g.color}
+                width={320}
+                height={28}
+                format={{ notation: "compact", maximumFractionDigits: 1 }}
+                title={`${g.label}: ${g.value.toLocaleString()} of ${g.target.toLocaleString()} ${g.unit}`}
+                style={fluid}
+              />
+            </li>
+          ))}
+        </ul>
+      </Card>
+
+      <Card title="Weight path" hint="12 weeks actual · 8 ahead" span="full">
+        <ForecastCone
+          data={weightTrend}
+          forecast={weightForecast}
+          target={weightTarget}
+          unit="week"
+          label="landing"
+          domain={weightDomain}
+          color={C.amber}
+          format={{ maximumFractionDigits: 1 }}
+          width={920}
+          height={168}
+          title="Body-weight history and 8-week forecast against the 72 kg target"
+          animate
+          style={fluid}
+        />
+        <p className="caption">
+          Median lands just under target; the 80% band still straddles it — clear only if the recent
+          slope holds.
+        </p>
+      </Card>
+
+      <Card title="Fitness percentile" hint="vs peers · 26 weeks">
+        <PercentileTrace
+          data={fitnessPercentile}
+          positive="up"
+          unit="week"
+          label="last"
+          showBands
+          color={C.green}
+          width={460}
+          height={128}
+          title="Fitness percentile against peers, drifting over 26 weeks"
+          animate
+          style={fluid}
+        />
+        <p className="caption">
+          Shaded fields are the middle half and the outer edges of the pack. You climbed into the
+          top third.
+        </p>
+      </Card>
+
+      <Card title="Where today sits" hint={`${totalStepsToday.toLocaleString()} steps`}>
+        <RugStrip
+          data={stepDistribution}
+          markValue={totalStepsToday}
+          domain={stepDistributionDomain}
+          orientation="horizontal"
+          width={460}
+          height={60}
+          color={C.coral}
+          format={{ notation: "compact", maximumFractionDigits: 1 }}
+          title="Daily step counts over 90 days, with today marked"
+          animate
+          style={fluid}
+        />
+        <p className="caption">
+          Each tick is a day&rsquo;s step count. The bold tick is today — better than usual.
+        </p>
+      </Card>
+
+      <Card span="full" className="card--prose">
+        <p className="prose">
+          Zooming out, the last six weeks of weight have settled into a gentle{" "}
+          <span className="mc-inline">
+            <StaticSparkline
+              data={weightTrend.slice(-6)}
+              width={96}
+              height={24}
+              color={C.amber}
+              format={{ maximumFractionDigits: 1 }}
+              summary={false}
+              style={{ width: "4.2em", height: "1.1em" }}
+            />
+          </span>{" "}
+          slide, and today&rsquo;s steps landed{" "}
+          <Delta
+            value={totalStepsToday}
+            from={avgDailySteps}
+            positive="up"
+            format={{ style: "percent", maximumFractionDigits: 0 }}
+            summary={false}
+          />{" "}
+          above a typical day.
+        </p>
+      </Card>
+    </div>
+  );
+}

--- a/examples/vitals-health/src/components/ui.tsx
+++ b/examples/vitals-health/src/components/ui.tsx
@@ -1,0 +1,66 @@
+import type { ReactNode } from "react";
+
+/** Charts fill their container; viewBox keeps the aspect. */
+export const fluid = { width: "100%", height: "auto" } as const;
+
+export function Card({
+  title,
+  hint,
+  span,
+  className,
+  children,
+}: {
+  title?: string;
+  hint?: ReactNode;
+  span?: "wide" | "narrow" | "full";
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className={`card${span ? ` card--${span}` : ""}${className ? ` ${className}` : ""}`}>
+      {title && (
+        <header className="card__head">
+          <h3 className="card__title">{title}</h3>
+          {hint && <span className="card__hint">{hint}</span>}
+        </header>
+      )}
+      {children}
+    </section>
+  );
+}
+
+/** A compact KPI tile: a label, a single chart, and a headline value. */
+export function Kpi({
+  label,
+  value,
+  sub,
+  accent,
+  children,
+}: {
+  label: string;
+  value: ReactNode;
+  sub?: ReactNode;
+  accent?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="kpi">
+      <span className="kpi__label">{label}</span>
+      <div className="kpi__chart">{children}</div>
+      <span className="kpi__value" style={accent ? { color: accent } : undefined}>
+        {value}
+      </span>
+      {sub && <span className="kpi__sub">{sub}</span>}
+    </section>
+  );
+}
+
+/** An editorial opener for a view: a kicker + one warm line of context. */
+export function Lede({ kicker, children }: { kicker: string; children: ReactNode }) {
+  return (
+    <header className="lede">
+      <p className="lede__kicker">{kicker}</p>
+      <p className="lede__text">{children}</p>
+    </header>
+  );
+}

--- a/examples/vitals-health/src/data.ts
+++ b/examples/vitals-health/src/data.ts
@@ -1,0 +1,351 @@
+// Believable mock health data for the "Vitals" example dashboard.
+// A single pinned "today" keeps every generated series deterministic.
+
+export const TODAY = "2026-07-15";
+
+const iso = (d: Date): string => d.toISOString().slice(0, 10);
+
+/** ISO date `days` before (positive) the pinned TODAY. */
+function daysBefore(days: number): string {
+  const d = new Date(`${TODAY}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() - days);
+  return iso(d);
+}
+
+// A tiny seeded PRNG so the "random-looking" series never reshuffle per reload.
+function mulberry32(seed: number): () => number {
+  let a = seed;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const clamp = (v: number, lo: number, hi: number): number => Math.max(lo, Math.min(hi, v));
+
+// ─── shared palette (mid-tone so it reads on cream AND warm-dark) ──────────
+
+export const C = {
+  coral: "#D9573D", // move / steps / primary accent
+  green: "#2FA07C", // exercise / workouts
+  amber: "#C79038", // stand / weight
+  blue: "#5B84B4", // sleep
+  plum: "#9A6BA6", // REM / accents
+} as const;
+
+// ─── TODAY ────────────────────────────────────────────────────────────────
+
+/** Move / Exercise / Stand style activity rings. */
+export const rings = [
+  { key: "move", label: "Move", value: 512, max: 600, unit: "kcal", color: C.coral },
+  { key: "exercise", label: "Exercise", value: 38, max: 45, unit: "min", color: C.green },
+  { key: "stand", label: "Stand", value: 10, max: 12, unit: "hrs", color: C.amber },
+] as const;
+
+/** Steps per hour across the day (midnight → 11pm). */
+export const hourlySteps: number[] = [
+  0, 0, 0, 0, 0, 120, 640, 1180, 720, 340, 210, 880, 1460, 520, 300, 260, 410, 980, 1620, 1240, 560,
+  220, 90, 40,
+];
+
+export const totalStepsToday = hourlySteps.reduce((a, b) => a + b, 0);
+
+/** Macronutrient split for the day, in grams. */
+export const macros = [
+  { label: "Carbs", value: 246 },
+  { label: "Protein", value: 128 },
+  { label: "Fat", value: 61 },
+];
+
+export const macroColors = ["#E0A23C", "#C25B43", "#7C9A6B"];
+
+export const restingHrDelta = -3; // bpm vs last week (down is good)
+export const activeCalDelta = { value: 512, from: 468 }; // kcal vs yesterday
+
+/** Recovery / strain right now (0 calm … 1 strained). Lower is better rested. */
+export const recovery = 0.31;
+
+/** Heart-rate time-in-zone today, in minutes. Order is semantic, low → high. */
+export const hrZones = {
+  below: 618, // resting / light
+  in: 486, // fat-burn target band
+  above: 214, // cardio
+  severeAbove: 58, // peak
+};
+
+/** Water intake — glasses of the 8-glass goal. */
+export const water = { value: 6, total: 8 };
+
+/** Current logged-workout streak, in days. */
+export const streakDays = 12;
+
+/** Daily energy goal for the thermometer gauge. */
+export const energyGoal = { value: 512, target: 600, domain: [0, 800] as [number, number] };
+
+/** In-progress workout for the ETA bar. */
+export const activeWorkout = {
+  progress: 0.62, // fraction complete
+  elapsed: 22, // minutes in
+  rate: 0.62 / 22, // fraction per minute → ~13 min left
+};
+
+// ─── SLEEP ──────────────────────────────────────────────────────────────
+
+/**
+ * One night of sleep stages. `t` is minutes from lights-out; each state holds
+ * until the next entry. Ends around 7h35m.
+ */
+export const sleepStages = [
+  { t: 0, state: "Awake" },
+  { t: 8, state: "Light" },
+  { t: 22, state: "Deep" },
+  { t: 62, state: "Light" },
+  { t: 78, state: "REM" },
+  { t: 96, state: "Light" },
+  { t: 112, state: "Deep" },
+  { t: 158, state: "Light" },
+  { t: 176, state: "REM" },
+  { t: 202, state: "Light" },
+  { t: 214, state: "Awake" },
+  { t: 220, state: "Light" },
+  { t: 246, state: "Deep" },
+  { t: 286, state: "Light" },
+  { t: 300, state: "REM" },
+  { t: 332, state: "Light" },
+  { t: 352, state: "Deep" },
+  { t: 388, state: "Light" },
+  { t: 404, state: "REM" },
+  { t: 438, state: "Light" },
+  { t: 455, state: "Awake" },
+];
+
+export const sleepStates = ["Awake", "REM", "Light", "Deep"];
+// warm → cool as sleep deepens
+export const sleepStateColors = ["#D89A6A", "#B57BA6", "#7FA8C9", "#4E74A4"];
+
+/** Nightly sleep duration (hours) over the last 14 nights, oldest → newest. */
+export const sleepDuration: number[] = [
+  7.1, 6.4, 7.8, 8.0, 6.9, 5.8, 7.3, 7.6, 8.1, 6.7, 7.0, 7.9, 6.5, 7.6,
+];
+
+/** Sleep-consistency score (0–100) per day over the last 8 weeks. */
+export const sleepConsistency: { date: string; value: number }[] = (() => {
+  const rnd = mulberry32(42);
+  const out: { date: string; value: number }[] = [];
+  for (let i = 55; i >= 0; i--) {
+    const base = 62 + Math.sin((55 - i) / 4) * 14;
+    const jitter = (rnd() - 0.4) * 28;
+    const v = clamp(Math.round(base + jitter), 28, 98);
+    out.push({ date: daysBefore(i), value: v });
+  }
+  return out;
+})();
+
+/**
+ * Movement per hour over a 24h clock (0 = midnight). Low overnight, two daytime
+ * peaks — the sleep/wake shape of a day. `now` accents the current hour.
+ */
+export const dayCycle: number[] = [
+  4, 2, 1, 1, 2, 6, 24, 52, 63, 40, 34, 58, 71, 44, 30, 36, 49, 66, 88, 74, 55, 38, 20, 9,
+];
+export const dayCycleNow = 21; // 9pm — winding down
+
+/** Wellness-cycle marker (0 → 1). Day 19 of a 28-day block. */
+export const cyclePhase = 19 / 28;
+
+/**
+ * Circadian resting heart rate: a low overnight trough, a morning climb, a
+ * daytime plateau. Folded across ~14 nights, with last night overlaid.
+ */
+function circadianHr(hour: number, rnd: () => number, spread = 1): number {
+  // trough ~4am, peak ~7pm
+  const phase = ((hour - 4 + 24) % 24) / 24; // 0 at 4am
+  const base = 55 + 15 * Math.sin(phase * Math.PI); // 55 → ~70 → 55
+  return Math.round((base + (rnd() - 0.5) * 6 * spread) * 10) / 10;
+}
+
+export const foldedHr: { t: number; value: number }[] = (() => {
+  const rnd = mulberry32(19);
+  const out: { t: number; value: number }[] = [];
+  for (let day = 0; day < 14; day++) {
+    for (let h = 0; h < 24; h++) {
+      out.push({ t: day * 24 + h, value: circadianHr(h, rnd) });
+    }
+  }
+  return out;
+})();
+
+export const foldedHrToday: { t: number; value: number }[] = (() => {
+  const rnd = mulberry32(77);
+  const out: { t: number; value: number }[] = [];
+  for (let h = 0; h < 24; h++) out.push({ t: h, value: circadianHr(h, rnd, 0.5) - 1.5 });
+  return out;
+})();
+
+// ─── MOVE ───────────────────────────────────────────────────────────────
+
+/** Daily workout minutes over the last 16 weeks (112 days), oldest → newest. */
+export const workoutStreak: number[] = (() => {
+  const rnd = mulberry32(7);
+  const out: number[] = [];
+  for (let i = 0; i < 112; i++) {
+    const dow = i % 7;
+    // rest-ish on Mondays/Fridays, hard sessions midweek + weekend long runs
+    const rest = dow === 0 || dow === 4;
+    const roll = rnd();
+    if (rest && roll < 0.65) out.push(0);
+    else if (roll < 0.18) out.push(0);
+    else out.push(Math.round(18 + rnd() * (dow === 6 ? 74 : 46)));
+  }
+  return out;
+})();
+
+/** First calendar day of the workout grid, for weekday alignment. */
+export const workoutStart = daysBefore(111);
+
+/** Pass/fail workout history (did I train?) — last 63 days, oldest → newest. */
+export const workoutDone: boolean[] = workoutStreak.slice(-63).map((m) => m > 0);
+
+/**
+ * Workout minutes by weekday, 12 weeks, Monday-first row-major (index 0 = a
+ * Monday). CyclePlot reshapes into 7 slots so each weekday shows its own shape.
+ */
+export const weekdayMinutes: number[] = (() => {
+  const rnd = mulberry32(23);
+  // Mon light, Tue–Thu solid, Fri light, Sat long, Sun moderate
+  const shape = [22, 46, 52, 48, 20, 78, 40];
+  const out: number[] = [];
+  for (let w = 0; w < 12; w++) {
+    for (let d = 0; d < 7; d++) {
+      const drift = w * 0.6 * (d === 5 ? 1.4 : 1); // Saturdays creep up over time
+      const v = shape[d] + drift + (rnd() - 0.5) * 16;
+      out.push(Math.round(clamp(v, 0, 120)));
+    }
+  }
+  return out;
+})();
+
+export const weekdayNames = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+/** A full year of daily active minutes for the spiral (365 days). */
+export const yearActivity: number[] = (() => {
+  const rnd = mulberry32(101);
+  const out: number[] = [];
+  for (let i = 0; i < 365; i++) {
+    const dow = i % 7;
+    // gentle seasonal swell: quieter deep winter, busier spring & late summer
+    const season = 34 + 20 * Math.sin(((i - 60) / 365) * Math.PI * 2);
+    const weekend = dow === 6 ? 22 : dow === 5 ? 10 : 0;
+    const rest = (dow === 0 || dow === 4) && rnd() < 0.5;
+    const v = rest ? rnd() * 8 : season + weekend + (rnd() - 0.4) * 30;
+    out.push(Math.round(clamp(v, 0, 120)));
+  }
+  return out;
+})();
+
+export const yearStart = daysBefore(364);
+
+/** Saturday long-run elevation profile: distance (m) + elevation (m). */
+export const runRoute: { d: number; elev: number }[] = (() => {
+  const rnd = mulberry32(55);
+  const out: { d: number; elev: number }[] = [];
+  let elev = 42;
+  for (let d = 0; d <= 10000; d += 250) {
+    const km = d / 1000;
+    // a valley dip, a long climb to ~7.5k, then a descent home
+    const ridge =
+      42 +
+      58 * Math.sin((km / 10) * Math.PI) +
+      26 * Math.sin((km / 10) * Math.PI * 3) +
+      (rnd() - 0.5) * 6;
+    elev = clamp(ridge, 20, 180);
+    out.push({ d, elev: Math.round(elev * 10) / 10 });
+  }
+  return out;
+})();
+
+// ─── TRENDS ─────────────────────────────────────────────────────────────
+
+/** Weekly goal progress bullets. */
+export const goals = [
+  {
+    label: "Steps",
+    value: 58200,
+    target: 70000,
+    bands: [40000, 60000],
+    domain: [0, 84000] as [number, number],
+    unit: "steps",
+    color: C.coral,
+  },
+  {
+    label: "Active minutes",
+    value: 214,
+    target: 250,
+    bands: [120, 200],
+    domain: [0, 300] as [number, number],
+    unit: "min",
+    color: C.green,
+  },
+  {
+    label: "Workouts",
+    value: 4,
+    target: 5,
+    bands: [2, 4],
+    domain: [0, 7] as [number, number],
+    unit: "sessions",
+    color: C.amber,
+  },
+];
+
+/** Body-weight trend (kg) over the last 12 weeks, oldest → newest. */
+export const weightTrend: number[] = [
+  76.4, 76.1, 76.3, 75.8, 75.5, 75.6, 75.1, 74.8, 74.9, 74.4, 74.1, 73.8,
+];
+
+export const weightDomain: [number, number] = [70, 78];
+
+/** Daily step totals over the last 90 days — the distribution behind today. */
+export const stepDistribution: number[] = (() => {
+  const rnd = mulberry32(88);
+  const out: number[] = [];
+  for (let i = 0; i < 90; i++) {
+    const dow = i % 7;
+    const base = dow === 6 ? 12500 : dow === 0 ? 6200 : 8600;
+    const v = base + (rnd() - 0.5) * 5200;
+    out.push(Math.round(clamp(v, 2400, 18500)));
+  }
+  return out;
+})();
+
+export const stepDistributionDomain: [number, number] = [2000, 19000];
+
+/** Mean daily steps over the same 90-day window, for the "vs typical" delta. */
+export const avgDailySteps = Math.round(
+  stepDistribution.reduce((a, b) => a + b, 0) / stepDistribution.length,
+);
+
+/** Fitness percentile vs peers, one reading per week for 26 weeks (0–100). */
+export const fitnessPercentile: number[] = (() => {
+  const rnd = mulberry32(64);
+  const out: number[] = [];
+  let p = 47;
+  for (let i = 0; i < 26; i++) {
+    p += (rnd() - 0.38) * 6; // slow upward drift with wobble
+    out.push(Math.round(clamp(p, 5, 95)));
+  }
+  return out;
+})();
+
+/** Weight forecast cone — 8 weeks ahead from the last actual. */
+export const weightForecast = (() => {
+  const mid = [73.5, 73.2, 72.9, 72.6, 72.4, 72.2, 72.0, 71.8];
+  const p80 = mid.map((m, i): [number, number] => {
+    const hw = 0.35 + i * 0.18;
+    return [Math.round((m - hw) * 10) / 10, Math.round((m + hw) * 10) / 10];
+  });
+  return { mid, p80 };
+})();
+export const weightTarget = 72;

--- a/examples/vitals-health/src/main.tsx
+++ b/examples/vitals-health/src/main.tsx
@@ -1,0 +1,13 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import "@microcharts/react/styles.css";
+import "@microcharts/react/motion";
+import "./app.css";
+import "./analytics";
+import { App } from "./App";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/examples/vitals-health/tsconfig.json
+++ b/examples/vitals-health/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "moduleDetection": "force",
+    "isolatedModules": true
+  },
+  "include": ["src"]
+}

--- a/examples/vitals-health/vite.config.ts
+++ b/examples/vitals-health/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: { port: 4003, strictPort: true, host: true },
+});


### PR DESCRIPTION
## Summary
- Adds seven independent example apps under `examples/` that exercise the full `@microcharts/react` catalog in real product contexts (analytics, finance, health, devops, editorial, real estate, AI evals).
- Apps install `@microcharts/react@0.8.0` from npm; includes README, DEPLOY docs, and `deploy-cloudflare.sh` for Cloudflare Pages (one project per app).
- Manual pre-release visual harness — not part of the pnpm workspace or CI.

## Live URLs
- https://microcharts-pulse.pages.dev
- https://microcharts-ledger.pages.dev
- https://microcharts-vitals.pages.dev
- https://microcharts-shipyard.pages.dev
- https://microcharts-dispatch.pages.dev
- https://microcharts-atlas.pages.dev
- https://microcharts-cortex.pages.dev

## Test plan
- [ ] `cd examples/<app> && npm install && npm run dev` for each app (ports 4001–4007)
- [ ] Spot-check light/dark and interactive scrubbing on atlas, cortex, dispatch
- [ ] Confirm `./deploy-cloudflare.sh` rebuilds cleanly if redeploying

Made with [Cursor](https://cursor.com)