### PR TITLE
chore: add glama.json and Glama registry links

### DIFF
--- a/.changeset/mcp-glama-listing.md
+++ b/.changeset/mcp-glama-listing.md
@@ -1,0 +1,8 @@
+---
+"@microcharts/mcp": patch
+---
+
+Link the Glama registry listing from the server README.
+
+The README ships inside the package, so the badge — which renders the registry's security and quality score — only
+reaches npm on a release.

--- a/README.md
+++ b/README.md
@@ -188,7 +188,8 @@ library: **find** the chart type that answers a question, **get** its exact prop
 
 Works in Claude Desktop, Claude Code, Cursor, and VS Code; nothing is hosted and no key is involved. The same three
 capabilities ship as Vercel AI SDK tools on the `@microcharts/mcp/ai-sdk` subpath. Full reference:
-[microcharts.dev/docs/mcp](https://microcharts.dev/docs/mcp).
+[microcharts.dev/docs/mcp](https://microcharts.dev/docs/mcp). Also listed in the
+[Glama MCP registry](https://glama.ai/mcp/servers/ganapativs/microcharts).
 
 ## Compatibility
 

--- a/apps/docs/content/docs/mcp.mdx
+++ b/apps/docs/content/docs/mcp.mdx
@@ -343,6 +343,7 @@ The rendered sample for every stable chart is exercised in that same suite.
 
 ---
 
-The package lives at [`@microcharts/mcp`](https://www.npmjs.com/package/@microcharts/mcp). If your assistant doesn't
-speak MCP, the [Quickstart](/docs/quickstart) has a paste-and-run prompt that teaches it the library directly, and
+The package lives at [`@microcharts/mcp`](https://www.npmjs.com/package/@microcharts/mcp), and is listed in the
+[Glama MCP registry](https://glama.ai/mcp/servers/ganapativs/microcharts). If your assistant doesn't speak MCP, the
+[Quickstart](/docs/quickstart) has a paste-and-run prompt that teaches it the library directly, and
 [AI-native](/docs/ai) covers the grammar it emits.

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["ganapativs"]
+}

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,5 +1,7 @@
 # @microcharts/mcp
 
+[![microcharts MCP server](https://glama.ai/mcp/servers/ganapativs/microcharts/badges/score.svg)](https://glama.ai/mcp/servers/ganapativs/microcharts)
+
 An MCP server and Vercel AI-SDK toolset for [microcharts](https://microcharts.dev) — let a model **find** the right
 word-sized chart, **get** exactly how to wire it, and **render** it to a finished SVG with real alt text.
 


### PR DESCRIPTION
Adds the metadata Glama's server quality checklist asks for, plus links to the listing.

- `glama.json` — declares maintainers per [Glama's schema](https://glama.ai/mcp/schemas/server.json). The checklist flags `No glama.json`; it only counts once the file is on `main`.
- `packages/mcp/README.md` — Glama score badge (the exact markdown Glama generates for this server).
- `README.md` + `apps/docs/content/docs/mcp.mdx` — link the registry listing from the MCP sections.

The server is listed and claimed at [glama.ai/mcp/servers/ganapativs/microcharts](https://glama.ai/mcp/servers/ganapativs/microcharts).

Docs test suite passes (1965). No other working-tree changes are included in this branch.