### PR TITLE
fix: sync docs/MCP after 0.12.0 release

### DIFF
--- a/.changeset/mcp-catalog-0-12.md
+++ b/.changeset/mcp-catalog-0-12.md
@@ -1,0 +1,6 @@
+---
+"@microcharts/mcp": patch
+---
+
+Point the embedded catalog's `library` field at `@microcharts/react@0.12.0` (the Version Packages bump left the
+generated snapshot on 0.11.0).

--- a/apps/docs/src/lib/release-sizes.ts
+++ b/apps/docs/src/lib/release-sizes.ts
@@ -19,7 +19,7 @@ export type ReleaseSize = {
 };
 
 /** The release the working tree is on; its numbers come from live data. */
-export const CURRENT_VERSION = "0.11.0";
+export const CURRENT_VERSION = "0.12.0";
 
 const HISTORY: ReleaseSize[] = [
   { version: "0.4.0", median: 3.57, max: 4.97 },
@@ -29,6 +29,8 @@ const HISTORY: ReleaseSize[] = [
   { version: "0.8.0", median: 5.03, max: 6.64 },
   { version: "0.9.0", median: 5.04, max: 6.64 },
   { version: "0.10.0", median: 5.07, max: 6.75 },
+  // Frozen from the `@microcharts/react@0.11.0` tag's chart-sizes.json.
+  { version: "0.11.0", median: 5.24, max: 6.94 },
 ];
 
 export const RELEASE_SIZES: readonly ReleaseSize[] = [

--- a/packages/mcp/src/catalog.generated.json
+++ b/packages/mcp/src/catalog.generated.json
@@ -1,5 +1,5 @@
 {
-  "library": "0.11.0",
+  "library": "0.12.0",
   "sharedProps": [
     {
       "name": "data",


### PR DESCRIPTION
## Summary
- Bump docs `CURRENT_VERSION` to `0.12.0` and freeze `0.11.0` interactive size history (median 5.24 / max 6.94).
- Regenerate MCP `catalog.generated.json` so `library` points at `@microcharts/react@0.12.0`.
- Add MCP patch changeset so the next Version Packages publishes `@microcharts/mcp@0.1.9` with the corrected catalog pin.

## Publishing
- **No re-publish of `@microcharts/react@0.12.0`** — already on npm from #97.
- **MCP needs one more patch publish** after this merges (catalog still shipped with `library: "0.11.0"` in 0.1.8). Merge this PR, then merge the Version Packages PR for `@microcharts/mcp@0.1.9`.

## Test plan
- [ ] `quality` / `gen:check` green
- [ ] `docs` / `release-sizes.test.ts` green
- [ ] Confirm Version Packages opens for MCP patch only

Made with [Cursor](https://cursor.com)