### PR TITLE
docs: add TanStack Charts comparison page

### DIFF
--- a/apps/docs/content/docs/full-chart-libraries.mdx
+++ b/apps/docs/content/docs/full-chart-libraries.mdx
@@ -81,6 +81,7 @@ anything.
 
 - [When to use microcharts](/docs/when-to-use)
 - [microcharts vs Recharts](/docs/vs-recharts) · [microcharts vs Chart.js](/docs/vs-chartjs) — the per-library detail
+- [microcharts vs TanStack Charts](/docs/vs-tanstack-charts) — a typed chart grammar, measured at `0.0.0`
 - [React sparklines](/docs/react-sparklines)
 - [Inline charts](/docs/inline-charts)
 - [Performance](/docs/performance)

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -102,7 +102,8 @@ the cell. microcharts is built for the cell itself: word-sized SVG marks, one ch
 The two solve different problems — see [When to use](/docs/when-to-use) and
 [Full chart libraries](/docs/full-chart-libraries), or the measured per-library pages: [vs Recharts](/docs/vs-recharts),
 [vs Chart.js](/docs/vs-chartjs), [vs react-sparklines](/docs/vs-react-sparklines),
-[vs MUI X Sparkline](/docs/vs-mui-x-sparkline), and [vs visx](/docs/vs-visx).
+[vs MUI X Sparkline](/docs/vs-mui-x-sparkline), [vs visx](/docs/vs-visx), and
+[vs TanStack Charts](/docs/vs-tanstack-charts).
 
 ### Are microcharts accessible?
 

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -27,6 +27,7 @@
     "vs-chartjs",
     "vs-react-sparklines",
     "vs-mui-x-sparkline",
-    "vs-visx"
+    "vs-visx",
+    "vs-tanstack-charts"
   ]
 }

--- a/apps/docs/content/docs/performance.mdx
+++ b/apps/docs/content/docs/performance.mdx
@@ -34,6 +34,11 @@ EventTimeline, VolumeProfile, GradedBand and LikertStrip; the last two crossed t
 onto a real `Intl` formatter. The annotation hosts carry a small shared walker that resolves `Threshold`, `Marker`, and
 the rest against the chart's scale, and you pay for it only on those charts.
 
+Every number on this page is measured in this repo. For a reading nobody here produced, open the package on
+[Bundlephobia](https://bundlephobia.com/package/@microcharts/react): it installs the published tarball, counts the
+dependencies, and sizes the root entry. Its figure covers the package root rather than a per-chart subpath, so read it
+as a check on the dependency count, not as the number a chart costs you.
+
 ### Splitting the stylesheet
 
 `@microcharts/react/styles.css` is one artifact for the whole catalog, and importing it once is the right default: it is

--- a/apps/docs/content/docs/vs-tanstack-charts.mdx
+++ b/apps/docs/content/docs/vs-tanstack-charts.mdx
@@ -1,0 +1,76 @@
+---
+title: microcharts vs TanStack Charts — tiny charts comparison
+description:
+  TanStack Charts is a typed chart grammar over d3, published as a 0.0.0 proof; this page measures one of its React
+  charts and lists what each library decides for you.
+---
+
+[TanStack Charts](https://tanstack.com/charts) is a typed visualization grammar: you declare marks, channels, and d3
+scales, and an adapter renders SVG for React, Vue, Solid, Svelte, Angular, Lit, or the vanilla DOM. Its catalog covers
+full surfaces — lines, bars, heatmaps, treemaps, choropleths, streamgraphs. microcharts ships finished word-sized marks
+for React with the design decisions already made.
+
+Check the release status before you compare anything else. TanStack Charts went to npm as `0.0.0` on 2026-07-29, and its
+README calls the packages a product proof that is not ready for production. Everything measured below is that snapshot,
+and it will move.
+
+## The numbers
+
+<VsTanstackChartsTable />
+
+That <TanstackChartGzip /> is one line chart: `defineChart` with a single `lineY` mark and two d3 scales, through
+`@tanstack/react-charts`, with react external. TanStack publishes <TanstackVendorGzip /> for the same class of chart on
+the vanilla renderer, so the two readings agree. That is a fair price for a chart with axes, grid, guide margins, and
+tooltips. It is also about ten times the budget of a Sparkline that has to fit in a table cell.
+
+## What each library decides
+
+TanStack Charts hands you the composition. You pick the scales, the marks, the domains, the guides, and the label text,
+and the type system checks that they line up with your datum. That is the point of a grammar: the chart you need next
+year is the same API as the chart you need today.
+
+microcharts hands you the chart. The catalog is <CatalogTotal /> fixed types, so there is no grammar to grow into and no
+composition to assemble when the shape you want is missing. In exchange, areas anchor at zero, direction is never
+color-alone, labels reserve deterministic gutters, and empty or all-null data render documented placeholders. You pass
+`data` and get a mark that is already sized for a sentence.
+
+## Chrome and node count
+
+That one-line chart renders <TanstackSvgNodes /> SVG elements server-side, because guides, grid, and axis rules are part
+of what a chart surface means. A microchart runs about six nodes, because axes and legends are hard-coded away rather
+than configured off. Both counts are right for their job. Neither library is trying to hit the other one's number.
+
+## Server Components
+
+TanStack Charts renders SVG on the server, and the React `<Chart>` component reads that same prerendered markup. The
+component itself calls `useMemo`, `useId`, and `useLayoutEffect` and carries no `'use client'` directive, so in an RSC
+app it goes inside a client boundary and ships its JavaScript. The static microcharts entry is hook-free by design and
+renders from a Server Component with zero client JS; interactivity lives in a separate `/interactive` subpath.
+
+## Accessibility
+
+Both libraries treat the accessible name as required rather than optional. TanStack Charts types `ariaLabel` as a
+required prop and renders `role="img"` with `aria-roledescription="chart"`, so the sentence a screen reader announces is
+yours to write and keep in sync with the data. microcharts generates that sentence from the data with `describeSeries`,
+and `summary={false}` is the decorative opt-out.
+
+## Reach for TanStack Charts
+
+- You want one typed grammar for every chart in the product, at panel size
+- You need shapes microcharts excludes on purpose: treemaps, choropleths, networks, streamgraphs
+- You render charts from more than one framework and want the same definition in each
+- You are comfortable tracking a pre-1.0 API
+
+## Reach for microcharts
+
+- The mark belongs in a sentence, a table cell, a KPI, or a streamed reply
+- You want static RSC output at <SizeMarketing /> gzip with zero runtime dependencies
+- You want the accessible summary, the edge cases, and the design generated for you
+- You are on React 18 as well as React 19
+
+## Next
+
+- [When to use microcharts](/docs/when-to-use)
+- [Full chart libraries](/docs/full-chart-libraries) — the same decision against Recharts and Chart.js
+- [microcharts vs visx](/docs/vs-visx) — the other build-it-yourself fork in the road
+- [Design notes](/docs/design-notes) — the decisions microcharts makes for you

--- a/apps/docs/content/docs/vs-visx.mdx
+++ b/apps/docs/content/docs/vs-visx.mdx
@@ -60,4 +60,5 @@ A bespoke visualization deserves primitives, so reach for visx when:
 - [When to use microcharts](/docs/when-to-use)
 - [Design notes](/docs/design-notes) — the decisions microcharts makes for you
 - [microcharts vs Recharts](/docs/vs-recharts)
+- [microcharts vs TanStack Charts](/docs/vs-tanstack-charts) — the same fork, one layer up in the grammar
 - [Composition](/docs/composition) — placing marks in real surfaces

--- a/apps/docs/content/docs/when-to-use.mdx
+++ b/apps/docs/content/docs/when-to-use.mdx
@@ -8,10 +8,10 @@ description:
 microcharts draws tiny charts for React that sit _inside_ an interface: a trend after a number, a bullet in a KPI, a
 strip in a table cell, a mark in a streamed reply.
 
-It is not a substitute for [Recharts](https://recharts.org), [Chart.js](https://www.chartjs.org), Nivo, ECharts, or
-visx. Those libraries draw surfaces that are mostly chart: axes, legends, tooltips, brush, zoom. microcharts draws
-mostly words and UI with a word-sized mark in them. Use a full library when the page _is_ the chart. Use microcharts
-when the chart sits inside something you were already reading.
+It is not a substitute for [Recharts](https://recharts.org), [Chart.js](https://www.chartjs.org), Nivo, ECharts, visx,
+or [TanStack Charts](https://tanstack.com/charts). Those libraries draw surfaces that are mostly chart: axes, legends,
+tooltips, brush, zoom. microcharts draws mostly words and UI with a word-sized mark in them. Use a full library when the
+page _is_ the chart. Use microcharts when the chart sits inside something you were already reading.
 
 ## Fit
 
@@ -60,6 +60,6 @@ in-catalog replacement — for example [SegmentedBar](/docs/charts/segmented-bar
 - [Full chart libraries](/docs/full-chart-libraries) — Recharts and Chart.js, side by side
 - Comparing a specific library? [vs Recharts](/docs/vs-recharts) · [vs Chart.js](/docs/vs-chartjs) ·
   [vs react-sparklines](/docs/vs-react-sparklines) · [vs MUI X Sparkline](/docs/vs-mui-x-sparkline) ·
-  [vs visx](/docs/vs-visx)
+  [vs visx](/docs/vs-visx) · [vs TanStack Charts](/docs/vs-tanstack-charts)
 - [Quickstart](/docs/quickstart) — install and first chart
 - [Introduction](/docs) — grammar, catalog, and where they live

--- a/apps/docs/src/app/global.css
+++ b/apps/docs/src/app/global.css
@@ -1128,7 +1128,10 @@ body {
     }
   }
 }
-.glass-rail[data-scrolled] {
+/* Scrolled surface. The `:root` attribute comes from the boot script in
+   layout.tsx, which sets it before hydration, so a reload at a restored offset
+   never paints a bare rail first. */
+:root[data-rail-scrolled] .glass-rail {
   background-color: color-mix(in oklab, var(--color-fd-background) 72%, transparent);
   -webkit-backdrop-filter: blur(16px) saturate(var(--glass-sat)) brightness(var(--glass-bright));
   backdrop-filter: blur(16px) saturate(var(--glass-sat)) brightness(var(--glass-bright));
@@ -1136,7 +1139,7 @@ body {
 /* While the mobile sheet is open the WHOLE header is solid page ink — rail and
    sheet must read as one seamless surface (the sheet can't frost, see above),
    so the rail drops its translucency instead of the sheet faking one. Wins
-   over [data-scrolled] by source order. */
+   over the scrolled surface by source order. */
 .glass-rail[data-menu-open] {
   background-color: var(--color-fd-background);
   -webkit-backdrop-filter: none;
@@ -1671,11 +1674,14 @@ figure:has(> pre) .shiki,
   border-top: 0;
 }
 /* Row headers (`<th scope="row">`, e.g. the compare tables) — same cell as a
-   td, not the mono column-header treatment. */
+   td, not the mono column-header treatment. Fumadocs' prose gives every `th` a
+   muted fill; on light that paints the first column a different colour from the
+   rest of the row, so clear it here. */
 .prose tbody th,
 .mc-table tbody th {
   border: 0;
   border-top: 1px solid color-mix(in oklab, var(--hairline) 50%, transparent);
+  background-color: transparent;
   padding: 0.7rem 1rem;
   vertical-align: top;
   text-align: left;

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -74,6 +74,13 @@ const mono = localFont({
 // Apply saved accent + chart preset before first paint.
 const ACCENT_SCRIPT = `try{var d=document.documentElement,a=localStorage.getItem("mc-accent");if(a&&a!=="cobalt")d.dataset.accent=a;var p=localStorage.getItem("mc-preset");if(p&&p!=="modern")d.dataset.mcPreset=p}catch(e){}`;
 
+// Mark the scrolled state on :root before hydration, so a reload at a restored
+// scroll offset paints the header's surface in the first frame instead of
+// materialising it a beat later (which is what a hydration-time effect does).
+// Scroll restoration can land before or after this script runs, so the state is
+// re-read on the next frame and on pageshow (bfcache) as well as on scroll.
+const RAIL_SCRIPT = `try{var d=document.documentElement,f=function(){d.toggleAttribute("data-rail-scrolled",(window.scrollY||0)>8)};f();addEventListener("scroll",f,{passive:true});addEventListener("pageshow",f);requestAnimationFrame(f)}catch(e){}`;
+
 // Console easter egg — unicode blocks of the hero sparkline series [3,5,4,8,6,9,7,11].
 const CONSOLE_SCRIPT = `try{console.log("%c▁▃▂▅▄▆▅█%c  ${SITE.name}%c\\n${SITE.tagline}\\nThat glyph is the hero's sparkline in text. Small enough for a sentence, a table cell, or a console.log.\\nZero dependencies, ~2–7 kB interactive · ~1–4 kB static per chart, accessible by default.\\n\\nDocs    ${SITE.url}/docs\\nSource  ${SITE.repo}","color:#2f52d4;font-size:15px;letter-spacing:1.5px","color:#2f52d4;font-weight:700;font-size:13px","color:#8a8986;font-size:11px;line-height:1.7")}catch(e){}`;
 
@@ -168,6 +175,7 @@ export default function Layout({ children }: LayoutProps<"/">) {
         <div aria-hidden className="site-grain" />
         <div aria-hidden className="site-wash" />
         <script dangerouslySetInnerHTML={{ __html: ACCENT_SCRIPT }} />
+        <script dangerouslySetInnerHTML={{ __html: RAIL_SCRIPT }} />
         <script dangerouslySetInnerHTML={{ __html: CONSOLE_SCRIPT }} />
         <script type="application/ld+json">{jsonLdScript(organizationJsonLd())}</script>
         <script type="application/ld+json">{jsonLdScript(websiteJsonLd())}</script>

--- a/apps/docs/src/components/appearance-menu.tsx
+++ b/apps/docs/src/components/appearance-menu.tsx
@@ -7,6 +7,7 @@ import { ArrowUpRight, Check, Copy, Monitor, Moon, Palette, Sun } from "lucide-r
 import { Sparkline } from "@microcharts/react/sparkline";
 import { SegmentedBar } from "@microcharts/react/segmented-bar";
 import { cn } from "@/lib/cn";
+import { CopyLabel } from "@/components/ui/copy";
 import { PRESETS as MC_PRESETS } from "@/lib/mc-tokens";
 import { serializeTokens } from "@/lib/token-export";
 
@@ -331,7 +332,7 @@ export function AppearanceMenu() {
                   ) : (
                     <Copy className="size-3.5" />
                   )}
-                  {copied ? "Copied CSS" : "Copy tokens"}
+                  <CopyLabel copied={copied} idle="Copy tokens" done="Copied CSS" />
                 </button>
                 <Link
                   href="/docs/theming#copy-tokens"

--- a/apps/docs/src/components/charts/token-swatches.tsx
+++ b/apps/docs/src/components/charts/token-swatches.tsx
@@ -4,6 +4,7 @@ import { Check, Copy } from "lucide-react";
 import { Sparkline } from "@microcharts/react/sparkline";
 import { MiniBar } from "@microcharts/react/mini-bar";
 import { cn } from "@/lib/cn";
+import { CopyLabel } from "@/components/ui/copy";
 import { SEMANTIC_TOKENS, CATEGORICAL_TOKENS, PRESETS, type ColorToken } from "@/lib/mc-tokens";
 import { serializeTokens } from "@/lib/token-export";
 
@@ -174,7 +175,7 @@ function CopyPresetTokens({ preset }: { preset: string }) {
       className="inline-flex items-center gap-1 rounded-md border border-fd-border/70 px-1.5 py-0.5 text-[0.62rem] font-medium text-fd-muted-foreground transition-colors hover:border-fd-primary/40 hover:text-fd-foreground"
     >
       {copied ? <Check className="size-3 text-fd-primary" /> : <Copy className="size-3" />}
-      {copied ? "Copied" : "Copy tokens"}
+      <CopyLabel copied={copied} idle="Copy tokens" done="Copied" />
     </button>
   );
 }

--- a/apps/docs/src/components/home/actions.tsx
+++ b/apps/docs/src/components/home/actions.tsx
@@ -68,9 +68,12 @@ export function HeroActions() {
       </div>
       <div className="grid justify-items-start gap-y-2.5 sm:flex sm:flex-wrap sm:items-center sm:gap-x-3.5">
         <CopyLine text={`pnpm add ${SITE.pkg}`} />
+        {/* No margin nudges: the separator sits on the row's own gap, equal on
+            both sides. The old -1.5/+1.5 pair corrected for a trailing gap
+            inside CopyLine that the copy control no longer reserves. */}
         <span
           aria-hidden
-          className="hidden select-none sm:-ml-1.5 sm:mr-1.5 sm:inline"
+          className="hidden select-none sm:inline"
           style={{ color: "var(--rule-2)" }}
         >
           /

--- a/apps/docs/src/components/home/copy-line.tsx
+++ b/apps/docs/src/components/home/copy-line.tsx
@@ -9,9 +9,10 @@ import { track } from "@/lib/analytics";
  * binary at full strength, verb quiet, package on the accent, so it recolours
  * with the palette. No box — the syntax colour already says "shell command".
  *
- * The button keeps its width when the label changes so the row never reflows, and
- * `aria-live` sits on a separate node: swapping the accessible name of the
- * control you just activated is announced as a different control.
+ * The row reserves the confirmation's box before it is shown, so clicking copy
+ * moves nothing. `aria-live` sits on a separate visually-hidden node: swapping
+ * the accessible name of the control you just activated is announced as a
+ * different control.
  */
 export function CopyLine({
   text,
@@ -55,8 +56,17 @@ export function CopyLine({
           <Copy aria-hidden className="size-3.5" style={{ color: "var(--ink-3)" }} />
         )}
       </button>
-      <span aria-live="polite" className="mono-s" style={{ color: "var(--ink-3)" }}>
-        {copied ? "copied" : ""}
+      {/* The confirmation reserves its box up front — width from the word, height
+          pinned by `leading-none` — so the row never grows when it appears. */}
+      <span
+        aria-hidden
+        className="mono-s leading-none transition-opacity duration-150"
+        style={{ color: "var(--ink-3)", opacity: copied ? 1 : 0 }}
+      >
+        copied
+      </span>
+      <span aria-live="polite" className="sr-only">
+        {copied ? "Copied" : ""}
       </span>
     </span>
   );

--- a/apps/docs/src/components/home/copy-line.tsx
+++ b/apps/docs/src/components/home/copy-line.tsx
@@ -9,10 +9,10 @@ import { track } from "@/lib/analytics";
  * binary at full strength, verb quiet, package on the accent, so it recolours
  * with the palette. No box — the syntax colour already says "shell command".
  *
- * The row reserves the confirmation's box before it is shown, so clicking copy
- * moves nothing. `aria-live` sits on a separate visually-hidden node: swapping
- * the accessible name of the control you just activated is announced as a
- * different control.
+ * Copying swaps the trailing icon to a tick and nothing else: same box, same
+ * row, no reflow and no reserved gap. `aria-live` sits on a separate
+ * visually-hidden node, because swapping the accessible name of the control you
+ * just activated is announced as a different control.
  */
 export function CopyLine({
   text,
@@ -42,7 +42,7 @@ export function CopyLine({
   }
 
   return (
-    <span className="inline-flex items-center gap-3">
+    <span className="inline-flex items-center">
       <button
         type="button"
         onClick={copy}
@@ -56,15 +56,9 @@ export function CopyLine({
           <Copy aria-hidden className="size-3.5" style={{ color: "var(--ink-3)" }} />
         )}
       </button>
-      {/* The confirmation reserves its box up front — width from the word, height
-          pinned by `leading-none` — so the row never grows when it appears. */}
-      <span
-        aria-hidden
-        className="mono-s leading-none transition-opacity duration-150"
-        style={{ color: "var(--ink-3)", opacity: copied ? 1 : 0 }}
-      >
-        copied
-      </span>
+      {/* The tick IS the confirmation. A visible "copied" word either reflows the
+          row or reserves a gap that sits there permanently; the icon swap says
+          the same thing inside a box that never changes. */}
       <span aria-live="polite" className="sr-only">
         {copied ? "Copied" : ""}
       </span>

--- a/apps/docs/src/components/mdx.tsx
+++ b/apps/docs/src/components/mdx.tsx
@@ -144,10 +144,14 @@ import {
   CatalogTotal,
   ChartSize,
   SizeMarketing,
+  TanstackChartGzip,
+  TanstackSvgNodes,
+  TanstackVendorGzip,
   VsChartJsTable,
   VsMuiXTable,
   VsReactSparklinesTable,
   VsRechartsTable,
+  VsTanstackChartsTable,
   VsVisxTable,
 } from "@/components/ui/choose-facts";
 import dynamic from "next/dynamic";
@@ -376,6 +380,10 @@ export function getMDXComponents(components?: MDXComponents) {
     VsReactSparklinesTable,
     VsMuiXTable,
     VsVisxTable,
+    VsTanstackChartsTable,
+    TanstackChartGzip,
+    TanstackVendorGzip,
+    TanstackSvgNodes,
     ...components,
   } satisfies MDXComponents;
 }

--- a/apps/docs/src/components/site-footer.tsx
+++ b/apps/docs/src/components/site-footer.tsx
@@ -53,7 +53,12 @@ const featured = FEATURED_SLUGS.map((slug) => STABLE_CHARTS.find((c) => c.slug =
   (c): c is (typeof STABLE_CHARTS)[number] => c !== undefined,
 );
 
-const cols: { title: string; links: { href: string; label: string; external?: boolean }[] }[] = [
+// `external` = a plain <a> (a file this site serves, not a route); `offsite`
+// adds the new-tab treatment the rest of the outbound links here use.
+const cols: {
+  title: string;
+  links: { href: string; label: string; external?: boolean; offsite?: boolean }[];
+}[] = [
   {
     title: "Docs",
     links: [
@@ -62,6 +67,10 @@ const cols: { title: string; links: { href: string; label: string; external?: bo
       { href: "/docs/accessibility", label: "Accessibility" },
       { href: "/docs/performance", label: "Performance" },
       { href: "/docs/theming", label: "Theming" },
+      // The one link in this column that leaves the site: Bundlephobia installs
+      // the published tarball and counts its dependencies, so the size claims on
+      // /docs/performance have a reading next to them that nobody here produced.
+      { href: SITE.bundlephobia, label: "Bundle size ↗", external: true, offsite: true },
     ],
   },
   {
@@ -221,6 +230,8 @@ export function SiteFooter() {
                     <li key={l.href}>
                       <a
                         href={l.href}
+                        target={l.offsite ? "_blank" : undefined}
+                        rel={l.offsite ? "noreferrer noopener" : undefined}
                         className="text-fd-muted-foreground link-underline hover:text-fd-foreground"
                       >
                         {l.label}

--- a/apps/docs/src/components/site-nav.tsx
+++ b/apps/docs/src/components/site-nav.tsx
@@ -60,7 +60,6 @@ const ctrl = "ghost-ctrl size-8";
 
 export function SiteNav() {
   const pathname = usePathname();
-  const [scrolled, setScrolled] = useState(false);
   const [open, setOpen] = useState(false);
 
   // The mobile sheet never survives a navigation or an Escape.
@@ -76,26 +75,13 @@ export function SiteNav() {
     return () => window.removeEventListener("keydown", onKey);
   }, [open]);
 
-  useEffect(() => {
-    let raf = 0;
-    const onScroll = () => {
-      cancelAnimationFrame(raf);
-      raf = requestAnimationFrame(() => setScrolled(window.scrollY > 8));
-    };
-    onScroll();
-    window.addEventListener("scroll", onScroll, { passive: true });
-    return () => {
-      cancelAnimationFrame(raf);
-      window.removeEventListener("scroll", onScroll);
-    };
-  }, []);
-
   return (
-    <header
-      className="glass-rail sticky top-0 z-40"
-      data-scrolled={scrolled || undefined}
-      data-menu-open={open || undefined}
-    >
+    // The scrolled surface is not React's business. The boot script in
+    // layout.tsx sets `:root[data-rail-scrolled]` before hydration and keeps it
+    // on scroll, so a reload at a restored offset paints the right rail in the
+    // first frame — a hydration-time effect never can, which is what made the
+    // background appear a beat after the page.
+    <header className="glass-rail sticky top-0 z-40" data-menu-open={open || undefined}>
       <nav className="mx-auto flex h-14 max-w-shell items-center gap-5 px-4 sm:px-6">
         <Wordmark />
         <div className="hidden items-center gap-0.5 md:flex">

--- a/apps/docs/src/components/ui/agent-prompt-copy.tsx
+++ b/apps/docs/src/components/ui/agent-prompt-copy.tsx
@@ -2,6 +2,7 @@
 
 import { useRef, useState } from "react";
 import { Check, Copy, Link2 } from "lucide-react";
+import { CopyLabel } from "@/components/ui/copy";
 import { SITE } from "@/lib/site";
 import { track } from "@/lib/analytics";
 
@@ -35,7 +36,7 @@ export function AgentPromptCopy() {
         }}
       >
         {copied === "full" ? <Check className="size-4" /> : <Copy className="size-4" />}
-        {copied === "full" ? "Copied" : "Copy setup prompt"}
+        <CopyLabel copied={copied === "full"} idle="Copy setup prompt" done="Copied" />
       </button>
       <button
         type="button"
@@ -45,7 +46,7 @@ export function AgentPromptCopy() {
         onClick={() => copy(SHORT_PROMPT, "short")}
       >
         {copied === "short" ? <Check className="size-3.5" /> : <Link2 className="size-3.5" />}
-        {copied === "short" ? "Copied" : "Copy short version"}
+        <CopyLabel copied={copied === "short"} idle="Copy short version" done="Copied" />
       </button>
     </div>
   );

--- a/apps/docs/src/components/ui/choose-facts.tsx
+++ b/apps/docs/src/components/ui/choose-facts.tsx
@@ -6,6 +6,7 @@ import {
   MUI_X_CHARTS,
   REACT_SPARKLINES_LEGACY,
   RECHARTS,
+  TANSTACK_CHARTS,
   VISX,
 } from "@/lib/competitor-facts";
 
@@ -188,6 +189,69 @@ export function VsVisxTable() {
         },
       ]}
       note={`visx size via esbuild bundle of LinePath + scaleLinear, react external, minify+gzip ${VISX.measuredAt}. microcharts from .size-limit.json (CI).`}
+    />
+  );
+}
+
+/** Pinned TanStack Charts readings, so /docs/vs-tanstack-charts prose never
+ *  hard-codes a competitor number. */
+export function TanstackChartGzip() {
+  return <span className="tabular-nums">{TANSTACK_CHARTS.oneChartGzipKb} kB</span>;
+}
+
+export function TanstackVendorGzip() {
+  return <span className="tabular-nums">{TANSTACK_CHARTS.vendorSvgChartGzipKb} kB</span>;
+}
+
+export function TanstackSvgNodes() {
+  return <span className="tabular-nums">{TANSTACK_CHARTS.ssrSvgNodes}</span>;
+}
+
+/** Orientation table for /docs/vs-tanstack-charts — a grammar in pre-release
+ *  against a finished word-sized catalog. */
+export function VsTanstackChartsTable() {
+  const spark = CHART_GZIP.sparkline;
+  const ts = TANSTACK_CHARTS;
+  return (
+    <CompareTable
+      competitor={`TanStack Charts ${ts.version}`}
+      rows={[
+        {
+          signal: "Gzip for one line chart",
+          them: `~${ts.oneChartGzipKb} kB (React adapter, react external)`,
+          us: `${spark?.static} kB static · ${spark?.interactive} kB interactive`,
+        },
+        {
+          signal: "Release status",
+          them: `${ts.status} — first published ${ts.firstPublish}`,
+          us: `stable on npm, ${CATALOG.total} charts`,
+        },
+        {
+          signal: "Runtime dependencies",
+          them: `${ts.runtimeDeps} d3 packages, plus ${ts.appInstalls.join(" + ")} in your app`,
+          us: "0 (React is a peer)",
+        },
+        {
+          signal: "React support",
+          them: `peer ${ts.reactPeer}`,
+          us: "peer ^18 || ^19",
+        },
+        {
+          signal: "Server Components",
+          them: "renders SVG on the server; the React component is hook-based, so it needs a client boundary",
+          us: "static entry renders in RSC, zero client JS",
+        },
+        {
+          signal: "Accessible name",
+          them: (
+            <>
+              required <code>ariaLabel</code> prop — you write the sentence
+            </>
+          ),
+          us: 'role="img" + summary from the data',
+        },
+      ]}
+      note={`TanStack Charts gzip via esbuild bundle of defineChart + lineY + d3 scales through @tanstack/react-charts, react external, minify+gzip ${ts.measuredAt}; status, deps, and markup read from the published ${ts.version} package the same day. microcharts from .size-limit.json (CI).`}
     />
   );
 }

--- a/apps/docs/src/components/ui/copy-agent-setup.tsx
+++ b/apps/docs/src/components/ui/copy-agent-setup.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { Check, Copy } from "lucide-react";
 import { cn } from "@/lib/cn";
+import { CopyLabel } from "@/components/ui/copy";
 import { track } from "@/lib/analytics";
 
 function fetchPrompt() {
@@ -51,7 +52,7 @@ export function CopyAgentSetup({ className }: { className?: string }) {
       onClick={() => void copy()}
     >
       {copied ? <Check className="size-4 pop-in" /> : <Copy className="size-4" />}
-      {copied ? "Copied to clipboard" : "Copy setup prompt"}
+      <CopyLabel copied={copied} idle="Copy setup prompt" done="Copied to clipboard" />
     </button>
   );
 }

--- a/apps/docs/src/components/ui/copy.tsx
+++ b/apps/docs/src/components/ui/copy.tsx
@@ -1,8 +1,36 @@
 "use client";
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import { Check, Copy } from "lucide-react";
 import { cn } from "@/lib/cn";
 import { track, type CopyKind } from "@/lib/analytics";
+
+/**
+ * Idle and copied labels stacked in one grid cell, so the label box is always
+ * the max of the two and confirming a copy never reflows the row. The hidden
+ * half uses `visibility: hidden`, which also keeps it out of the a11y tree.
+ *
+ * Use this anywhere a copy control swaps its text. Icon-only controls need
+ * nothing: `Copy` and `Check` share a box, and `pop-in` animates transform,
+ * opacity, and blur, none of which lay out.
+ */
+export function CopyLabel({
+  idle,
+  done,
+  copied,
+  className,
+}: {
+  idle: ReactNode;
+  done: ReactNode;
+  copied: boolean;
+  className?: string;
+}) {
+  return (
+    <span className={cn("grid place-items-center", className)}>
+      <span className={cn("col-start-1 row-start-1", copied && "invisible")}>{idle}</span>
+      <span className={cn("col-start-1 row-start-1", !copied && "invisible")}>{done}</span>
+    </span>
+  );
+}
 
 // Literal size classes so Tailwind sees them (cnfast doesn't merge conflicts).
 const SIZE = { 7: "size-7", 8: "size-8" } as const;

--- a/apps/docs/src/lib/competitor-facts.test.ts
+++ b/apps/docs/src/lib/competitor-facts.test.ts
@@ -4,6 +4,7 @@ import {
   MUI_X_CHARTS,
   REACT_SPARKLINES_LEGACY,
   RECHARTS,
+  TANSTACK_CHARTS,
   VISX,
 } from "./competitor-facts";
 
@@ -45,6 +46,17 @@ describe("competitor-facts", () => {
     expect(MUI_X_CHARTS.runtimeDeps).toBe(10);
     expect(MUI_X_CHARTS.requiredPeers).toContain("@mui/material");
     expect(MUI_X_CHARTS.license).toBe("MIT");
+  });
+
+  it("pins TanStack Charts as a pre-release proof with a measured chart", () => {
+    expect(TANSTACK_CHARTS.version).toBe("0.0.0");
+    expect(TANSTACK_CHARTS.firstPublish).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(TANSTACK_CHARTS.license).toBe("MIT");
+    expect(TANSTACK_CHARTS.oneChartGzipKb).toBeGreaterThan(10);
+    expect(TANSTACK_CHARTS.oneChartGzipKb).toBeLessThan(50);
+    expect(TANSTACK_CHARTS.runtimeDeps).toBe(4);
+    expect(TANSTACK_CHARTS.reactPeer).toBe("^19.0.0");
+    expect(TANSTACK_CHARTS.measuredAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
   });
 
   it("pins the visx minimal-sparkline measurement", () => {

--- a/apps/docs/src/lib/competitor-facts.ts
+++ b/apps/docs/src/lib/competitor-facts.ts
@@ -77,6 +77,37 @@ export const VISX = {
   measuredAt: "2026-07-23",
 } as const;
 
+/** TanStack Charts — a typed chart grammar over granular d3 modules, published
+ *  as a `0.0.0` proof on 2026-07-29. Sizes measured 2026-07-30 via esbuild
+ *  minify+gzip on one `lineY` chart through `@tanstack/react-charts`, react
+ *  external. Markup facts read from the SSR output of that same bundle. */
+export const TANSTACK_CHARTS = {
+  name: "TanStack Charts",
+  pkg: "@tanstack/charts",
+  reactPkg: "@tanstack/react-charts",
+  version: "0.0.0",
+  firstPublish: "2026-07-29",
+  license: "MIT",
+  /** README, 2026-07-30: not published for production use yet. */
+  status: "unpublished 0.0.0 product proof",
+  /** One line chart (defineChart + lineY + two d3 scales) through the React
+   *  adapter, react/react-dom external, esbuild minify+gzip — 2026-07-30. */
+  oneChartGzipKb: 20.2,
+  /** tanstack.com/charts, 2026-07-30 — their own figure, vanilla renderer. */
+  vendorSvgChartGzipKb: "18.5–19.2",
+  /** d3-array, d3-geo, d3-scale, d3-shape (plus two @types packages). */
+  runtimeDeps: 4,
+  /** The app installs d3 scale/array itself; the docs install line says so. */
+  appInstalls: ["d3-array", "d3-scale"],
+  reactPeer: "^19.0.0",
+  /** SVG element count in the SSR output of that one-line chart, grid and axes
+   *  included — measured 2026-07-30. */
+  ssrSvgNodes: 28,
+  measuredAt: "2026-07-30",
+  docs: "https://tanstack.com/charts",
+  repo: "https://github.com/TanStack/charts",
+} as const;
+
 /** Chart.js + the usual React wrapper. Canvas-first, full chart surfaces. */
 export const CHART_JS = {
   name: "Chart.js",

--- a/apps/docs/src/lib/jsonld.ts
+++ b/apps/docs/src/lib/jsonld.ts
@@ -174,7 +174,7 @@ export const DOCS_INTRO_FAQS = [
   },
   {
     q: "How is microcharts different from Recharts or Chart.js?",
-    a: "Those are full chart libraries for surfaces that are mostly chart. microcharts sits inside an interface — word-sized SVG marks where a full chart library would be too heavy and too loud. One chart per subpath, ~2–7 kB interactive · ~1–4 kB static gzip, no axes or legends, static RSC entries with zero client JavaScript. Not a replacement. See /docs/when-to-use and /docs/full-chart-libraries, or the measured per-library pages: /docs/vs-recharts, /docs/vs-chartjs, /docs/vs-react-sparklines, /docs/vs-mui-x-sparkline, and /docs/vs-visx.",
+    a: "Those are full chart libraries for surfaces that are mostly chart. microcharts sits inside an interface — word-sized SVG marks where a full chart library would be too heavy and too loud. One chart per subpath, ~2–7 kB interactive · ~1–4 kB static gzip, no axes or legends, static RSC entries with zero client JavaScript. Not a replacement. See /docs/when-to-use and /docs/full-chart-libraries, or the measured per-library pages: /docs/vs-recharts, /docs/vs-chartjs, /docs/vs-react-sparklines, /docs/vs-mui-x-sparkline, /docs/vs-visx, and /docs/vs-tanstack-charts.",
   },
   {
     q: "Are microcharts accessible?",

--- a/apps/docs/src/lib/site.ts
+++ b/apps/docs/src/lib/site.ts
@@ -11,6 +11,9 @@ export const SITE = {
   pkg: "@microcharts/react",
   repo: "https://github.com/ganapativs/microcharts",
   npm: "https://www.npmjs.com/package/@microcharts/react",
+  /** Third-party read on the published package — dependency count and the size
+   *  of the root entry, measured by someone other than us. */
+  bundlephobia: "https://bundlephobia.com/package/@microcharts/react",
   author: "Ganapati V S",
   authorUrl: "https://meetguns.com",
   authorX: "https://x.com/ganapativs",


### PR DESCRIPTION
## Summary
- Add `/docs/vs-tanstack-charts` with pinned `@tanstack/react-charts@0.0.0` size/SSR facts and cross-links from choose/compare pages.
- Wire `TANSTACK_CHARTS` competitor facts + MDX helpers so prose never hard-codes competitor numbers.
- Move glass-rail scrolled state to the layout boot script (`:root[data-rail-scrolled]`) so restored scroll paints without a post-hydration flash; share `CopyLabel` across copy buttons.

## Test plan
- [ ] Open `/docs/vs-tanstack-charts` and confirm table + inline fact components render measured numbers
- [ ] Confirm nav links from index, when-to-use, full-chart-libraries, and vs-visx resolve
- [ ] Hard-reload mid-page and confirm glass rail background is present on first paint
- [ ] Smoke-test copy buttons (idle → Copied label)
- [ ] Run docs competitor-facts tests if touching facts again


Made with [Cursor](https://cursor.com)