### PR TITLE
fix(mcp): type render_microchart's data param

### DIFF
--- a/.changeset/eighty-cars-repeat.md
+++ b/.changeset/eighty-cars-repeat.md
@@ -1,0 +1,9 @@
+---
+"@microcharts/mcp": patch
+---
+
+Declare a real JSON Schema type for `render_microchart`'s `data` parameter. It was `z.any()`, which emits `{}` with no
+`type` — clients that build a form or a prompt from the schema (Glama's inspector among them) read that as an unknown
+field type, and a model learns nothing about what to pass. It is now the union the catalog actually uses: an array for
+ordered series, or an object for the few charts whose data is keyed. Scalar charts still omit it. Per-chart shapes are
+unchanged and still validated at render time.

--- a/packages/mcp/src/ai-sdk.ts
+++ b/packages/mcp/src/ai-sdk.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { findChart } from "./tools/find";
 import { getChart } from "./tools/get";
 import { renderChart } from "./render-core";
+import { dataParam } from "./schema";
 
 /**
  * The same three capabilities as the MCP server, packaged as Vercel AI-SDK
@@ -47,7 +48,7 @@ export const microchartsTools: ToolSet = {
       "width) in `props`; check get_microchart for the exact shape.",
     inputSchema: z.object({
       type: z.string().describe('Chart slug, e.g. "sparkline".'),
-      data: z.any().optional().describe("Primary series; omit for scalar charts."),
+      data: dataParam,
       props: z
         .record(z.string(), z.any())
         .optional()

--- a/packages/mcp/src/schema.ts
+++ b/packages/mcp/src/schema.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+/**
+ * The `data` parameter of `render_microchart`, shared by the MCP tool and its
+ * AI-SDK twin so the two advertise one contract.
+ *
+ * Every chart takes its own data shape, so this parameter is genuinely
+ * polymorphic — but `z.any()` is the wrong way to say that: it emits `{}` with
+ * no `type` at all, which reads as "unknown field type" to a client building a
+ * form (or a prompt) from the schema, and tells a model nothing.
+ *
+ * The honest description is the union the catalog actually uses: a series
+ * (`number[]`, `(number | null)[]`, `{ label, value }[]`, …) or, for the handful
+ * of charts whose data is keyed rather than ordered (`{ plan, actual }`, …), an
+ * object. Scalar charts omit it and pass their value through `props`. Element
+ * types stay open on purpose — the per-chart shape is validated in
+ * `render-core`, which can name the chart and point at `get_microchart`.
+ */
+export const dataParam = z
+  .union([z.array(z.unknown()), z.record(z.string(), z.unknown())])
+  .optional()
+  .describe(
+    "Primary series (array), or a keyed object for charts that take one; omit for scalar charts.",
+  );

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -4,6 +4,7 @@ import { findChart } from "./tools/find";
 import { getChart } from "./tools/get";
 import { renderChart } from "./render-core";
 import { catalog, LIBRARY_VERSION } from "./catalog";
+import { dataParam } from "./schema";
 import { AGENT_SETUP } from "./assets.generated";
 import { MCP_VERSION } from "./version";
 
@@ -140,7 +141,7 @@ export function createServer(): McpServer {
         "chart takes its own data shape — get_microchart returns a valid `sample` to adapt.",
       inputSchema: {
         type: z.string().describe('Chart slug, e.g. "sparkline".'),
-        data: z.any().optional().describe("Primary series; omit for scalar charts."),
+        data: dataParam,
         props: z
           .record(z.string(), z.any())
           .optional()

--- a/packages/mcp/test/server.test.ts
+++ b/packages/mcp/test/server.test.ts
@@ -14,6 +14,15 @@ import { MCP_VERSION } from "../src/version";
  */
 let client: Client;
 
+/** True when a JSON Schema node says what it accepts — directly, or through
+ *  every branch of a union. `z.any()` emits `{}`, which says nothing. */
+const typed = (schema: unknown): boolean => {
+  const node = schema as { type?: unknown; anyOf?: unknown[]; oneOf?: unknown[] };
+  const branches = node.anyOf ?? node.oneOf;
+  if (branches) return branches.length > 0 && branches.every(typed);
+  return node.type !== undefined;
+};
+
 beforeAll(async () => {
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   client = new Client({ name: "test", version: "0" });
@@ -36,6 +45,45 @@ describe("mcp server", () => {
       expect(t.outputSchema, `${t.name} has no outputSchema`).toBeDefined();
       expect(t.description?.length ?? 0).toBeGreaterThan(40);
     }
+  });
+
+  /**
+   * A parameter declared as `z.any()` emits `{}` — no `type` — which a client
+   * building a form or a prompt from the schema reads as "unknown field type"
+   * (Glama's inspector says exactly that). Polymorphic parameters must still say
+   * what they accept, so assert every declared property carries a type, either
+   * directly or through the branches of a union.
+   */
+  it("declares a usable type for every input property", async () => {
+    const { tools } = await client.listTools();
+    for (const t of tools) {
+      const props = (t.inputSchema as { properties?: Record<string, unknown> }).properties ?? {};
+      for (const [name, schema] of Object.entries(props)) {
+        expect(typed(schema), `${t.name}.${name} has no JSON Schema type`).toBe(true);
+      }
+    }
+  });
+
+  it("accepts both data shapes the catalog uses, and refuses a scalar", async () => {
+    const series = await client.callTool({
+      name: "render_microchart",
+      arguments: { type: "sparkline", data: [3, 5, 4, 8, 6, 9] },
+    });
+    expect(series.isError).toBeFalsy();
+
+    // A handful of charts key their data instead of ordering it.
+    const keyed = await client.callTool({
+      name: "render_microchart",
+      arguments: { type: "burn-chart", data: { plan: [10, 7, 4, 0], actual: [10, 8, 6, 3] } },
+    });
+    expect(keyed.isError).toBeFalsy();
+
+    // `data` is never a bare scalar — those charts take a `value` prop instead.
+    const scalar = await client.callTool({
+      name: "render_microchart",
+      arguments: { type: "sparkline", data: 42 },
+    });
+    expect(scalar.isError).toBe(true);
   });
 
   it("serves both resources", async () => {


### PR DESCRIPTION
`render_microchart`'s `data` was declared `z.any()`, which emits `{}` — no JSON Schema `type` at all. Anything that builds a form or a prompt from the schema reads that as an unknown field type (Glama's MCP inspector says verbatim: `Unsupported field schema for field root_data: Unknown field type undefined`), and a model calling the tool learns nothing about what to pass.

The parameter is genuinely polymorphic — each chart has its own data shape — but the honest description is the union the catalog actually uses, not an erasure:

- **array** for ordered series (`number[]`, `(number | null)[]`, `{ label, value }[]`, …) — 73 of the catalog's samples
- **object** for the few charts whose data is keyed rather than ordered (`{ plan, actual }` and friends) — 8 samples
- **omitted** for the 25 scalar charts, which pass their value through `props`

Emitted schema is now:

```json
{
  "description": "Primary series (array), or a keyed object for charts that take one; omit for scalar charts.",
  "anyOf": [
    { "type": "array", "items": {} },
    { "type": "object", "propertyNames": { "type": "string" }, "additionalProperties": {} }
  ]
}
```

Element types stay open on purpose: the per-chart shape is validated in `render-core`, which can name the chart, quote its `dataShape`, and point at `get_microchart`. A tighter zod schema would replace those messages with a generic parse error.

The schema lives in `src/schema.ts` so the MCP tool and its AI-SDK twin advertise one contract.

## Tests

- `declares a usable type for every input property` — walks every registered tool's input properties and fails any that carry neither a `type` nor a union of typed branches. This is the regression guard: it fails if `data` goes back to `z.any()`.
- `accepts both data shapes the catalog uses, and refuses a scalar` — array data (sparkline), keyed data (burn-chart), and a bare number rejected.

145 passing, typecheck/lint/format/knip clean.