### PR TITLE
chore(examples): bump microcharts to 0.10.0

### DIFF
--- a/examples/atlas-realestate/package.json
+++ b/examples/atlas-realestate/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview --port 4006 --strictPort"
   },
   "dependencies": {
-    "@microcharts/react": "^0.8.0",
+    "@microcharts/react": "^0.10.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/examples/cortex-ai/package.json
+++ b/examples/cortex-ai/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview --port 4007 --strictPort"
   },
   "dependencies": {
-    "@microcharts/react": "^0.8.0",
+    "@microcharts/react": "^0.10.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/examples/dispatch-editorial/package.json
+++ b/examples/dispatch-editorial/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview --port 4005 --strictPort"
   },
   "dependencies": {
-    "@microcharts/react": "^0.8.0",
+    "@microcharts/react": "^0.10.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/examples/ledger-finance/package.json
+++ b/examples/ledger-finance/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview --port 4002 --strictPort"
   },
   "dependencies": {
-    "@microcharts/react": "^0.8.0",
+    "@microcharts/react": "^0.10.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/examples/pulse-analytics/package.json
+++ b/examples/pulse-analytics/package.json
@@ -7,7 +7,7 @@
     "start": "next start -p 4001"
   },
   "dependencies": {
-    "@microcharts/react": "^0.8.0",
+    "@microcharts/react": "^0.10.0",
     "next": "^15.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/examples/shipyard-devops/package.json
+++ b/examples/shipyard-devops/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview --port 4004 --strictPort"
   },
   "dependencies": {
-    "@microcharts/react": "^0.8.0",
+    "@microcharts/react": "^0.10.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/examples/vitals-health/package.json
+++ b/examples/vitals-health/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview --port 4003 --strictPort"
   },
   "dependencies": {
-    "@microcharts/react": "^0.8.0",
+    "@microcharts/react": "^0.10.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },


### PR DESCRIPTION
Bumps all seven example apps from `@microcharts/react@^0.8.0` to `^0.10.0` (npm latest), and redeploys each one to its Cloudflare Pages project.

0.10.0 is the release that carries the catalog consistency audit (#81): every interactive chart now paints the reading it announces, `summary={false}` no longer discards an explicit `title`, and the interactive wrapper's `width: fit-content` / `max-width` moved out of the inline style into `styles.css` — so a consumer class like `className="w-full"` now sizes the interactive twin the same way it sizes the static one. The examples pick all of that up with no source changes.

## Verified

Every app rebuilt from scratch against 0.10.0 — the six Vite apps run `tsc -b && vite build`, so this is a typecheck too. All seven built clean, no source edits needed.

| App | Project | Live | Marks rendered |
| --- | --- | --- | --- |
| pulse-analytics | `microcharts-pulse` | https://microcharts-pulse.pages.dev | 14 (baked into the HTML — Next `output: "export"`) |
| ledger-finance | `microcharts-ledger` | https://microcharts-ledger.pages.dev | 13 |
| vitals-health | `microcharts-vitals` | https://microcharts-vitals.pages.dev | 11 |
| shipyard-devops | `microcharts-shipyard` | https://microcharts-shipyard.pages.dev | 55 |
| dispatch-editorial | `microcharts-dispatch` | https://microcharts-dispatch.pages.dev | 10 (5 interactive) |
| atlas-realestate | `microcharts-atlas` | https://microcharts-atlas.pages.dev | 56 |
| cortex-ai | `microcharts-cortex` | https://microcharts-cortex.pages.dev | 14 |

All seven return HTTP 200 and render their full chart set in a real browser, with no console errors. Pulse ships its charts in the served HTML (zero client JS for the static entries); the Vite apps are client-rendered, so their shell is empty by design and the counts above are post-hydration.

## Scope

Only the seven `package.json` dependency lines. Lockfiles are gitignored in `examples/`, and no app source changed.