### PR TITLE
chore: stop renovate bumping published contracts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,12 @@
       "matchPackageNames": ["react", "react-dom", "@types/react", "@types/react-dom"],
       "matchUpdateTypes": ["major"],
       "dependencyDashboardApproval": true
+    },
+    {
+      "description": "engines + peerDependencies are the PUBLISHED contract, not the dev toolchain. `rangeStrategy: bump` would narrow them to whatever this repo happens to develop against — engines.node >=20 to >=24.18.0, or a peer range to the newest patch — locking consumers out for no gain. They move by hand, with intent. `.node-version` is unaffected, so the toolchain still tracks Node.",
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["engines", "peerDependencies"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
`engines` and `peerDependencies` describe what **consumers** may install. They are not a record of what this repo happens to develop against — but with the repo-wide `rangeStrategy: "bump"`, Renovate treats them exactly like any other version range and narrows them to the local toolchain.

### What it does today

`renovate/node-24.x` is queued right now on the dependency dashboard (#24). Its diff:

```diff
 .node-version                      24  ->  24.18.0      # fine — dev toolchain
 apps/docs/.node-version            24  ->  24.18.0      # fine — dev toolchain
-  package.json         "node": ">=20"                    # PUBLISHED contract
+  package.json         "node": ">=24.18.0"
-  packages/mcp/…       "node": ">=20"                    # PUBLISHED contract
+  packages/mcp/…       "node": ">=24.18.0"
```

Those last two are the published contract for `@microcharts/react` and `@microcharts/mcp`. The library is deliberately Node-20-safe ES2022 — `ci.yml` says so where it pins the test matrix:

> the published ESM is node-20-safe ES2022, so the Node version moves only the dev toolchain, not chart behaviour

So merging that PR would lock every consumer to Node ≥ 24.18.0 to buy exactly nothing.

### It is recurring, not a one-off

- #33 — `chore(deps): update node.js to >=20.20.2` — same engines rewrite, closed.
- #65 — narrowed the `@microcharts/mcp` `ai` peer from `^7.0.0` to `^7.0.37`, shrinking what consumers may install and requiring an npm release to reach anyone. Closed.
- #24 still lists the node bump under "Awaiting Schedule", so it comes back every Monday.

Nothing in the config told Renovate to stop, so each one had to be caught and closed by hand.

### The rule

```json
{
  "matchManagers": ["npm"],
  "matchDepTypes": ["engines", "peerDependencies"],
  "enabled": false
}
```

Both fields now move only by hand, with intent — which is the only way a semver contract should move.

**`.node-version` is deliberately not covered**: it belongs to the `node` manager, not `npm`, so the dev toolchain keeps tracking Node releases. That is the half of `renovate/node-24.x` that was always fine.

Validated with Renovate's own `renovate-config-validator` (`Config validated successfully`).
