### PR TITLE
feat(docs): add Google Analytics 4

### DIFF
--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import { Bricolage_Grotesque, Hanken_Grotesk, JetBrains_Mono } from "next/font/google";
+import { Analytics } from "@/components/analytics";
 import { Provider } from "@/components/provider";
 import { SITE } from "@/lib/site";
 import {
@@ -150,6 +151,7 @@ export default function Layout({ children }: LayoutProps<"/">) {
         <script type="application/ld+json">{jsonLdScript(websiteJsonLd())}</script>
         <script type="application/ld+json">{jsonLdScript(softwareSourceCodeJsonLd())}</script>
         <script type="application/ld+json">{jsonLdScript(softwareApplicationJsonLd())}</script>
+        <Analytics />
         <Provider>{children}</Provider>
       </body>
     </html>

--- a/apps/docs/src/components/analytics.tsx
+++ b/apps/docs/src/components/analytics.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import Script from "next/script";
+import { usePathname, useSearchParams } from "next/navigation";
+import { Suspense, useEffect, useRef } from "react";
+
+const GA_ID = "G-LN11CCKKTW";
+
+declare global {
+  interface Window {
+    dataLayer: unknown[];
+    gtag: (...args: unknown[]) => void;
+  }
+}
+
+/** SPA pageviews — first load is covered by gtag('config'). */
+function GaPageViews() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const first = useRef(true);
+
+  useEffect(() => {
+    if (first.current) {
+      first.current = false;
+      return;
+    }
+    const qs = searchParams.toString();
+    const path = qs ? `${pathname}?${qs}` : pathname;
+    window.gtag?.("config", GA_ID, { page_path: path });
+  }, [pathname, searchParams]);
+
+  return null;
+}
+
+export function Analytics() {
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
+        strategy="afterInteractive"
+      />
+      <Script id="gtag-init" strategy="afterInteractive">{`
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', '${GA_ID}');
+`}</Script>
+      <Suspense fallback={null}>
+        <GaPageViews />
+      </Suspense>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Add GA4 (`G-LN11CCKKTW`) to the docs site via gtag.js in the root layout.
- Track initial pageviews plus App Router SPA navigations (`page_path` updates).
- No env/gitignore changes — measurement ID is hardcoded.

## Test plan
- [ ] Deploy docs and confirm the tag loads (`gtag/js?id=G-LN11CCKKTW`)
- [ ] Check GA Realtime for a hit on `/` and a client navigation (e.g. `/docs`)
- [ ] Confirm Enhanced Measurement remains enabled on the web stream


Made with [Cursor](https://cursor.com)