### PR TITLE
ci: bump node to 24.18.1, gate playwright bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
-          node-version: 24.18.0
+          node-version: 24.18.1
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm typecheck
@@ -77,7 +77,7 @@ jobs:
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
-          node-version: 24.18.0
+          node-version: 24.18.1
       - run: node scripts/check-mcp-changeset.mjs "origin/${{ github.base_ref }}"
 
   # Per-subpath gzip diff against the base branch, replied as one sticky PR
@@ -103,7 +103,7 @@ jobs:
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
-          node-version: 24.18.0
+          node-version: 24.18.1
       - name: Diff sizes against ${{ github.base_ref }}
         id: diff
         # The report has to reach the PR even when the gate fails, so the
@@ -152,7 +152,7 @@ jobs:
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
-          node-version: 24.18.0
+          node-version: 24.18.1
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm vitest run --project core --project dom
@@ -185,7 +185,7 @@ jobs:
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
-          node-version: 24.18.0
+          node-version: 24.18.1
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Pin React ${{ matrix.react }}
@@ -203,7 +203,7 @@ jobs:
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
-          node-version: 24.18.0
+          node-version: 24.18.1
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm build # dist/ that the fixture imports
@@ -221,7 +221,7 @@ jobs:
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
-          node-version: 24.18.0
+          node-version: 24.18.1
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
-          node-version: 24.18.0
+          node-version: 24.18.1
           cache: pnpm
           registry-url: https://registry.npmjs.org
       # Pinned to the npm 11 line: OIDC trusted publishing needs npm >= 11.5,

--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
-          node-version: 24.18.0
+          node-version: 24.18.1
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm build

--- a/renovate.json
+++ b/renovate.json
@@ -31,9 +31,21 @@
       "dependencyDashboardApproval": true
     },
     {
-      "description": "engines + peerDependencies are the PUBLISHED contract, not the dev toolchain. `rangeStrategy: bump` would narrow them to whatever this repo happens to develop against — engines.node >=20 to >=24.18.0, or a peer range to the newest patch — locking consumers out for no gain. They move by hand, with intent. `.node-version` is unaffected, so the toolchain still tracks Node.",
+      "description": "engines + peerDependencies are the PUBLISHED contract, not the dev toolchain. `rangeStrategy: bump` would narrow them to whatever this repo happens to develop against — engines.node >=20 to >=24.18.0, or a peer range to the newest patch — locking consumers out for no gain. They move by hand, with intent.",
       "matchManagers": ["npm"],
       "matchDepTypes": ["engines", "peerDependencies"],
+      "enabled": false
+    },
+    {
+      "description": "Playwright and the CI container image are ONE version. `test-browser` and `visual` run inside `mcr.microsoft.com/playwright:vX-noble`, which ships the browsers preinstalled; if the npm package outruns the tag, every leg dies with \"Executable doesn't exist at /ms-playwright/…\". npm publishes a release before MCR builds the image, so this can never be safe to automate. Approve from the dependency dashboard only once the tag exists at https://mcr.microsoft.com/v2/playwright/tags/list, and move ci.yml + visual.yml in the same PR.",
+      "matchPackageNames": ["playwright", "playwright-core", "@playwright/test"],
+      "groupName": "playwright + CI image",
+      "dependencyDashboardApproval": true,
+      "automerge": false
+    },
+    {
+      "description": "`.node-version` is deliberately the floating major `24`, so every local toolchain (fnm/nvm/nodenv) picks up each Node patch — including security patches — with no PR at all. Renovate's nodenv manager would rewrite it to one exact patch, which narrows local installs, disagrees with the exact `node-version:` each CI job pins for itself, and files a PR per Node release. CI's pins are the ones that move by hand.",
+      "matchManagers": ["nodenv"],
       "enabled": false
     }
   ]


### PR DESCRIPTION
Unblocks #86 and replaces #87. All three changes are about which pins Renovate is allowed to move on its own.

## Playwright is gated on the CI image

`test-browser` and `visual` run inside `mcr.microsoft.com/playwright:vX-noble`, which ships the browsers preinstalled. The npm package and that tag are one version. npm publishes a release before MCR builds the image — **1.62.0 is on npm right now with no image published** ([tag list](https://mcr.microsoft.com/v2/playwright/tags/list) tops out at 1.61.1) — which is exactly why #86 fails both React legs:

```
Executable doesn't exist at /ms-playwright/chromium_headless_shell-1234/...
 -  current: mcr.microsoft.com/playwright:v1.61.1-noble
 -  required: mcr.microsoft.com/playwright:v1.62.0-noble
```

The comment at `ci.yml:165` already said the two move together; nothing enforced it, so the grouped devDependency PR swept playwright up and broke itself. Playwright now sits in its own group behind `dependencyDashboardApproval`, so the bump waits for someone who can check the tag list and edit both workflow pins in the same PR.

## The nodenv manager is off

`.node-version` is the floating major `24` on purpose: every local toolchain picks up each Node patch, security ones included, with no PR at all. Renovate rewrites it to one exact patch (#87), which narrows local installs, disagrees with the exact `node-version:` each CI job pins for itself, and files a PR per Node release.

The stale clause in the engines/peerDependencies rule that said `.node-version` is "unaffected, so the toolchain still tracks Node" is corrected — it now describes the pin that actually does the tracking.

## CI node pins move by hand, so they move here

That policy only works if CI's own pins are maintained, and they were sitting on a CVE'd patch. 24.18.0 → 24.18.1 across all nine jobs in `ci.yml`, `release.yml`, `visual.yml`. [24.18.1](https://github.com/nodejs/node/releases/tag/v24.18.1) is a security release: three High CVEs (CVE-2026-56846, CVE-2026-56848 http2; CVE-2026-58043 permission model) plus eight lower ones. Low practical exposure for a build runner, but no reason to sit on it.

## After this lands

- #86 rebases without the playwright bump and its nine other devDep updates go green.
- #87 closes; `.node-version` stays at `24`.

## Verification

Pre-push gate green locally: `gen:check`, typecheck, node tests, docs tests, browser tests. `nodenv` confirmed as the manager owning `.node-version` per [the Renovate docs](https://docs.renovatebot.com/modules/manager/nodenv/).