### PR TITLE
chore: bump examples to @microcharts/react 0.18.1

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # microcharts examples — visual test suite
 
-Seven **independent** real-world apps that each install `@microcharts/react` **from npm** (`0.18.0`) and integrate it
+Seven **independent** real-world apps that each install `@microcharts/react` **from npm** (`0.18.1`) and integrate it
 via the [quickstart agent prompt](https://microcharts.dev/docs/quickstart). They are a **manual** visual harness: before
 shipping a major change, bump the dependency to the target version (or RC), reinstall, launch all seven, and eyeball
 that rendering, theming, interactivity, and the RSC/static path still behave — then take it live.
@@ -31,7 +31,7 @@ Together they cover: **all 106 chart types**, static vs interactive entries, all
 `selectedIndex`), **`readout={false}` + `datum.formatted`**, **`SparkGroup`**, **`defineTheme` + `MicroProvider`**, and
 responsive reflow (tested at 375 / 768 / 1280). Each app is a multi-section product with light+dark support.
 
-## Feature matrix (0.18.0 coverage)
+## Feature matrix (0.18.1 coverage)
 
 | Surface                         | pulse                        | ledger | vitals  | shipyard | dispatch             | atlas     | cortex |
 | ------------------------------- | ---------------------------- | ------ | ------- | -------- | -------------------- | --------- | ------ |
@@ -53,13 +53,13 @@ responsive reflow (tested at 375 / 768 / 1280). Each app is a multi-section prod
 
 ```bash
 cd examples/<app>
-npm install                                        # resolves @microcharts/react@0.18.0 from npm
+npm install                                        # resolves @microcharts/react@0.18.1 from npm
 npm run dev                                        # fixed port — see table
 ```
 
 Or launch any of them from the editor via the `ex-*` entries in `.claude/launch.json`.
 
-To point the suite at a newer release or RC, bump `@microcharts/react` in each app's `package.json` (e.g. `"0.18.1"` or
+To point the suite at a newer release or RC, bump `@microcharts/react` in each app's `package.json` (e.g. `"0.18.2"` or
 `"0.13.0-rc.1"`) and re-run `npm install`.
 
 ## Deploy (Cloudflare Pages — one URL per app)

--- a/examples/atlas-realestate/package.json
+++ b/examples/atlas-realestate/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview --port 4006 --strictPort"
   },
   "dependencies": {
-    "@microcharts/react": "^0.18.0",
+    "@microcharts/react": "^0.18.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/examples/cortex-ai/package.json
+++ b/examples/cortex-ai/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview --port 4007 --strictPort"
   },
   "dependencies": {
-    "@microcharts/react": "^0.18.0",
+    "@microcharts/react": "^0.18.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/examples/dispatch-editorial/package.json
+++ b/examples/dispatch-editorial/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview --port 4005 --strictPort"
   },
   "dependencies": {
-    "@microcharts/react": "^0.18.0",
+    "@microcharts/react": "^0.18.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/examples/ledger-finance/package.json
+++ b/examples/ledger-finance/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview --port 4002 --strictPort"
   },
   "dependencies": {
-    "@microcharts/react": "^0.18.0",
+    "@microcharts/react": "^0.18.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/examples/pulse-analytics/package.json
+++ b/examples/pulse-analytics/package.json
@@ -7,7 +7,7 @@
     "start": "next start -p 4001"
   },
   "dependencies": {
-    "@microcharts/react": "^0.18.0",
+    "@microcharts/react": "^0.18.1",
     "next": "^15.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/examples/shipyard-devops/package.json
+++ b/examples/shipyard-devops/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview --port 4004 --strictPort"
   },
   "dependencies": {
-    "@microcharts/react": "^0.18.0",
+    "@microcharts/react": "^0.18.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/examples/vitals-health/package.json
+++ b/examples/vitals-health/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview --port 4003 --strictPort"
   },
   "dependencies": {
-    "@microcharts/react": "^0.18.0",
+    "@microcharts/react": "^0.18.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },


### PR DESCRIPTION
## Summary
- Bump all 7 example apps from `@microcharts/react@^0.18.0` to `^0.18.1` and refresh README version refs.
- Redeployed every app to Cloudflare Pages on 0.18.1.

## Test plan
- [ ] Confirm example package.json pins are `^0.18.1`
- [ ] Spot-check production URLs still load
- [ ] CI green


Made with [Cursor](https://cursor.com)