### PR TITLE
chore: add react changeset for data-change glide

### DIFF
--- a/.changeset/data-change-glide.md
+++ b/.changeset/data-change-glide.md
@@ -1,0 +1,15 @@
+---
+"@microcharts/react": minor
+---
+
+**Value marks glide when the data changes.** Role-bearing geometry (`data-mc-ink`, `data-mc-cat`, `data-mc-cone`) now
+transitions on its geometry attributes, so a re-render travels to the new reading instead of cutting. Scrub focus marks
+reuse DOM nodes and travel on `transform`; discrete selection rings still snap. Entrance voice labels wait for the story
+front before they speak, so an endpoint caption lands with the stroke that names it.
+
+**Ink roles reach more marks.** Charts that painted value geometry with bare `fill`/`stroke` attributes now carry a role
+(and move the paint to an inline style when the role would otherwise change colour or opacity). Thermometer mercury uses
+`accent` rather than the tube's translucent `fill` role, so the column is opaque again. Interactive thermometer chips
+print `value / target` when a target is set.
+
+**Motion engine.** Endpoint labels clamp to the story end so waiting on the front never lengthens the entrance.

--- a/.changeset/mcp-data-change-glide.md
+++ b/.changeset/mcp-data-change-glide.md
@@ -2,4 +2,5 @@
 "@microcharts/mcp": patch
 ---
 
-Refresh the embedded styles after the data-change glide CSS landed.
+Refresh the embedded `styles.css` snapshot so the published server matches the data-change glide CSS from
+`@microcharts/react`.


### PR DESCRIPTION
## Summary
- PR #96 landed library motion/ink-role work but only a `@microcharts/mcp` patch changeset, so Version Packages (#97) would publish MCP 0.1.8 alone.
- Add an `@microcharts/react` **minor** changeset for data-change glide, scrub travel, ink-role coverage, and thermometer fixes.
- Clarify the existing MCP changeset so it re-ships the embedded styles with that release.

## Test plan
- [ ] After merge, confirm Changesets updates #97 to include `@microcharts/react@0.12.0` (or next minor) plus `@microcharts/mcp@0.1.8`
- [ ] Do not merge #97 until that update lands


Made with [Cursor](https://cursor.com)