### PR TITLE
feat(docs): make the site legible to agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,8 +201,21 @@ Independent pnpm workspace. **Fumadocs + Next static export (`output: 'export'`)
 consumes the built library (`@microcharts/react` → `dist/`), so **build the library before building or developing the
 docs** (`pnpm build:site` does both). The site origin is swappable via `NEXT_PUBLIC_SITE_URL`. Every doc example must be
 a real, compiled component (docs-as-tests): `describeSeries` output shown in docs must be the actual generated string.
-The docs also publish machine surfaces — `/llms.txt`, `/llms-full.txt`, and `/catalog.json` — kept in sync with
+The docs also publish machine surfaces — `/llms.txt`, `/llms-full.txt`, `/catalog.json`, `/openapi.json`,
+`/api/charts.json` + `/api/charts/<slug>.json`, and `/.well-known/mcp/server-card.json` — kept in sync with
 `package.json#exports` and gated by tests.
+
+**The agent surface is four rules, and all four are load-bearing.** (1) **Every page route has a Markdown twin**:
+`/docs/*` mirrors come from `scripts/gen-md.ts`, the React routes (`/`, `/charts`, `/examples`, `/brand`, `/contact`,
+`/privacy`) from `lib/page-mirrors.ts` + `lib/trust-pages.ts` via `<route>.md` route handlers. Adding a page route means
+adding its twin, or `Accept: text/markdown` there silently falls back to HTML. (2) **`worker.ts` is the only place that
+touches the network**; every decision it makes is a pure function in `lib/content-negotiation.ts` (negotiation, 406,
+error format) or `lib/agent-errors.ts` (RFC 9457 problem details, the Markdown recovery note, closest-match
+suggestions), unit-tested without a network. (3) **`/openapi.json` is derived from the registry**, so it cannot describe
+a chart the site does not serve — and `agent-surface.test.ts` re-checks every documented path against a real `out/`,
+which means it only runs after `pnpm build` (like `metadata.test.ts`). (4) **Errors answer in the caller's format**:
+problem+json on `/api/*` and `.json`, Markdown for any client that never names `text/html`, the designed HTML page for
+browsers. A 404 always beats a 406 when both apply — "no such page" is the more useful answer.
 
 ## Writing voice (every prose surface: docs, README, site copy, error messages, PR/issue text)
 

--- a/apps/docs/content/docs/ai.mdx
+++ b/apps/docs/content/docs/ai.mdx
@@ -222,9 +222,26 @@ These routes are generated from the same source as the package, so an agent read
 <SurfaceCards />
 
 The `.md` mirrors are static files — `/docs/ai` has a sibling `/docs/ai.md` — so they resolve on any host with no
-runtime, rewrite, or middleware. This site also deploys behind a small Cloudflare Worker that runs on `/docs/*` only:
-send `Accept: text/markdown` and the same doc URL returns the mirror inline, with `Vary: Accept` on both the Markdown
-and the HTML response. Appending `.md` always works; the negotiation is a convenience on top.
+runtime, rewrite, or middleware. Every page has one, including `/`, `/charts` and `/examples`. This site also deploys
+behind a small Cloudflare Worker: send `Accept: text/markdown` to any page URL and it returns that page's mirror inline,
+with `Vary: Accept, Accept-Encoding` on both the Markdown and the HTML response. Appending `.md` always works; the
+negotiation is a convenience on top.
+
+### Errors
+
+A wrong URL is a dead end for a script unless the response says where to go instead. Every 404, 405 and 406 answers in
+the caller's own format:
+
+- `/api/*` and any `.json` path get [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) problem details: `type`, `title`,
+  `status`, `detail` and `instance`, plus a stable `code`, an `error` object, ordered `hints`, and `links` to this
+  site's entry points.
+- Any other scripted client — anything that doesn't name `text/html`, which covers `curl` and most agents — gets a short
+  Markdown note carrying those same links, plus the closest matching real URLs read from the sitemap.
+  [`/404.md`](/404.md) is the static version of it.
+- Browsers keep the designed 404 page.
+
+A 405 carries an `Allow` header, because everything here is read-only. A 406 arrives only when a request accepts neither
+HTML nor Markdown.
 
 `/llms.txt` points at one more surface the cards don't: [`/agent-setup.md`](/agent-setup.md), the paste-and-run setup
 prompt for a coding agent, extracted from the [Quickstart](/docs/quickstart) so the two can't drift. Or skip the URL

--- a/apps/docs/src/app/(home)/brand/page.tsx
+++ b/apps/docs/src/app/(home)/brand/page.tsx
@@ -16,6 +16,7 @@ export const metadata: Metadata = docsMeta({
   description:
     "The microcharts mark, lockup, wordmark, colors, and type, with clear-space rules, usage guidance, and downloadable SVG and PNG assets.",
   path: "/brand",
+  markdown: "/brand.md",
 });
 
 export default function BrandPage() {

--- a/apps/docs/src/app/(home)/charts/page.tsx
+++ b/apps/docs/src/app/(home)/charts/page.tsx
@@ -7,6 +7,7 @@ export const metadata: Metadata = docsMeta({
   title: "Micro Charts for React — Full Catalog",
   description: chartsIndexDescription(),
   path: "/charts",
+  markdown: "/charts.md",
   keywords: [
     "micro charts",
     "micro charts react",

--- a/apps/docs/src/app/(home)/contact/page.tsx
+++ b/apps/docs/src/app/(home)/contact/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import { ProseDoc } from "@/components/prose-doc";
+import { docsMeta } from "@/lib/metadata";
+import { CONTACT_PAGE } from "@/lib/trust-pages";
+
+export const metadata: Metadata = docsMeta({
+  title: CONTACT_PAGE.title,
+  description: CONTACT_PAGE.description,
+  path: "/contact",
+  markdown: "/contact.md",
+});
+
+export default function ContactPage() {
+  return <ProseDoc page={CONTACT_PAGE} />;
+}

--- a/apps/docs/src/app/(home)/examples/page.tsx
+++ b/apps/docs/src/app/(home)/examples/page.tsx
@@ -10,6 +10,7 @@ export const metadata: Metadata = docsMeta({
   description:
     "Seven production-grade apps built with @microcharts/react from npm — a trading terminal, a print magazine, an eval console — exercising every chart type in the catalog.",
   path: "/examples",
+  markdown: "/examples.md",
   keywords: [
     "microcharts examples",
     "react chart examples",

--- a/apps/docs/src/app/(home)/privacy/page.tsx
+++ b/apps/docs/src/app/(home)/privacy/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import { ProseDoc } from "@/components/prose-doc";
+import { docsMeta } from "@/lib/metadata";
+import { PRIVACY_PAGE } from "@/lib/trust-pages";
+
+export const metadata: Metadata = docsMeta({
+  title: PRIVACY_PAGE.title,
+  description: PRIVACY_PAGE.description,
+  path: "/privacy",
+  markdown: "/privacy.md",
+});
+
+export default function PrivacyPage() {
+  return <ProseDoc page={PRIVACY_PAGE} />;
+}

--- a/apps/docs/src/app/.well-known/mcp/server-card.json/route.ts
+++ b/apps/docs/src/app/.well-known/mcp/server-card.json/route.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+export const revalidate = false;
+export const dynamic = "force-static";
+
+/**
+ * The MCP server card, at the well-known path agents probe for it.
+ *
+ * The bytes are `packages/mcp/server.json` verbatim — the same registry
+ * manifest `scripts/sync-server-json.mjs` generates and the release workflow
+ * publishes, read at build time rather than copied, so the version here is
+ * always the version that shipped.
+ *
+ * It advertises a stdio server: a client spawns `npx -y @microcharts/mcp`
+ * locally. There is no HTTP endpoint to hand out, and this card does not claim
+ * one.
+ */
+export function GET() {
+  const card = readFileSync(resolve(process.cwd(), "../../packages/mcp/server.json"), "utf8");
+  return new Response(card, {
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+  });
+}

--- a/apps/docs/src/app/404.md/route.ts
+++ b/apps/docs/src/app/404.md/route.ts
@@ -1,0 +1,18 @@
+import { notFoundMarkdown } from "@/lib/page-mirrors";
+
+export const revalidate = false;
+export const dynamic = "force-static";
+
+/**
+ * The 404 recovery note as a static file.
+ *
+ * The Worker renders this same body, with the missing path and closest-match
+ * URLs filled in, for any 404 a non-browser asks for. This file is the
+ * host-agnostic version: on a plain CDN with no Worker, an agent that gets the
+ * HTML 404 page still has a documented URL to read instead.
+ */
+export function GET() {
+  return new Response(notFoundMarkdown(), {
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+  });
+}

--- a/apps/docs/src/app/api/charts.json/route.ts
+++ b/apps/docs/src/app/api/charts.json/route.ts
@@ -1,0 +1,11 @@
+import { buildChartIndex } from "@/lib/api-charts";
+
+export const revalidate = false;
+export const dynamic = "force-static";
+
+/** Index of every chart type, with the URL that expands each one. */
+export function GET() {
+  return new Response(`${JSON.stringify(buildChartIndex(), null, 2)}\n`, {
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+  });
+}

--- a/apps/docs/src/app/api/charts/[...slug]/route.ts
+++ b/apps/docs/src/app/api/charts/[...slug]/route.ts
@@ -1,0 +1,30 @@
+import { notFound } from "next/navigation";
+import { buildChartDocument, chartSlugs } from "@/lib/api-charts";
+
+export const revalidate = false;
+export const dynamic = "force-static";
+
+/**
+ * One chart's full API surface as JSON: the catalog entry, plus the shared
+ * props and reading instructions it has to be combined with.
+ *
+ * The `.json` suffix rides in the catch-all param — the same trick the OG image
+ * and `llms.mdx` routes use — so the export writes `out/api/charts/<slug>.json`
+ * beside `out/api/charts.json` instead of colliding with it.
+ */
+export async function GET(_req: Request, { params }: RouteContext<"/api/charts/[...slug]">) {
+  const { slug } = await params;
+  const name = slug?.join("/") ?? "";
+  const document = name.endsWith(".json")
+    ? buildChartDocument(name.slice(0, -".json".length))
+    : null;
+  if (!document) notFound();
+
+  return new Response(`${JSON.stringify(document, null, 2)}\n`, {
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+  });
+}
+
+export function generateStaticParams() {
+  return chartSlugs().map((slug) => ({ slug: [`${slug}.json`] }));
+}

--- a/apps/docs/src/app/brand.md/route.ts
+++ b/apps/docs/src/app/brand.md/route.ts
@@ -1,0 +1,11 @@
+import { brandMarkdown } from "@/lib/page-mirrors";
+
+export const revalidate = false;
+export const dynamic = "force-static";
+
+/** The brand page's Markdown twin. Also served from `/brand` on `Accept: text/markdown`. */
+export function GET() {
+  return new Response(brandMarkdown(), {
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+  });
+}

--- a/apps/docs/src/app/charts.md/route.ts
+++ b/apps/docs/src/app/charts.md/route.ts
@@ -1,0 +1,11 @@
+import { chartsMarkdown } from "@/lib/page-mirrors";
+
+export const revalidate = false;
+export const dynamic = "force-static";
+
+/** The chart index's Markdown twin. Also served from `/charts` on `Accept: text/markdown`. */
+export function GET() {
+  return new Response(chartsMarkdown(), {
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+  });
+}

--- a/apps/docs/src/app/contact.md/route.ts
+++ b/apps/docs/src/app/contact.md/route.ts
@@ -1,0 +1,12 @@
+import { abs } from "@/lib/site";
+import { CONTACT_PAGE, trustPageMarkdown } from "@/lib/trust-pages";
+
+export const revalidate = false;
+export const dynamic = "force-static";
+
+/** `/contact`'s Markdown twin. Also served from `/contact` on `Accept: text/markdown`. */
+export function GET() {
+  return new Response(trustPageMarkdown(CONTACT_PAGE, abs("/contact")), {
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+  });
+}

--- a/apps/docs/src/app/examples.md/route.ts
+++ b/apps/docs/src/app/examples.md/route.ts
@@ -1,0 +1,11 @@
+import { examplesMarkdown } from "@/lib/page-mirrors";
+
+export const revalidate = false;
+export const dynamic = "force-static";
+
+/** The examples page's Markdown twin. Also served from `/examples` on `Accept: text/markdown`. */
+export function GET() {
+  return new Response(examplesMarkdown(), {
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+  });
+}

--- a/apps/docs/src/app/index.md/route.ts
+++ b/apps/docs/src/app/index.md/route.ts
@@ -1,0 +1,11 @@
+import { homeMarkdown } from "@/lib/page-mirrors";
+
+export const revalidate = false;
+export const dynamic = "force-static";
+
+/** The home page's Markdown twin. Also served from `/` on `Accept: text/markdown`. */
+export function GET() {
+  return new Response(homeMarkdown(), {
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+  });
+}

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -103,6 +103,10 @@ export const metadata: Metadata = {
     types: {
       "application/atom+xml": [{ url: "/rss.xml", title: `${SITE.name} releases` }],
       "text/plain": [{ url: "/llms.txt", title: `${SITE.name} for LLMs` }],
+      // The home page's Markdown twin, which `/` also serves on
+      // `Accept: text/markdown`. Every other route sets its own alternates
+      // through `docsMeta`, so this advertisement stays on the page it names.
+      "text/markdown": [{ url: "/index.md", title: `${SITE.name} home as Markdown` }],
     },
   },
   robots: {

--- a/apps/docs/src/app/llms.txt/route.ts
+++ b/apps/docs/src/app/llms.txt/route.ts
@@ -81,7 +81,18 @@ ${chartLines}
 - MCP server \`@microcharts/mcp\` (\`npx -y @microcharts/mcp\`, stdio): tools \`find_microchart\`, \`get_microchart\`, \`render_microchart\`; resources \`microcharts://catalog\`, \`microcharts://agent-setup\`. Docs: ${mdUrl(["mcp"])}. Prefer calling it over re-reading the catalog when your client can spawn an MCP server.
 - [Chart catalog JSON](${abs("/catalog.json")}): names, import paths, props, data shapes.
 - [Catalog JSON Schema](${abs("/catalog.schema.json")}): the contract the catalog validates against.
+- [OpenAPI description](${abs("/openapi.json")}): every endpoint on this site, with an operation id, typed parameters and a response schema. Load this first if you call the site programmatically.
+- [Chart index JSON](${abs("/api/charts.json")}): one line per chart, each linking to \`${SITE.url}/api/charts/<slug>.json\` — that chart's full prop surface in ~8 kB instead of the catalog's 290 kB.
+- [MCP server card](${abs("/.well-known/mcp/server-card.json")}): the \`server.json\` registry manifest for \`@microcharts/mcp\`, served at the path MCP's draft server-card proposal uses.
 - [Full docs context](${abs("/llms-full.txt")}): complete generated docs text.
+- [Home page as Markdown](${abs("/index.md")}): every page has a twin like this one. Send \`Accept: text/markdown\` to any page URL, or add \`.md\` to it; responses carry \`Vary: Accept, Accept-Encoding\`.
+- [404 recovery note](${abs("/404.md")}): errors are machine-readable — 404, 405 and 406 return RFC 9457 problem details on \`/api/*\` and \`.json\` paths, and a short Markdown note with recovery links everywhere else.
+
+## Project
+
+- [Contact](${abs("/contact.md")}): where to file a bug, propose a chart type, or report a security issue.
+- [Privacy](${abs("/privacy.md")}): what this site collects, stores, and sends on.
+- [Source](${SITE.repo}): MIT licensed. Issues and proposals go here.
 
 ## Does Not Support
 

--- a/apps/docs/src/app/not-found.tsx
+++ b/apps/docs/src/app/not-found.tsx
@@ -6,6 +6,27 @@ export const metadata: Metadata = {
   robots: { index: false },
 };
 
+/**
+ * The HTML 404.
+ *
+ * Browsers land here. Every other client gets the same information as Markdown
+ * or RFC 9457 problem details, rendered at the edge by `worker.ts` and
+ * published as a static file at `/404.md`. The machine-surface row below is
+ * what those bodies link to, so a reader and a script recover the same way.
+ */
+const RECOVERY = [
+  { href: "/docs", label: "Documentation" },
+  { href: "/charts", label: "All charts" },
+  { href: "/examples", label: "Examples" },
+];
+
+const MACHINE = [
+  { href: "/llms.txt", label: "/llms.txt" },
+  { href: "/sitemap.xml", label: "/sitemap.xml" },
+  { href: "/catalog.json", label: "/catalog.json" },
+  { href: "/openapi.json", label: "/openapi.json" },
+];
+
 export default function NotFound() {
   return (
     <main
@@ -19,17 +40,44 @@ export default function NotFound() {
       <p className="max-w-md text-fd-muted-foreground">
         The chart you&apos;re looking for may have moved. Browse the charts, or start from the docs.
       </p>
-      <nav className="flex flex-wrap items-center justify-center gap-4 text-sm font-medium">
+      <nav
+        aria-label="Recover"
+        className="flex flex-wrap items-center justify-center gap-4 text-sm font-medium"
+      >
         <Link href="/" className="underline underline-offset-4 hover:text-fd-primary">
           Home
         </Link>
-        <Link href="/docs" className="underline underline-offset-4 hover:text-fd-primary">
-          Documentation
-        </Link>
-        <Link href="/charts" className="underline underline-offset-4 hover:text-fd-primary">
-          Charts
-        </Link>
+        {RECOVERY.map((item) => (
+          <Link
+            key={item.href}
+            href={item.href}
+            className="underline underline-offset-4 hover:text-fd-primary"
+          >
+            {item.label}
+          </Link>
+        ))}
       </nav>
+      <nav
+        aria-label="Machine-readable index"
+        className="flex max-w-md flex-wrap items-center justify-center gap-x-4 gap-y-2 font-mono text-xs text-fd-muted-foreground"
+      >
+        {MACHINE.map((item) => (
+          <a
+            key={item.href}
+            href={item.href}
+            className="underline underline-offset-4 hover:text-fd-primary"
+          >
+            {item.label}
+          </a>
+        ))}
+      </nav>
+      <p className="max-w-md font-mono text-xs text-fd-muted-foreground">
+        Reading this with a script?{" "}
+        <a href="/404.md" className="underline underline-offset-4">
+          /404.md
+        </a>{" "}
+        is this page as Markdown, and any page here answers <code>Accept: text/markdown</code>.
+      </p>
     </main>
   );
 }

--- a/apps/docs/src/app/openapi.json/route.ts
+++ b/apps/docs/src/app/openapi.json/route.ts
@@ -1,0 +1,11 @@
+import { buildOpenApi } from "@/lib/openapi";
+
+export const revalidate = false;
+export const dynamic = "force-static";
+
+/** OpenAPI 3.1 description of this site's machine surface. See `lib/openapi.ts`. */
+export function GET() {
+  return new Response(`${JSON.stringify(buildOpenApi(), null, 2)}\n`, {
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+  });
+}

--- a/apps/docs/src/app/privacy.md/route.ts
+++ b/apps/docs/src/app/privacy.md/route.ts
@@ -1,0 +1,12 @@
+import { abs } from "@/lib/site";
+import { PRIVACY_PAGE, trustPageMarkdown } from "@/lib/trust-pages";
+
+export const revalidate = false;
+export const dynamic = "force-static";
+
+/** `/privacy`'s Markdown twin. Also served from `/privacy` on `Accept: text/markdown`. */
+export function GET() {
+  return new Response(trustPageMarkdown(PRIVACY_PAGE, abs("/privacy")), {
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+  });
+}

--- a/apps/docs/src/app/sitemap.ts
+++ b/apps/docs/src/app/sitemap.ts
@@ -60,6 +60,18 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "monthly" as const,
       src: `${HOME}/brand/page.tsx`,
     },
+    {
+      path: "/contact",
+      priority: 0.4,
+      changeFrequency: "yearly" as const,
+      src: `${HOME}/contact/page.tsx`,
+    },
+    {
+      path: "/privacy",
+      priority: 0.4,
+      changeFrequency: "yearly" as const,
+      src: `${HOME}/privacy/page.tsx`,
+    },
   ].map((r) => ({
     url: loc(r.path),
     lastModified: fileLastModified(r.src),

--- a/apps/docs/src/components/prose-doc.tsx
+++ b/apps/docs/src/components/prose-doc.tsx
@@ -1,0 +1,115 @@
+import type { ReactNode } from "react";
+import Link from "next/link";
+import type { TrustPage } from "@/lib/trust-pages";
+import { SITE } from "@/lib/site";
+
+/**
+ * Renders a `TrustPage` — `/contact` and `/privacy`.
+ *
+ * The copy lives in `lib/trust-pages.ts` because the Markdown twins serialize
+ * from the same structures. That means the prose arrives as text with a small
+ * Markdown subset in it, and this file is the renderer for that subset:
+ * `[label](href)`, `` `code` ``, and `**bold**`. Nothing else is supported, and
+ * anything unmatched renders as the literal text it is.
+ */
+
+/** One `[label](href)`, `` `code` `` or `**bold**` run, and the text between. */
+const INLINE = /\[([^\]]+)\]\(([^)]+)\)|`([^`]+)`|\*\*([^*]+)\*\*/g;
+
+/** A link to this site renders as a client-side navigation; anything else opens out. */
+function InlineLink({ href, children }: { href: string; children: ReactNode }) {
+  const internal = href.startsWith("/")
+    ? href
+    : href.startsWith(SITE.url)
+      ? href.slice(SITE.url.length) || "/"
+      : null;
+
+  if (internal) {
+    return (
+      <Link prefetch={false} href={internal} className="ulink">
+        {children}
+      </Link>
+    );
+  }
+  return (
+    <a href={href} target="_blank" rel="noreferrer noopener" className="ulink">
+      {children}
+    </a>
+  );
+}
+
+export function renderInline(text: string): ReactNode[] {
+  const nodes: ReactNode[] = [];
+  let last = 0;
+  let key = 0;
+
+  for (const match of text.matchAll(INLINE)) {
+    const index = match.index;
+    if (index > last) nodes.push(text.slice(last, index));
+
+    const [raw, label, href, code, bold] = match;
+    if (label && href) {
+      nodes.push(
+        <InlineLink key={(key += 1)} href={href}>
+          {label}
+        </InlineLink>,
+      );
+    } else if (code) {
+      nodes.push(
+        <code key={(key += 1)} className="font-mono text-[0.86em] text-[var(--ink)]">
+          {code}
+        </code>,
+      );
+    } else if (bold) {
+      nodes.push(<strong key={(key += 1)}>{bold}</strong>);
+    }
+    last = index + raw.length;
+  }
+
+  if (last < text.length) nodes.push(text.slice(last));
+  return nodes;
+}
+
+export function ProseDoc({ page }: { page: TrustPage }) {
+  return (
+    <div className="act act-open">
+      <div className="shell grid gap-10">
+        <header className="grid gap-4">
+          <h1 className="display-2" style={{ maxWidth: "var(--m-head)" }}>
+            {page.title}
+          </h1>
+          <p className="lead u-lede" style={{ maxWidth: "var(--m-lead)" }}>
+            {page.intro}
+          </p>
+        </header>
+
+        {page.sections.map((section) => (
+          <section key={section.id} aria-labelledby={section.id} className="grid gap-3">
+            <h2 id={section.id} className="h3" style={{ maxWidth: "var(--m-head)" }}>
+              {section.heading}
+            </h2>
+            {section.blocks.map((block) =>
+              "p" in block ? (
+                <p key={block.p} className="prose" style={{ maxWidth: "var(--m-prose)" }}>
+                  {renderInline(block.p)}
+                </p>
+              ) : (
+                <ul
+                  key={block.list[0]}
+                  className="grid list-disc gap-2 pl-5"
+                  style={{ maxWidth: "var(--m-prose)" }}
+                >
+                  {block.list.map((item) => (
+                    <li key={item} className="prose">
+                      {renderInline(item)}
+                    </li>
+                  ))}
+                </ul>
+              ),
+            )}
+          </section>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/docs/src/components/site-footer.tsx
+++ b/apps/docs/src/components/site-footer.tsx
@@ -85,6 +85,7 @@ const cols: {
     links: [
       { href: "/llms.txt", label: "llms.txt", external: true },
       { href: "/catalog.json", label: "catalog.json", external: true },
+      { href: "/openapi.json", label: "openapi.json", external: true },
       { href: "/docs/ai", label: "AI-native" },
     ],
   },
@@ -140,15 +141,24 @@ export function SiteFooter() {
                 /brand is permission to use the name and the mark. Same category,
                 same line, in the column whose subject is the identity it
                 documents. */}
-            <div className="mono-label mt-4 flex items-center gap-1.5">
+            <div className="mono-label mt-4 flex flex-wrap items-center gap-1.5">
               <span>Zero deps · MIT ·</span>
-              <Link
-                prefetch={false}
-                href="/brand"
-                className="underline decoration-fd-border underline-offset-[3px] transition-colors hover:text-fd-foreground hover:decoration-fd-muted-foreground"
-              >
-                Brand
-              </Link>
+              {[
+                { href: "/brand", label: "Brand" },
+                { href: "/contact", label: "Contact" },
+                { href: "/privacy", label: "Privacy" },
+              ].map((item, i) => (
+                <span key={item.href} className="flex items-center gap-1.5">
+                  <Link
+                    prefetch={false}
+                    href={item.href}
+                    className="underline decoration-fd-border underline-offset-[3px] transition-colors hover:text-fd-foreground hover:decoration-fd-muted-foreground"
+                  >
+                    {item.label}
+                  </Link>
+                  {i < 2 && <span aria-hidden>·</span>}
+                </span>
+              ))}
             </div>
             {/* The byline belongs to the brand block, not to the bar across the
                 bottom. Down there it was the only thing on the left of a rule the

--- a/apps/docs/src/lib/agent-errors.test.ts
+++ b/apps/docs/src/lib/agent-errors.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import {
+  entryPoints,
+  methodNotAllowed,
+  notAcceptable,
+  notFound,
+  problemJson,
+  problemMarkdown,
+  suggestRoutes,
+} from "./agent-errors.ts";
+
+const ORIGIN = "https://microcharts.dev";
+
+describe("problem builders", () => {
+  it("names the path that missed, and offers a way out", () => {
+    const problem = notFound({ path: "/sparklines", origin: ORIGIN });
+    expect(problem.status).toBe(404);
+    expect(problem.code).toBe("not_found");
+    expect(problem.detail).toContain("/sparklines");
+    expect(problem.hints.length).toBeGreaterThan(0);
+    expect(problem.links.length).toBeGreaterThan(0);
+  });
+
+  it("falls back to generic wording for the static twin", () => {
+    const problem = notFound({ path: null, origin: ORIGIN });
+    expect(problem.detail).toContain("the URL you requested");
+    expect(problem.detail).not.toContain("null");
+  });
+
+  it("carries the allowed methods on a 405", () => {
+    const problem = methodNotAllowed({ path: "/api/search", origin: ORIGIN, method: "POST" });
+    expect(problem.status).toBe(405);
+    expect(problem.allow).toEqual(["GET", "HEAD"]);
+    expect(problem.detail).toContain("POST");
+  });
+
+  it("quotes the offending Accept on a 406", () => {
+    const problem = notAcceptable({
+      path: "/charts/core",
+      origin: ORIGIN,
+      accept: "text/markdown",
+    });
+    expect(problem.status).toBe(406);
+    expect(problem.detail).toContain("text/markdown");
+  });
+
+  it("points every entry point at the requesting origin", () => {
+    const preview = "https://preview.example.dev";
+    for (const link of entryPoints(preview)) expect(link.href.startsWith(preview)).toBe(true);
+  });
+
+  it("lists the site's machine surfaces", () => {
+    const hrefs = entryPoints(ORIGIN).map((l) => l.href);
+    expect(hrefs).toContain(`${ORIGIN}/llms.txt`);
+    expect(hrefs).toContain(`${ORIGIN}/sitemap.xml`);
+    expect(hrefs).toContain(`${ORIGIN}/openapi.json`);
+    expect(hrefs).toContain(`${ORIGIN}/catalog.json`);
+  });
+});
+
+describe("problemJson", () => {
+  const body = JSON.parse(
+    problemJson(
+      notFound({ path: "/nope", origin: ORIGIN, suggestions: [`${ORIGIN}/docs`] }),
+      ORIGIN,
+    ),
+  );
+
+  it("is RFC 9457 problem details", () => {
+    expect(body.type).toMatch(/^https:\/\//);
+    expect(body.title).toBeTruthy();
+    expect(body.status).toBe(404);
+    expect(body.detail).toBeTruthy();
+    expect(body.instance).toBe("/nope");
+  });
+
+  it("carries the members an agent acts on", () => {
+    expect(body.code).toBe("not_found");
+    expect(body.error).toEqual({ code: "not_found", message: body.detail });
+    expect(Array.isArray(body.hints)).toBe(true);
+    expect(body.suggestions).toEqual([`${ORIGIN}/docs`]);
+    expect(body.links.every((l: { href: string }) => l.href.startsWith(ORIGIN))).toBe(true);
+  });
+});
+
+describe("problemMarkdown", () => {
+  const md = problemMarkdown(
+    notFound({
+      path: "/sparklines",
+      origin: ORIGIN,
+      suggestions: [`${ORIGIN}/docs/charts/sparkline`],
+    }),
+  );
+
+  it("opens with an H1 that states the status", () => {
+    expect(md.startsWith("# 404 — ")).toBe(true);
+  });
+
+  it("links the recovery routes as Markdown", () => {
+    expect(md).toContain(`[llms.txt](${ORIGIN}/llms.txt)`);
+    expect(md).toContain("## Where to look next");
+    expect(md).toContain(`<${ORIGIN}/docs/charts/sparkline>`);
+  });
+
+  it("stays short enough to read in a tool result", () => {
+    expect(md.length).toBeLessThan(2000);
+  });
+
+  it("balances its code fences", () => {
+    expect((md.match(/```/g) ?? []).length % 2).toBe(0);
+  });
+
+  it("drops the suggestions heading when there are none", () => {
+    expect(problemMarkdown(notFound({ path: "/x", origin: ORIGIN }))).not.toContain(
+      "## Closest matches",
+    );
+  });
+});
+
+describe("suggestRoutes", () => {
+  const routes = [
+    "/docs",
+    "/docs/quickstart",
+    "/docs/charts",
+    "/docs/charts/sparkline",
+    "/docs/charts/spark-bar",
+    "/docs/theming",
+    "/charts",
+    "/examples/cortex",
+  ];
+
+  it("finds the page behind a near-miss slug", () => {
+    expect(suggestRoutes("/docs/charts/sparklines", routes)[0]).toBe("/docs/charts/sparkline");
+    expect(suggestRoutes("/docs/chart/sparkline", routes)[0]).toBe("/docs/charts/sparkline");
+  });
+
+  it("falls back to the section when only the section matches", () => {
+    expect(suggestRoutes("/docs/theme", routes)).toContain("/docs/theming");
+  });
+
+  it("offers the section a missing page would have lived in", () => {
+    expect(suggestRoutes("/docs/nothing-here", routes)).toContain("/docs");
+  });
+
+  it("returns nothing for a path with no overlap", () => {
+    expect(suggestRoutes("/wp-admin/xyz", routes)).toEqual([]);
+  });
+
+  // Regression: short tokens are one edit from everything, so a nonsense path
+  // came back with three confident-looking guesses.
+  it("stays quiet rather than guessing", () => {
+    expect(suggestRoutes("/some-path-that-does-not-exist", routes)).toEqual([]);
+    expect(suggestRoutes("/.env", routes)).toEqual([]);
+    expect(suggestRoutes("/api/v2/users", routes)).toEqual([]);
+  });
+
+  it("caps the list", () => {
+    expect(suggestRoutes("/docs/charts", routes, 2).length).toBe(2);
+  });
+
+  it("survives an empty route list", () => {
+    expect(suggestRoutes("/docs", [])).toEqual([]);
+  });
+});

--- a/apps/docs/src/lib/agent-errors.ts
+++ b/apps/docs/src/lib/agent-errors.ts
@@ -1,0 +1,303 @@
+/**
+ * Error bodies an agent can act on.
+ *
+ * A static site's default 404 is a designed HTML page: fine for a reader,
+ * useless to a script, which gets a screenful of chrome and no way to recover.
+ * These builders answer the same 404 in the caller's own format — RFC 9457
+ * problem details for the JSON surface, a short Markdown note with real links
+ * for everything else — so a wrong URL ends in a next step rather than a dead
+ * end.
+ *
+ * Pure and runtime-free: the Cloudflare Worker renders these at the edge, and
+ * `scripts/gen-md.ts` writes the same Markdown body to `/404.md` so the
+ * recovery note exists as a plain static file on any host.
+ */
+
+/** A named entry point offered to a caller that landed nowhere. */
+export type ProblemLink = { title: string; href: string; note: string };
+
+/** One error, in the shape both renderers read. */
+export type Problem = {
+  status: number;
+  /** Stable, matchable code — `not_found`, `method_not_allowed`, … */
+  code: string;
+  title: string;
+  detail: string;
+  /** The path that produced it. */
+  instance: string;
+  /** What to do next, most useful first. */
+  hints: string[];
+  links: ProblemLink[];
+  /** Real URLs on this site that look like what was asked for. */
+  suggestions: string[];
+  /** Set on a 405 so the response can carry a matching `Allow` header. */
+  allow?: string[];
+};
+
+/** Absolute URL for a site-relative path against the origin that served it. */
+function at(origin: string, path: string): string {
+  return `${origin.replace(/\/+$/, "")}${path}`;
+}
+
+/**
+ * The entry points every error body offers. Ordered by how much ground each one
+ * covers: the docs index for a reader, `llms.txt` for an agent mapping the
+ * site, then the machine surfaces.
+ */
+export function entryPoints(origin: string): ProblemLink[] {
+  return [
+    {
+      title: "Documentation",
+      href: at(origin, "/docs"),
+      note: "Every guide and chart page, with a `.md` twin at the same URL.",
+    },
+    {
+      title: "llms.txt",
+      href: at(origin, "/llms.txt"),
+      note: "One-page index of this site, written for agents.",
+    },
+    {
+      title: "llms-full.txt",
+      href: at(origin, "/llms-full.txt"),
+      note: "The whole documentation set as one Markdown file.",
+    },
+    {
+      title: "catalog.json",
+      href: at(origin, "/catalog.json"),
+      note: "Every chart type as JSON: import path, props, data shape.",
+    },
+    {
+      title: "openapi.json",
+      href: at(origin, "/openapi.json"),
+      note: "OpenAPI 3.1 description of every machine-readable endpoint here.",
+    },
+    {
+      title: "sitemap.xml",
+      href: at(origin, "/sitemap.xml"),
+      note: "Every indexable URL, with last-modified dates.",
+    },
+  ];
+}
+
+/** The two ways to read any page as Markdown, stated the same way everywhere. */
+export const MARKDOWN_HINT =
+  "Add `.md` to any page URL, or send `Accept: text/markdown`, to read it as Markdown.";
+
+const INDEX_HINT = "Fetch /llms.txt for a one-page index of every documented URL.";
+const API_HINT = "Fetch /openapi.json for the machine-readable surface of this site.";
+
+/**
+ * 404 — the path resolves to nothing. `path` is `null` for the static
+ * `/404.md` twin, which is written once and cannot name the URL that missed.
+ */
+export function notFound(input: {
+  path: string | null;
+  origin: string;
+  suggestions?: string[];
+}): Problem {
+  const { path, origin, suggestions = [] } = input;
+  return {
+    status: 404,
+    code: "not_found",
+    title: "No page at this URL",
+    detail: `microcharts.dev serves nothing at ${path ?? "the URL you requested"}. The path may be misspelled, or it may never have existed.`,
+    instance: path ?? "",
+    hints: [
+      suggestions.length > 0
+        ? "One of the suggested URLs below is probably the page you want."
+        : INDEX_HINT,
+      MARKDOWN_HINT,
+      API_HINT,
+    ],
+    links: entryPoints(origin),
+    suggestions,
+  };
+}
+
+/** 405 — the path exists, the method does not. */
+export function methodNotAllowed(input: {
+  path: string;
+  origin: string;
+  method: string;
+  allow?: string[];
+}): Problem {
+  const { path, origin, method, allow = ["GET", "HEAD"] } = input;
+  return {
+    status: 405,
+    code: "method_not_allowed",
+    title: "This endpoint is read-only",
+    detail: `${method} is not supported at ${path}. microcharts.dev is a static site: every endpoint answers ${allow.join(" and ")} and nothing else.`,
+    instance: path,
+    hints: [
+      `Retry with ${allow[0]}.`,
+      "Nothing here accepts writes. To generate or render a chart, run the MCP server: `npx -y @microcharts/mcp`.",
+      API_HINT,
+    ],
+    links: entryPoints(origin),
+    suggestions: [],
+    allow,
+  };
+}
+
+/** 406 — the client accepts only a type this URL cannot produce. */
+export function notAcceptable(input: { path: string; origin: string; accept: string }): Problem {
+  const { path, origin, accept } = input;
+  return {
+    status: 406,
+    code: "not_acceptable",
+    title: "No representation matches your Accept header",
+    detail: `${path} has no Markdown twin, and your request accepts nothing else (Accept: ${accept}).`,
+    instance: path,
+    hints: ["Retry with `Accept: text/html` or `Accept: */*`.", MARKDOWN_HINT, INDEX_HINT],
+    links: entryPoints(origin),
+    suggestions: [],
+  };
+}
+
+/**
+ * RFC 9457 problem details, plus the members an agent actually acts on.
+ *
+ * `type`/`title`/`status`/`detail`/`instance` are the registered members; RFC
+ * 9457 §3.2 allows extensions, so `code`, `error`, `hints`, `links` and
+ * `suggestions` ride along. `error` restates code and message under the shape
+ * most SDKs reach for first.
+ */
+export function problemJson(problem: Problem, origin: string): string {
+  const body = {
+    type: at(origin, "/docs/ai#errors"),
+    title: problem.title,
+    status: problem.status,
+    detail: problem.detail,
+    instance: problem.instance,
+    code: problem.code,
+    error: { code: problem.code, message: problem.detail },
+    hints: problem.hints,
+    suggestions: problem.suggestions,
+    links: problem.links.map((l) => ({ rel: "related", title: l.title, href: l.href })),
+  };
+  return `${JSON.stringify(body, null, 2)}\n`;
+}
+
+/** The same error as a short Markdown note: a heading, what happened, where to go. */
+export function problemMarkdown(problem: Problem): string {
+  const lines = [`# ${problem.status} — ${problem.title.toLowerCase()}`, "", problem.detail, ""];
+
+  if (problem.suggestions.length > 0) {
+    lines.push("## Closest matches", "");
+    for (const url of problem.suggestions) lines.push(`- <${url}>`);
+    lines.push("");
+  }
+
+  lines.push("## Where to look next", "");
+  for (const link of problem.links) lines.push(`- [${link.title}](${link.href}) — ${link.note}`);
+  lines.push("", "## Notes", "");
+  for (const hint of problem.hints) lines.push(`- ${hint}`);
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+/**
+ * Real URLs that look like the one that missed.
+ *
+ * Scores each candidate on the path segments it shares with the request, so
+ * `/docs/chart/sparklines` finds `/docs/charts/sparkline` and a typo in the
+ * last segment still matches its neighbours. Ties break toward the shorter
+ * URL, which is the more general page.
+ */
+export function suggestRoutes(path: string, routes: readonly string[], limit = 3): string[] {
+  const wanted = tokens(path);
+  if (wanted.length === 0) return [];
+
+  const scored: { url: string; score: number }[] = [];
+  for (const url of routes) {
+    const candidate = tokens(url);
+    if (candidate.length === 0) continue;
+
+    let score = 0;
+    for (const token of wanted) {
+      score += Math.max(...candidate.map((c) => closeness(c, token)));
+    }
+    // The last segment carries the intent; reward matching it directly.
+    const tail = wanted[wanted.length - 1];
+    score += closeness(candidate[candidate.length - 1], tail);
+
+    // The section the missing page would have lived in is always worth
+    // offering: `/docs/nothing-here` has no near match, but `/docs` lists
+    // everything that is there. Worth less than a matching last segment, so
+    // `/docs/charts/sparklines` still ranks the chart above its shelf.
+    if (path.startsWith(`${url}/`)) score += 3;
+
+    if (score >= MIN_SCORE) scored.push({ url, score });
+  }
+
+  return scored
+    .sort((a, b) => b.score - a.score || a.url.length - b.url.length || (a.url < b.url ? -1 : 1))
+    .slice(0, limit)
+    .map((s) => s.url);
+}
+
+/** Lowercase alphanumeric path segments, split on separators and case changes. */
+function tokens(input: string): string[] {
+  return input
+    .toLowerCase()
+    .replace(/\.[a-z0-9]+$/, "")
+    .split(/[^a-z0-9]+/)
+    .filter((s) => s.length > 1 && s !== "http" && s !== "https" && s !== "www");
+}
+
+/**
+ * The score below which a candidate is noise rather than a suggestion. On the
+ * scale in `closeness`, one shared segment cannot reach it and two can.
+ * Offering three bad guesses is worse than offering none, because an agent will
+ * follow them.
+ */
+const MIN_SCORE = 7;
+
+/**
+ * How alike two path segments are: 4 identical, 3 near-exact, 2 a shared stem,
+ * 0 unrelated. Graded rather than boolean so a near-exact match outranks a
+ * stem one — flat scoring put `sparkbar` above `sparkline` for `sparklines`.
+ *
+ * Four characters is the floor, because at three every short word is one edit
+ * from every other: `not` matched `net-flow` and `does` matched `dot-plot`,
+ * which is how a nonsense path came back with three confident suggestions.
+ */
+function closeness(a: string, b: string): number {
+  if (a === b) return 4;
+  if (a.length < 4 || b.length < 4) return 0;
+  // A missing plural or a single typo: `sparkline` for `sparklines`.
+  if (a.startsWith(b) || b.startsWith(a) || editDistanceAtMostOne(a, b)) return 3;
+  // Only a shared stem: `sparkbar` for `sparklines`, `theming` for `theme`.
+  // Worth offering, never worth ranking above a near-exact match.
+  if (a.length >= 5 && b.length >= 5 && sharedPrefix(a, b) >= 4) return 2;
+  return 0;
+}
+
+/** How many leading characters `a` and `b` have in common. */
+function sharedPrefix(a: string, b: string): number {
+  let i = 0;
+  while (i < a.length && i < b.length && a[i] === b[i]) i += 1;
+  return i;
+}
+
+/** True when `a` and `b` are one insertion, deletion, or substitution apart. */
+function editDistanceAtMostOne(a: string, b: string): boolean {
+  if (Math.abs(a.length - b.length) > 1) return false;
+  const [short, long] = a.length <= b.length ? [a, b] : [b, a];
+  let i = 0;
+  let j = 0;
+  let edits = 0;
+  while (i < short.length && j < long.length) {
+    if (short[i] === long[j]) {
+      i += 1;
+      j += 1;
+      continue;
+    }
+    edits += 1;
+    if (edits > 1) return false;
+    if (short.length === long.length) i += 1;
+    j += 1;
+  }
+  return edits + (long.length - j) + (short.length - i) <= 1;
+}

--- a/apps/docs/src/lib/agent-surface.test.ts
+++ b/apps/docs/src/lib/agent-surface.test.ts
@@ -1,0 +1,148 @@
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { buildOpenApi } from "./openapi.ts";
+import { STABLE_CHARTS } from "./catalog.ts";
+import { SITE } from "./site.ts";
+
+/**
+ * The agent-facing surface, checked against a real export.
+ *
+ * Everything else in this directory tests a builder in isolation. This file
+ * tests that what the builders describe actually shipped: every path the
+ * OpenAPI document advertises resolves to a file in `out/`, every Markdown twin
+ * exists beside the page it mirrors, and the documents on disk are the ones the
+ * current source produces.
+ *
+ * Skipped without a build, like `metadata.test.ts` — `pnpm build` first.
+ */
+const out = fileURLToPath(new URL("../../out", import.meta.url));
+const hasBuild = existsSync(out);
+const read = (rel: string) => readFileSync(join(out, rel), "utf8");
+const exists = (rel: string) => existsSync(join(out, rel));
+
+/** Resolve a URL path the way Cloudflare's asset store does. */
+function resolves(path: string): boolean {
+  const clean = path === "/" ? "/index.html" : path;
+  return exists(clean) || exists(`${clean}.html`) || exists(`${clean}/index.html`);
+}
+
+describe.skipIf(!hasBuild)("the built agent surface", () => {
+  it("publishes the OpenAPI document the source describes", () => {
+    expect(JSON.parse(read("openapi.json"))).toEqual(buildOpenApi());
+  });
+
+  it("ships every path the OpenAPI document advertises", () => {
+    const doc = buildOpenApi();
+    const missing = Object.keys(doc.paths)
+      .map((path) => path.replace("{slug}", STABLE_CHARTS[0].slug))
+      .filter((path) => !resolves(path));
+    expect(missing).toEqual([]);
+  });
+
+  it.each([
+    "index.md",
+    "charts.md",
+    "examples.md",
+    "brand.md",
+    "contact.md",
+    "privacy.md",
+    "404.md",
+    "docs.md",
+    "docs/ai.md",
+  ])("mirrors %s", (file) => {
+    expect(exists(file), file).toBe(true);
+    expect(read(file).startsWith("# "), file).toBe(true);
+  });
+
+  it("gives every mirrored page an HTML twin at the same route", () => {
+    for (const page of ["index", "charts", "examples", "brand", "contact", "privacy"]) {
+      expect(exists(`${page}.html`), page).toBe(true);
+    }
+  });
+
+  it("slices the catalog into one document per chart", () => {
+    const index = JSON.parse(read("api/charts.json"));
+    expect(index.count).toBe(STABLE_CHARTS.length);
+    expect(index.charts.length).toBe(STABLE_CHARTS.length);
+
+    for (const chart of STABLE_CHARTS) {
+      const file = `api/charts/${chart.slug}.json`;
+      expect(exists(file), file).toBe(true);
+    }
+  });
+
+  it("keeps a per-chart document small enough to be worth fetching", () => {
+    const one = statSync(join(out, `api/charts/${STABLE_CHARTS[0].slug}.json`)).size;
+    const whole = statSync(join(out, "catalog.json")).size;
+    expect(one).toBeLessThan(whole / 10);
+  });
+
+  it("carries the chart's own props, not just a pointer", () => {
+    const doc = JSON.parse(read("api/charts/sparkline.json"));
+    expect(doc.chart.slug).toBe("sparkline");
+    expect(doc.chart.props.length).toBeGreaterThan(0);
+    expect(doc.sharedProps.length).toBeGreaterThan(0);
+    expect(doc.howToRead).toBeTruthy();
+  });
+
+  it("serves the MCP server card at the well-known path", () => {
+    const card = JSON.parse(read(".well-known/mcp/server-card.json"));
+    expect(card.name).toBe("io.github.ganapativs/microcharts");
+    expect(card.packages[0].transport.type).toBe("stdio");
+    // The bytes are the published registry manifest, not a copy of it.
+    const manifest = readFileSync(
+      fileURLToPath(new URL("../../../../packages/mcp/server.json", import.meta.url)),
+      "utf8",
+    );
+    expect(read(".well-known/mcp/server-card.json")).toBe(manifest);
+  });
+
+  it("lists the trust pages in the sitemap", () => {
+    const sitemap = read("sitemap.xml");
+    for (const path of ["/contact", "/privacy"]) {
+      expect(sitemap, path).toContain(`<loc>${SITE.url}${path}</loc>`);
+    }
+  });
+
+  it("gives the trust pages enough text to be worth checking", () => {
+    for (const page of ["contact", "privacy"]) {
+      const text = read(`${page}.html`)
+        .replace(/<script[\s\S]*?<\/script>/g, "")
+        .replace(/<style[\s\S]*?<\/style>/g, "")
+        .replace(/<[^>]+>/g, " ")
+        .replace(/\s+/g, " ")
+        .trim();
+      expect(text.length, page).toBeGreaterThan(500);
+    }
+  });
+
+  it("advertises the Markdown twin in the head of every mirrored page", () => {
+    for (const [page, mirror] of [
+      ["index", "/index.md"],
+      ["charts", "/charts.md"],
+      ["contact", "/contact.md"],
+      ["privacy", "/privacy.md"],
+    ]) {
+      expect(read(`${page}.html`), page).toContain(`${SITE.url}${mirror}`);
+    }
+  });
+
+  it("names the new surfaces in llms.txt", () => {
+    const llms = read("llms.txt");
+    for (const path of ["/openapi.json", "/api/charts.json", "/404.md", "/contact.md"]) {
+      expect(llms, path).toContain(`${SITE.url}${path}`);
+    }
+  });
+
+  it("resolves every site URL llms.txt points at", () => {
+    const llms = read("llms.txt");
+    const origin = SITE.url.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const paths = [...llms.matchAll(new RegExp(origin + "([^)\\s`]*)", "g"))]
+      .map((m) => m[1].replace(/[.,;:]+$/, ""))
+      .filter((p) => p.length > 0 && !p.includes("<slug>"));
+    const missing = [...new Set(paths)].filter((p) => !resolves(p));
+    expect(missing).toEqual([]);
+  });
+});

--- a/apps/docs/src/lib/ai-providers.ts
+++ b/apps/docs/src/lib/ai-providers.ts
@@ -111,6 +111,18 @@ export const MACHINE_SURFACES: MachineSurface[] = [
     href: "/docs/ai.md",
     label: "*.md mirrors",
     note: "clean Markdown",
-    body: "Append .md to any docs page for a Markdown copy an agent reads without parsing HTML — every component expanded to text and code.",
+    body: "Append .md to any page for a Markdown copy an agent reads without parsing HTML — every component expanded to text and code. Sending Accept: text/markdown to the page URL returns the same bytes.",
+  },
+  {
+    href: "/openapi.json",
+    label: "/openapi.json",
+    note: "the endpoints, typed",
+    body: "OpenAPI 3.1 description of every machine-readable route here, with an operation id, typed parameters and a response schema on each one. Point a function-calling agent at it and the surface loads itself.",
+  },
+  {
+    href: "/api/charts.json",
+    label: "/api/charts.json",
+    note: "one chart per fetch",
+    body: "An index of every chart type, each linking to /api/charts/<slug>.json — that chart’s props, imports and caveats in about 8 kB instead of the full catalog’s 290 kB.",
   },
 ];

--- a/apps/docs/src/lib/api-charts.ts
+++ b/apps/docs/src/lib/api-charts.ts
@@ -1,0 +1,89 @@
+/**
+ * The per-chart JSON endpoints behind `/api/charts.json` and
+ * `/api/charts/<slug>.json`.
+ *
+ * `/catalog.json` is the whole catalog in one document — 290 kB, because it
+ * carries all 106 charts. An agent wiring up one chart needs one entry. These
+ * two endpoints slice the same `buildCatalog()` output, so a chart's shape here
+ * is byte-identical to its shape there: one generator, no second data model to
+ * keep in sync.
+ *
+ * A per-chart document is self-contained on purpose. It carries `sharedProps`
+ * and `howToRead` alongside the entry, because a chart's full prop surface is
+ * shared + chart-specific — an agent that fetched only the entry would write
+ * props that do not exist.
+ */
+import { buildCatalog } from "./catalog-json";
+import { abs } from "./site";
+
+type Catalog = ReturnType<typeof buildCatalog>;
+type CatalogChart = Catalog["charts"][number];
+
+/** `buildCatalog` reads every chart's client source; memoise across the export. */
+let cached: Catalog | null = null;
+function catalog(): Catalog {
+  cached ??= buildCatalog();
+  return cached;
+}
+
+/** Where a chart is documented, in all three representations. */
+function locations(slug: string) {
+  return {
+    api: abs(`/api/charts/${slug}.json`),
+    docs: abs(`/docs/charts/${slug}`),
+    markdown: abs(`/docs/charts/${slug}.md`),
+  };
+}
+
+export type ChartIndex = ReturnType<typeof buildChartIndex>;
+
+/** Every chart type, one line each, with the URL that expands it. */
+export function buildChartIndex() {
+  const c = catalog();
+  return {
+    package: c.package,
+    homepage: c.homepage,
+    catalog: abs("/catalog.json"),
+    count: c.charts.length,
+    charts: c.charts.map((chart) => ({
+      name: chart.name,
+      slug: chart.slug,
+      status: chart.status,
+      collection: chart.collection,
+      tagline: chart.tagline,
+      ...locations(chart.slug),
+    })),
+  };
+}
+
+export type ChartDocument = {
+  package: string;
+  homepage: string;
+  howToRead: string;
+  api: string;
+  docs: string;
+  markdown: string;
+  sharedProps: Catalog["sharedProps"];
+  chart: CatalogChart;
+};
+
+/** One chart's full API surface, or `null` when no such chart exists. */
+export function buildChartDocument(slug: string): ChartDocument | null {
+  const c = catalog();
+  const chart = c.charts.find((entry) => entry.slug === slug);
+  if (!chart) return null;
+
+  return {
+    package: c.package,
+    homepage: c.homepage,
+    howToRead: c.howToRead,
+    ...locations(slug),
+    sharedProps: c.sharedProps,
+    chart,
+  };
+}
+
+/** Every slug the per-chart endpoint answers to. */
+export function chartSlugs(): string[] {
+  return catalog().charts.map((c) => c.slug);
+}

--- a/apps/docs/src/lib/content-negotiation.test.ts
+++ b/apps/docs/src/lib/content-negotiation.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { markdownAssetFor, matchAccept, negotiate } from "./content-negotiation.ts";
+import {
+  acceptsHtml,
+  errorFormat,
+  isApiPath,
+  markdownAssetFor,
+  matchAccept,
+  negotiate,
+  rewritableError,
+} from "./content-negotiation.ts";
 
 describe("matchAccept", () => {
   it("no header is a no-preference wildcard", () => {
@@ -43,33 +51,119 @@ describe("negotiate", () => {
     expect(negotiate("text/markdown;q=0.5, text/html", md)).toBe("html");
   });
 
+  // The acceptmarkdown contract's third probe: an explicit q=0 must fall back.
+  it("q=0 on markdown never selects it", () => {
+    expect(negotiate("text/markdown;q=0, text/html", md)).toBe("html");
+  });
+
   it("markdown-only with no mirror is 406, else degrades to HTML", () => {
     expect(negotiate("text/markdown", false)).toBe("not-acceptable");
     expect(negotiate("text/markdown, text/html;q=0.1", false)).toBe("html");
   });
+});
 
-  it("q=0 on markdown never selects it", () => {
-    expect(negotiate("text/markdown;q=0, text/html", md)).toBe("html");
+describe("acceptsHtml", () => {
+  it("is true for browsers, wildcards, and no header at all", () => {
+    expect(acceptsHtml("text/html,*/*;q=0.8")).toBe(true);
+    expect(acceptsHtml("*/*")).toBe(true);
+    expect(acceptsHtml(null)).toBe(true);
+    expect(acceptsHtml("text/*")).toBe(true);
+    expect(acceptsHtml("text/markdown, text/html;q=0.1")).toBe(true);
+  });
+
+  it("is false when HTML carries no quality", () => {
+    expect(acceptsHtml("application/json")).toBe(false);
+    expect(acceptsHtml("image/avif,image/webp")).toBe(false);
+    expect(acceptsHtml("text/html;q=0")).toBe(false);
+    expect(acceptsHtml("text/markdown")).toBe(false);
   });
 });
 
 describe("markdownAssetFor", () => {
   it.each([
+    ["/", "/index.md"],
     ["/docs", "/docs.md"],
     ["/docs/", "/docs.md"],
     ["/docs/ai", "/docs/ai.md"],
     ["/docs/charts", "/docs/charts.md"],
     ["/docs/charts/sparkline", "/docs/charts/sparkline.md"],
     ["/docs/charts/sparkline/", "/docs/charts/sparkline.md"],
+    // Every page route negotiates, not only `/docs/*`.
+    ["/charts", "/charts.md"],
+    ["/examples", "/examples.md"],
+    ["/contact", "/contact.md"],
+    ["/charts/core", "/charts/core.md"],
   ])("%s → %s", (path, expected) => {
     expect(markdownAssetFor(path)).toBe(expected);
   });
 
-  it("ignores non-doc routes and concrete files", () => {
-    expect(markdownAssetFor("/")).toBeNull();
-    expect(markdownAssetFor("/elements")).toBeNull();
+  it("ignores concrete files and the trees that have no twin", () => {
     expect(markdownAssetFor("/docs/charts/sparkline.md")).toBeNull();
     expect(markdownAssetFor("/docs/charts/sparkline.txt")).toBeNull();
     expect(markdownAssetFor("/catalog.json")).toBeNull();
+    expect(markdownAssetFor("/api/charts.json")).toBeNull();
+    expect(markdownAssetFor("/api/search")).toBeNull();
+    expect(markdownAssetFor("/_next/static/chunk.js")).toBeNull();
+    expect(markdownAssetFor("/og/default.png")).toBeNull();
+    expect(markdownAssetFor("/.well-known/mcp/server-card.json")).toBeNull();
+  });
+});
+
+describe("isApiPath", () => {
+  it("covers /api/* and every .json document", () => {
+    expect(isApiPath("/api")).toBe(true);
+    expect(isApiPath("/api/search")).toBe(true);
+    expect(isApiPath("/api/charts/sparkline.json")).toBe(true);
+    expect(isApiPath("/catalog.json")).toBe(true);
+    expect(isApiPath("/.well-known/mcp/server-card.json")).toBe(true);
+  });
+
+  it("leaves pages and other files alone", () => {
+    expect(isApiPath("/")).toBe(false);
+    expect(isApiPath("/docs/ai")).toBe(false);
+    expect(isApiPath("/llms.txt")).toBe(false);
+    expect(isApiPath("/apiary")).toBe(false);
+  });
+});
+
+describe("errorFormat", () => {
+  it("answers the JSON surface in JSON, whatever the caller sent", () => {
+    expect(errorFormat("text/html", "/api/charts/nope.json")).toBe("json");
+    expect(errorFormat(null, "/api/whatever")).toBe("json");
+    expect(errorFormat("text/markdown", "/catalog.jsonx")).toBe("markdown");
+  });
+
+  it("honours an explicit JSON ask on any path", () => {
+    expect(errorFormat("application/json", "/nope")).toBe("json");
+    expect(errorFormat("application/json, text/plain", "/nope")).toBe("json");
+  });
+
+  it("gives browsers the designed page", () => {
+    expect(errorFormat("text/html,application/xhtml+xml,image/avif,*/*;q=0.8", "/nope")).toBe(
+      "html",
+    );
+    expect(errorFormat("text/html", "/nope")).toBe("html");
+  });
+
+  it("gives every scripted client Markdown", () => {
+    expect(errorFormat("*/*", "/nope")).toBe("markdown"); // curl, most agents
+    expect(errorFormat(null, "/nope")).toBe("markdown");
+    expect(errorFormat("text/markdown", "/nope")).toBe("markdown");
+    expect(errorFormat("text/*", "/nope")).toBe("markdown");
+  });
+});
+
+describe("rewritableError", () => {
+  it("rewrites page routes and text-ish files", () => {
+    expect(rewritableError("/nope")).toBe(true);
+    expect(rewritableError("/docs/nope.md")).toBe(true);
+    expect(rewritableError("/nope.json")).toBe(true);
+    expect(rewritableError("/nope.xml")).toBe(true);
+  });
+
+  it("leaves binary misses to the asset store", () => {
+    expect(rewritableError("/brand/mark.svg")).toBe(false);
+    expect(rewritableError("/examples/atlas-dark.webp")).toBe(false);
+    expect(rewritableError("/fonts/Iosevka-400-latin.woff2")).toBe(false);
   });
 });

--- a/apps/docs/src/lib/content-negotiation.ts
+++ b/apps/docs/src/lib/content-negotiation.ts
@@ -1,7 +1,8 @@
 /**
- * `Accept: text/markdown` content negotiation, per https://acceptmarkdown.com —
- * the same doc URL serves HTML to browsers and the pre-generated Markdown mirror
- * to agents that ask for it, with no separate URL or redirect.
+ * `Accept` negotiation, per https://acceptmarkdown.com — the same URL serves
+ * HTML to browsers and the pre-generated Markdown mirror to agents that ask for
+ * it, with no separate URL or redirect. Every page route negotiates, not just
+ * `/docs/*`: `/` mirrors to `/index.md`, `/charts` to `/charts.md`.
  *
  * Pure and runtime-free so it unit-tests in the node project; the Cloudflare
  * Worker (`worker.ts`) is the only place that touches the network. The static
@@ -58,7 +59,7 @@ export function matchAccept(header: string | null | undefined, target: string): 
 export type Negotiation = "markdown" | "html" | "not-acceptable";
 
 /**
- * Decide what a doc route should serve for a given `Accept` header.
+ * Decide what a page route should serve for a given `Accept` header.
  *
  * - `markdown` — the client prefers Markdown and a mirror exists.
  * - `html` — the default; browsers and no-preference clients land here.
@@ -79,15 +80,87 @@ export function negotiate(accept: string | null | undefined, hasMarkdown: boolea
 }
 
 /**
- * Map a clean doc route to its `.md` mirror asset path, or `null` when the path
- * is not a negotiable doc route (non-`/docs`, or already a concrete file such as
- * `…/sparkline.md` / `…/catalog.json`). Mirrors `mirrorFor` in `gen-md.ts`:
- * `/docs` → `/docs.md`, `/docs/charts/sparkline` → `/docs/charts/sparkline.md`.
+ * Would this client accept the HTML representation?
+ *
+ * Asked only once Markdown has been ruled out and the page is known to exist,
+ * because HTML is then the only thing left to send. A client that gives
+ * `text/html` a zero quality — by naming another type and no wildcard, or by
+ * `text/html;q=0` — has nothing to receive, and RFC 9110 §15.5.7 says to answer
+ * 406 rather than send something it said it could not read.
+ */
+export function acceptsHtml(accept: string | null | undefined): boolean {
+  return matchAccept(accept, "text/html").q > 0;
+}
+
+/** Trees that never carry a Markdown twin: build output, API surface, images. */
+const NO_MIRROR = ["/_next/", "/api/", "/og/", "/.well-known/"];
+
+/**
+ * Map a clean page route to its `.md` mirror asset path, or `null` when the path
+ * cannot have one — a build/API/image tree, or an already-concrete file such as
+ * `…/sparkline.md` or `…/catalog.json`.
+ *
+ * Mirrors `mirrorFor` in `gen-md.ts`: `/` → `/index.md`, `/docs` → `/docs.md`,
+ * `/docs/charts/sparkline` → `/docs/charts/sparkline.md`. Whether the mirror
+ * actually exists is decided by probing the asset store, not by a list here —
+ * one less thing to keep in sync with the generator.
  */
 export function markdownAssetFor(pathname: string): string | null {
   const path = pathname.length > 1 && pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
-  if (path !== "/docs" && !path.startsWith("/docs/")) return null;
+  if (NO_MIRROR.some((p) => path === p.slice(0, -1) || path.startsWith(p))) return null;
+  if (path === "/" || path === "") return "/index.md";
   const last = path.slice(path.lastIndexOf("/") + 1);
   if (last.includes(".")) return null; // already a file (.md/.txt/.json/…)
   return `${path}.md`;
+}
+
+/**
+ * Is this path part of the JSON API surface (`/api/*` and the `.json`
+ * documents)? Those answer in JSON when they succeed, so they answer in JSON
+ * when they fail — an HTML error page there is unparseable to the caller.
+ */
+export function isApiPath(pathname: string): boolean {
+  const path = pathname.length > 1 && pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
+  return path === "/api" || path.startsWith("/api/") || path.endsWith(".json");
+}
+
+export type ErrorFormat = "json" | "markdown" | "html";
+
+/**
+ * Pick the representation for an *error* response.
+ *
+ * Deliberately more forward than {@link negotiate}: a successful page keeps the
+ * strict acceptmarkdown reading, where a bare full wildcard gets HTML, because
+ * there is a designed page to serve. An error has no page worth serving to a
+ * non-browser, so a client that never names `text/html` — a wildcard, a type
+ * wildcard, or no header at all, which is every scripted client — gets the
+ * Markdown recovery body instead of a screenful of chrome. The status code is
+ * identical either way; only the body changes.
+ */
+export function errorFormat(accept: string | null | undefined, pathname: string): ErrorFormat {
+  if (isApiPath(pathname)) return "json";
+
+  const json = matchAccept(accept, "application/json");
+  const md = matchAccept(accept, "text/markdown");
+  const html = matchAccept(accept, "text/html");
+
+  if (json.spec === 2 && json.q > 0 && json.q >= html.q && json.q >= md.q) return "json";
+  if (md.spec === 2 && md.q > 0 && md.q >= html.q) return "markdown";
+  // No explicit `text/html` in the header means no browser is reading this.
+  return html.spec === 2 && html.q > 0 ? "html" : "markdown";
+}
+
+/**
+ * Extensions whose 404 body is worth rewriting. A missing `.png` or `.woff2` is
+ * answered by the asset store untouched — a Markdown recovery note in an
+ * `<img>` slot helps nobody, and the status code already carries the message.
+ */
+const REWRITABLE = new Set(["md", "txt", "json", "html", "htm", "mdx", "xml", "yaml", "yml"]);
+
+/** Should a 404 for this path carry an agent-readable body? */
+export function rewritableError(pathname: string): boolean {
+  const last = pathname.slice(pathname.lastIndexOf("/") + 1);
+  if (!last.includes(".")) return true; // a page route
+  const ext = last.slice(last.lastIndexOf(".") + 1).toLowerCase();
+  return REWRITABLE.has(ext);
 }

--- a/apps/docs/src/lib/jsonld.ts
+++ b/apps/docs/src/lib/jsonld.ts
@@ -80,8 +80,27 @@ export function organizationJsonLd() {
     logo: abs("/apple-icon"),
     description: SITE.description,
     foundingDate: "2025",
-    sameAs: [SITE.repo, SITE.npm, SITE.authorX, SITE.authorGithub, SITE.authorUrl],
+    sameAs: [SITE.repo, SITE.npm, SITE.npmMcp, SITE.authorX, SITE.authorGithub, SITE.authorUrl],
     founder: author,
+    // Two ways in, both public and both answered by the maintainer. An
+    // open-source project has no switchboard and no postal address; these are
+    // the addresses SECURITY.md and CONTRIBUTING.md already publish.
+    contactPoint: [
+      {
+        "@type": "ContactPoint",
+        contactType: "technical support",
+        url: `${SITE.repo}/issues`,
+        email: SITE.email,
+        availableLanguage: "English",
+      },
+      {
+        "@type": "ContactPoint",
+        contactType: "security",
+        url: `${SITE.repo}/security/advisories/new`,
+        email: SITE.email,
+        availableLanguage: "English",
+      },
+    ],
   };
 }
 

--- a/apps/docs/src/lib/openapi.test.ts
+++ b/apps/docs/src/lib/openapi.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import Ajv2020 from "ajv/dist/2020";
+import { buildOpenApi } from "./openapi.ts";
+import { STABLE_CHARTS } from "./catalog.ts";
+import { SITE } from "./site.ts";
+import { methodNotAllowed, notAcceptable, notFound, problemJson } from "./agent-errors.ts";
+
+const doc = buildOpenApi();
+const operations = Object.entries(doc.paths).flatMap(([path, item]) =>
+  Object.entries(item as Record<string, Record<string, unknown>>).map(([method, op]) => ({
+    path,
+    method,
+    op,
+  })),
+);
+
+describe("the document", () => {
+  it("is OpenAPI 3.1", () => {
+    expect(doc.openapi).toMatch(/^3\.1\./);
+  });
+
+  it("points at the deployed origin", () => {
+    expect(doc.servers[0].url).toBe(SITE.url);
+  });
+
+  it("names a way to reach a human", () => {
+    expect(doc.info.contact.url).toContain("github.com");
+    expect(doc.info.contact.email).toBe(SITE.email);
+    expect(doc.info.license.identifier).toBe("MIT");
+  });
+
+  it("declares no authentication, because there is none", () => {
+    expect("security" in doc).toBe(false);
+    expect("securitySchemes" in doc.components).toBe(false);
+  });
+});
+
+describe("every operation", () => {
+  it("is a GET — the site is read-only", () => {
+    for (const { path, method } of operations) expect(`${path} ${method}`).toContain("get");
+  });
+
+  it("has a unique operationId", () => {
+    const ids = operations.map((o) => o.op.operationId);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const id of ids) expect(id).toMatch(/^[a-z][A-Za-z0-9]+$/);
+  });
+
+  it("has a summary and a description", () => {
+    for (const { path, op } of operations) {
+      expect(typeof op.summary, path).toBe("string");
+      expect((op.description as string).length, path).toBeGreaterThan(40);
+    }
+  });
+
+  it("declares a response schema for every status", () => {
+    for (const { path, op } of operations) {
+      const responses = op.responses as Record<string, Record<string, unknown>>;
+      expect(Object.keys(responses).length, path).toBeGreaterThan(0);
+      for (const [status, response] of Object.entries(responses)) {
+        if ("$ref" in response) continue; // shared response, checked below
+        const content = response.content as Record<string, { schema?: unknown }>;
+        expect(Object.keys(content).length, `${path} ${status}`).toBeGreaterThan(0);
+        for (const media of Object.values(content)) expect(media.schema).toBeTruthy();
+      }
+    }
+  });
+
+  it("types and describes every parameter", () => {
+    for (const { path, op } of operations) {
+      for (const parameter of (op.parameters ?? []) as Record<string, unknown>[]) {
+        if ("$ref" in parameter) {
+          const name = (parameter.$ref as string).split("/").pop() as string;
+          expect(doc.components.parameters, path).toHaveProperty(name);
+          continue;
+        }
+        expect(parameter.schema, path).toBeTruthy();
+      }
+    }
+  });
+
+  it("only tags with tags the document declares", () => {
+    const declared = new Set(doc.tags.map((t) => t.name));
+    for (const { path, op } of operations) {
+      for (const tag of (op.tags ?? []) as string[]) expect(declared, path).toContain(tag);
+    }
+  });
+});
+
+describe("references", () => {
+  const refs: string[] = [];
+  JSON.stringify(doc, (key, value) => {
+    if (key === "$ref" && typeof value === "string") refs.push(value);
+    return value;
+  });
+
+  it("resolves every local $ref", () => {
+    const local = refs.filter((r) => r.startsWith("#/"));
+    expect(local.length).toBeGreaterThan(0);
+    for (const ref of local) {
+      const resolved = ref
+        .slice(2)
+        .split("/")
+        .reduce<unknown>((node, part) => (node as Record<string, unknown>)?.[part], doc);
+      expect(resolved, ref).toBeTruthy();
+    }
+  });
+
+  it("points external refs at the published catalog schema", () => {
+    for (const ref of refs.filter((r) => !r.startsWith("#/"))) {
+      expect(ref.startsWith(`${SITE.url}/catalog.schema.json`), ref).toBe(true);
+    }
+  });
+});
+
+describe("the chart slug parameter", () => {
+  it("enumerates exactly the charts that ship", () => {
+    const enumerated = doc.components.parameters.ChartSlug.schema.enum;
+    expect([...enumerated].sort()).toEqual(STABLE_CHARTS.map((c) => c.slug).sort());
+  });
+});
+
+/**
+ * The strongest guarantee here: the Problem schema the document publishes is
+ * checked against the bodies the Worker actually renders. A drift between the
+ * two is the failure an agent would hit at runtime, so it fails here first.
+ */
+describe("the published Problem schema", () => {
+  const ajv = new Ajv2020({ strict: false, validateFormats: false });
+  const validate = ajv.compile(doc.components.schemas.Problem);
+  const origin = SITE.url;
+
+  it.each([
+    ["404", notFound({ path: "/nope", origin, suggestions: [`${origin}/docs`] })],
+    ["404 with no suggestions", notFound({ path: "/nope", origin })],
+    ["405", methodNotAllowed({ path: "/api/search", origin, method: "POST" })],
+    ["406", notAcceptable({ path: "/charts/core", origin, accept: "text/markdown" })],
+  ])("validates the real %s body", (_label, problem) => {
+    const body = JSON.parse(problemJson(problem, origin));
+    expect(validate(body), JSON.stringify(validate.errors)).toBe(true);
+  });
+
+  it("enumerates every code the builders emit", () => {
+    const codes = doc.components.schemas.Problem.properties.code.enum;
+    expect(codes).toContain(notFound({ path: "/x", origin }).code);
+    expect(codes).toContain(methodNotAllowed({ path: "/x", origin, method: "PUT" }).code);
+    expect(codes).toContain(notAcceptable({ path: "/x", origin, accept: "x" }).code);
+  });
+});

--- a/apps/docs/src/lib/openapi.ts
+++ b/apps/docs/src/lib/openapi.ts
@@ -1,0 +1,423 @@
+/**
+ * The OpenAPI description served at `/openapi.json`.
+ *
+ * microcharts.dev is a static site, so its "API" is the set of documents it
+ * publishes for machines: the chart catalog, the per-chart slices of it, the
+ * search index, the `llms.txt` pair, and the Markdown twin every page carries.
+ * They were always fetchable; without a description an agent had to be told
+ * they exist. This is that description, and it is built from the same registry
+ * the endpoints are built from — the chart slugs below are the shipped ones, so
+ * the spec cannot describe a chart the site does not serve.
+ *
+ * Read-only by construction: every operation is a GET, there is no auth, and
+ * `openapi.test.ts` asserts as much alongside the structural rules (unique
+ * operation ids, a description everywhere, a schema on every response).
+ */
+import { CATALOG_SCHEMA_PATH } from "./catalog-json";
+import { STABLE_CHARTS } from "./catalog";
+import { SITE, abs } from "./site";
+
+/** The published catalog schema, and JSON-pointer refs into its subschemas. */
+const CATALOG_SCHEMA = abs(CATALOG_SCHEMA_PATH);
+const CHART_ENTRY_REF = `${CATALOG_SCHEMA}#/properties/charts/items`;
+const SHARED_PROPS_REF = `${CATALOG_SCHEMA}#/properties/sharedProps`;
+
+const PROBLEM_CONTENT = {
+  "application/problem+json": { schema: { $ref: "#/components/schemas/Problem" } },
+  "text/markdown": {
+    schema: { type: "string", description: "The same error as a short Markdown note." },
+  },
+} as const;
+
+/** A GET that answers with one media type and one schema. */
+function ok(description: string, mediaType: string, schema: unknown) {
+  return { "200": { description, content: { [mediaType]: { schema } } } };
+}
+
+export function buildOpenApi() {
+  const slugs = STABLE_CHARTS.map((c) => c.slug).sort();
+  const exampleSlug = slugs.includes("sparkline") ? "sparkline" : slugs[0];
+
+  return {
+    openapi: "3.1.1",
+    info: {
+      title: "microcharts.dev",
+      version: "1.0.0",
+      summary: "Read-only endpoints describing the microcharts chart catalog and documentation.",
+      description: [
+        `Every endpoint here is a static document served from a CDN. All of them are GET, none of them need a key, and none of them rate-limit.`,
+        "",
+        "Two conventions apply site-wide and are worth knowing before you read the paths:",
+        "",
+        `- **Markdown twins.** Every page has one. Add \`.md\` to the URL, or send \`Accept: text/markdown\` to the page URL itself, and you get the same content as Markdown. Responses carry \`Vary: Accept, Accept-Encoding\`.`,
+        `- **Errors you can parse.** A 404, 405 or 406 answers with RFC 9457 problem details on this API surface, and with a short Markdown note anywhere else. Each one names where to look next.`,
+        "",
+        `To install the library itself, see ${abs("/docs/quickstart")}. To let a model call microcharts directly, run the MCP server: \`npx -y @microcharts/mcp\`.`,
+      ].join("\n"),
+      contact: {
+        name: `${SITE.name} issues`,
+        url: `${SITE.repo}/issues`,
+        email: SITE.email,
+      },
+      license: { name: "MIT", identifier: "MIT" },
+    },
+    externalDocs: { description: "Documentation", url: abs("/docs") },
+    servers: [{ url: SITE.url, description: "Production" }],
+    tags: [
+      { name: "Catalog", description: "The chart types, their props, and their data shapes." },
+      { name: "Documentation", description: "Pages and their Markdown twins." },
+      { name: "Discovery", description: "Files that map the site for agents and crawlers." },
+    ],
+    paths: {
+      "/api/charts.json": {
+        get: {
+          operationId: "listCharts",
+          tags: ["Catalog"],
+          summary: "List every chart type",
+          description:
+            "One line per chart — name, slug, collection, tagline — plus the URLs that expand it. Fetch this to choose a chart, then fetch that chart's document for its props.",
+          responses: ok("Every chart type the package ships.", "application/json", {
+            $ref: "#/components/schemas/ChartIndex",
+          }),
+        },
+      },
+      "/api/charts/{slug}.json": {
+        get: {
+          operationId: "getChart",
+          tags: ["Catalog"],
+          summary: "Get one chart's full API surface",
+          description:
+            "The chart's catalog entry, its shared props, and the instructions for combining the two. Self-contained: this is everything needed to write a correct chart, in about 8 kB rather than the 290 kB of the full catalog.",
+          parameters: [{ $ref: "#/components/parameters/ChartSlug" }],
+          responses: {
+            ...ok("The chart's props, imports, data shape, and caveats.", "application/json", {
+              $ref: "#/components/schemas/ChartDocument",
+            }),
+            "404": { $ref: "#/components/responses/NotFound" },
+          },
+        },
+      },
+      "/catalog.json": {
+        get: {
+          operationId: "getCatalog",
+          tags: ["Catalog"],
+          summary: "Get the whole catalog in one document",
+          description: `All ${slugs.length} charts with their props, imports, data shapes and caveats, plus the shared prop grammar. Prefer the per-chart endpoint unless you need the whole set.`,
+          responses: ok("The full catalog.", "application/json", { $ref: CATALOG_SCHEMA }),
+        },
+      },
+      "/catalog.schema.json": {
+        get: {
+          operationId: "getCatalogSchema",
+          tags: ["Catalog"],
+          summary: "Get the catalog's JSON Schema",
+          description: "The contract `/catalog.json` validates against, in CI. Draft 2020-12.",
+          responses: ok("JSON Schema for the catalog.", "application/schema+json", {
+            type: "object",
+          }),
+        },
+      },
+      "/api/search": {
+        get: {
+          operationId: "getSearchIndex",
+          tags: ["Discovery"],
+          summary: "Get the documentation search index",
+          description:
+            "The prebuilt full-text index the docs site searches in the browser. It is a whole index, not a query endpoint: fetch it once and search it locally. For a one-off lookup, `llms.txt` is smaller.",
+          responses: ok("Serialized search index.", "application/json", { type: "object" }),
+        },
+      },
+      "/llms.txt": {
+        get: {
+          operationId: "getLlmsTxt",
+          tags: ["Discovery"],
+          summary: "Get the agent index of this site",
+          description:
+            "The llmstxt.org index: what the package is, every guide and chart page as a Markdown link, and the things the library deliberately does not do. Start here when mapping the site.",
+          responses: ok("Markdown index.", "text/plain", { type: "string" }),
+        },
+      },
+      "/llms-full.txt": {
+        get: {
+          operationId: "getLlmsFull",
+          tags: ["Discovery"],
+          summary: "Get the entire documentation as one file",
+          description:
+            "Every documentation page concatenated as Markdown, around 880 kB. Use it to load the whole corpus at once; use `llms.txt` to navigate.",
+          responses: ok("The full documentation text.", "text/plain", { type: "string" }),
+        },
+      },
+      "/agent-setup.md": {
+        get: {
+          operationId: "getAgentSetup",
+          tags: ["Discovery"],
+          summary: "Get the setup prompt for a coding agent",
+          description:
+            "A paste-and-run prompt that installs the package, wires the stylesheet, and records the conventions an agent needs to write charts that compile.",
+          responses: ok("Setup instructions.", "text/markdown", { type: "string" }),
+        },
+      },
+      "/openapi.json": {
+        get: {
+          operationId: "getOpenApiDocument",
+          tags: ["Discovery"],
+          summary: "Get this description",
+          description:
+            "This document. Linked from every HTML and JSON response through the RFC 8631 `service-desc` link relation.",
+          responses: ok("This OpenAPI document.", "application/json", { type: "object" }),
+        },
+      },
+      "/.well-known/mcp/server-card.json": {
+        get: {
+          operationId: "getMcpServerCard",
+          tags: ["Discovery"],
+          summary: "Get the MCP server card",
+          description:
+            "How to run the microcharts MCP server, as the MCP registry's `server.json` manifest. Served at the path MCP's draft server-card proposal uses, which is where agents look; the document itself follows the released registry schema. The server is stdio, so a client spawns `npx -y @microcharts/mcp` rather than connecting over HTTP.",
+          responses: ok("MCP server card.", "application/json", {
+            $ref: "#/components/schemas/McpServerCard",
+          }),
+        },
+      },
+      "/": {
+        get: {
+          operationId: "getHomePage",
+          tags: ["Documentation"],
+          summary: "Get the home page, as HTML or Markdown",
+          description:
+            "Sends `Accept: text/markdown` and you get the Markdown twin from this same URL, which is also fetchable directly at `/index.md`. Every page route on this site behaves this way.",
+          parameters: [{ $ref: "#/components/parameters/Accept" }],
+          responses: {
+            "200": {
+              description: "The page, in the representation you asked for.",
+              headers: {
+                Vary: {
+                  description: "Always includes `Accept`, so caches key on it.",
+                  schema: { type: "string", examples: ["Accept, Accept-Encoding"] },
+                },
+              },
+              content: {
+                "text/html": { schema: { type: "string" } },
+                "text/markdown": { schema: { type: "string" } },
+              },
+            },
+          },
+        },
+      },
+      "/docs/charts/{slug}": {
+        get: {
+          operationId: "getChartPage",
+          tags: ["Documentation"],
+          summary: "Get a chart's documentation page",
+          description:
+            "The human page for one chart. Send `Accept: text/markdown` for the Markdown twin, or fetch `/docs/charts/{slug}.md` directly.",
+          parameters: [
+            { $ref: "#/components/parameters/ChartSlug" },
+            { $ref: "#/components/parameters/Accept" },
+          ],
+          responses: {
+            "200": {
+              description: "The page, in the representation you asked for.",
+              content: {
+                "text/html": { schema: { type: "string" } },
+                "text/markdown": { schema: { type: "string" } },
+              },
+            },
+            "404": { $ref: "#/components/responses/NotFound" },
+          },
+        },
+      },
+      "/docs/charts/{slug}.md": {
+        get: {
+          operationId: "getChartMarkdown",
+          tags: ["Documentation"],
+          summary: "Get a chart's documentation as Markdown",
+          description:
+            "The Markdown twin at its own URL, for clients that would rather not negotiate. Same bytes as `Accept: text/markdown` on the page.",
+          parameters: [{ $ref: "#/components/parameters/ChartSlug" }],
+          responses: {
+            ...ok("The page as Markdown.", "text/markdown", { type: "string" }),
+            "404": { $ref: "#/components/responses/NotFound" },
+          },
+        },
+      },
+      "/sitemap.xml": {
+        get: {
+          operationId: "getSitemap",
+          tags: ["Discovery"],
+          summary: "Get every indexable URL",
+          description:
+            "An XML sitemap with a real `lastmod` per URL, taken from the source file's last commit rather than build time.",
+          responses: ok("XML sitemap.", "application/xml", { type: "string" }),
+        },
+      },
+      "/rss.xml": {
+        get: {
+          operationId: "getFeed",
+          tags: ["Discovery"],
+          summary: "Get the release feed",
+          description:
+            "Every published version of the package as an Atom feed, newest first, with the changelog entry for each one. Poll this to notice a release without watching the repository.",
+          responses: ok("Atom feed.", "application/atom+xml", { type: "string" }),
+        },
+      },
+    },
+    components: {
+      parameters: {
+        ChartSlug: {
+          name: "slug",
+          in: "path",
+          required: true,
+          description: "The chart's slug, as listed by `listCharts`.",
+          schema: { type: "string", enum: slugs, examples: [exampleSlug] },
+        },
+        Accept: {
+          name: "Accept",
+          in: "header",
+          required: false,
+          description:
+            "`text/markdown` returns the Markdown twin; anything else, including `*/*`, returns HTML.",
+          schema: {
+            type: "string",
+            enum: ["text/html", "text/markdown"],
+            default: "text/html",
+            examples: ["text/markdown"],
+          },
+        },
+      },
+      responses: {
+        NotFound: {
+          description:
+            "Nothing is published at this URL. The body names the closest matching URLs and the site's entry points.",
+          content: PROBLEM_CONTENT,
+        },
+        MethodNotAllowed: {
+          description: "This site is read-only. The `Allow` header lists what it answers to.",
+          headers: {
+            Allow: { description: "Supported methods.", schema: { type: "string" } },
+          },
+          content: PROBLEM_CONTENT,
+        },
+      },
+      schemas: {
+        Problem: {
+          type: "object",
+          title: "Problem",
+          description:
+            "RFC 9457 problem details, extended with the members an agent acts on: a stable `code`, ordered `hints`, entry-point `links`, and `suggestions` — real URLs on this site that resemble the one requested.",
+          required: ["type", "title", "status", "detail", "code", "hints", "links"],
+          properties: {
+            type: { type: "string", format: "uri", description: "Where this error is documented." },
+            title: { type: "string", description: "Short, human-readable summary." },
+            status: { type: "integer", examples: [404] },
+            detail: { type: "string", description: "What happened, in one or two sentences." },
+            instance: { type: "string", description: "The path that produced this error." },
+            code: {
+              type: "string",
+              enum: ["not_found", "method_not_allowed", "not_acceptable"],
+              description: "Stable, matchable error code.",
+            },
+            error: {
+              type: "object",
+              description: "The same code and message, under the keys most SDKs reach for first.",
+              required: ["code", "message"],
+              properties: { code: { type: "string" }, message: { type: "string" } },
+            },
+            hints: {
+              type: "array",
+              description: "What to do next, most useful first.",
+              items: { type: "string" },
+            },
+            suggestions: {
+              type: "array",
+              description: "Real URLs on this site that look like the one requested.",
+              items: { type: "string", format: "uri" },
+            },
+            links: {
+              type: "array",
+              description: "Entry points that cover the rest of the site.",
+              items: {
+                type: "object",
+                required: ["rel", "title", "href"],
+                properties: {
+                  rel: { type: "string" },
+                  title: { type: "string" },
+                  href: { type: "string", format: "uri" },
+                },
+              },
+            },
+          },
+        },
+        ChartIndex: {
+          type: "object",
+          title: "ChartIndex",
+          description: "Every chart type in one line each.",
+          required: ["package", "count", "charts"],
+          properties: {
+            package: { type: "string", examples: [SITE.pkg] },
+            homepage: { type: "string", format: "uri" },
+            catalog: { type: "string", format: "uri", description: "The full catalog document." },
+            count: { type: "integer", description: "How many chart types ship." },
+            charts: {
+              type: "array",
+              items: {
+                type: "object",
+                required: ["name", "slug", "collection", "tagline", "api", "docs", "markdown"],
+                properties: {
+                  name: { type: "string", examples: ["Sparkline"] },
+                  slug: { type: "string", enum: slugs },
+                  status: { type: "string", enum: ["stable", "planned"] },
+                  collection: { type: "string" },
+                  tagline: { type: "string" },
+                  api: { type: "string", format: "uri", description: "This chart as JSON." },
+                  docs: { type: "string", format: "uri", description: "This chart's page." },
+                  markdown: {
+                    type: "string",
+                    format: "uri",
+                    description: "That page as Markdown.",
+                  },
+                },
+              },
+            },
+          },
+        },
+        ChartDocument: {
+          type: "object",
+          title: "ChartDocument",
+          description:
+            "One chart's full API surface. A chart's props are `sharedProps` plus `chart.props`; `howToRead` states how they combine.",
+          required: ["package", "howToRead", "sharedProps", "chart"],
+          properties: {
+            package: { type: "string", examples: [SITE.pkg] },
+            homepage: { type: "string", format: "uri" },
+            howToRead: { type: "string" },
+            api: { type: "string", format: "uri" },
+            docs: { type: "string", format: "uri" },
+            markdown: { type: "string", format: "uri" },
+            sharedProps: { $ref: SHARED_PROPS_REF },
+            chart: { $ref: CHART_ENTRY_REF },
+          },
+        },
+        McpServerCard: {
+          type: "object",
+          title: "McpServerCard",
+          description: "An MCP registry `server.json` document.",
+          required: ["name", "version", "packages"],
+          properties: {
+            $schema: { type: "string", format: "uri" },
+            name: { type: "string", examples: ["io.github.ganapativs/microcharts"] },
+            description: { type: "string" },
+            version: { type: "string" },
+            websiteUrl: { type: "string", format: "uri" },
+            repository: { type: "object" },
+            packages: {
+              type: "array",
+              description: "How to run the server. One npm package, over stdio.",
+              items: { type: "object" },
+            },
+          },
+        },
+      },
+    },
+  };
+}

--- a/apps/docs/src/lib/page-mirrors.test.ts
+++ b/apps/docs/src/lib/page-mirrors.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  brandMarkdown,
+  chartsMarkdown,
+  examplesMarkdown,
+  homeMarkdown,
+  notFoundMarkdown,
+} from "./page-mirrors.ts";
+import { STABLE_CHARTS } from "./catalog.ts";
+import { COLLECTIONS } from "./collections.ts";
+import { CATALOG } from "./docs-facts.ts";
+import { SHOWCASE } from "./showcase.ts";
+import { SITE } from "./site.ts";
+
+const MIRRORS = [
+  ["home", homeMarkdown()],
+  ["charts", chartsMarkdown()],
+  ["examples", examplesMarkdown()],
+  ["brand", brandMarkdown()],
+  ["404", notFoundMarkdown()],
+] as const;
+
+describe.each(MIRRORS)("the %s mirror", (_name, md) => {
+  it("opens with a single H1", () => {
+    expect(md.startsWith("# ")).toBe(true);
+    expect((md.match(/^# /gm) ?? []).length).toBe(1);
+  });
+
+  it("carries real content, not a stub", () => {
+    expect(md.length).toBeGreaterThan(500);
+  });
+
+  it("balances its code fences", () => {
+    expect((md.match(/```/g) ?? []).length % 2).toBe(0);
+  });
+
+  it("writes every link as absolute", () => {
+    for (const [, href] of md.matchAll(/\]\((.*?)\)/g)) {
+      expect(href.startsWith("https://"), href).toBe(true);
+    }
+  });
+
+  it("never links a path that cannot exist", () => {
+    for (const [, href] of md.matchAll(/\]\((https:\/\/microcharts\.dev.*?)\)/g)) {
+      expect(href, href).not.toContain("undefined");
+      expect(href, href).not.toMatch(/<slug>/);
+    }
+  });
+});
+
+describe("the home mirror", () => {
+  const md = homeMarkdown();
+
+  it("states the catalog size the rest of the site states", () => {
+    expect(md).toContain(`${CATALOG.total} chart types`);
+  });
+
+  it("shows an install line and a working import", () => {
+    expect(md).toContain(`npm i ${SITE.pkg}`);
+    expect(md).toContain(`import { Sparkline } from "${SITE.pkg}/sparkline"`);
+    expect(md).toContain(`import "${SITE.pkg}/styles.css"`);
+  });
+
+  it("points at the machine surfaces an agent needs next", () => {
+    for (const path of ["/llms.txt", "/catalog.json", "/openapi.json", "/api/charts.json"]) {
+      expect(md, path).toContain(`${SITE.url}${path}`);
+    }
+  });
+});
+
+describe("the charts mirror", () => {
+  const md = chartsMarkdown();
+
+  it("lists every shipped chart exactly once", () => {
+    for (const chart of STABLE_CHARTS) {
+      const link = `${SITE.url}/docs/charts/${chart.slug}.md`;
+      expect(md.split(link).length - 1, chart.slug).toBe(1);
+    }
+  });
+
+  it("files them under every collection", () => {
+    for (const collection of COLLECTIONS) expect(md).toContain(`### ${collection.label}`);
+  });
+});
+
+describe("the examples mirror", () => {
+  const md = examplesMarkdown();
+
+  it("covers every app in the showcase", () => {
+    for (const app of SHOWCASE) {
+      expect(md, app.slug).toContain(`### ${app.name}`);
+      expect(md, app.slug).toContain(app.url);
+    }
+  });
+});
+
+describe("the 404 mirror", () => {
+  const md = notFoundMarkdown();
+
+  it("does not pretend to know which URL missed", () => {
+    expect(md).toContain("the URL you requested");
+  });
+
+  it("still hands over the entry points", () => {
+    expect(md).toContain(`${SITE.url}/llms.txt`);
+    expect(md).toContain(`${SITE.url}/sitemap.xml`);
+  });
+});

--- a/apps/docs/src/lib/page-mirrors.ts
+++ b/apps/docs/src/lib/page-mirrors.ts
@@ -1,0 +1,151 @@
+/**
+ * Markdown twins for the pages that are React, not MDX.
+ *
+ * `scripts/gen-md.ts` mirrors everything under `content/docs`. The home page,
+ * the chart index, the examples and the brand page have no MDX behind them, so
+ * their twins are built here from the same registries the pages render from —
+ * `STABLE_CHARTS`, `COLLECTIONS`, `SHOWCASE`, `CATALOG` — and served by route
+ * handlers at `/index.md`, `/charts.md`, `/examples.md` and `/brand.md`.
+ *
+ * That matters for one specific caller: `Accept: text/markdown` on `/` used to
+ * fall through to HTML, because `/` had no twin to serve. Every page route on
+ * the site now negotiates.
+ */
+import { notFound, problemMarkdown } from "./agent-errors";
+import { STABLE_CHARTS } from "./catalog";
+import { COLLECTIONS } from "./collections";
+import { CATALOG, SIZE, SIZE_MARKETING } from "./docs-facts";
+import { SHOWCASE } from "./showcase";
+import { SITE, abs } from "./site";
+
+/** The block every twin ends with: where to go for the machine-readable set. */
+function machineSurfaces(): string {
+  return [
+    "## Machine-readable surfaces",
+    "",
+    `- [${abs("/llms.txt")}](${abs("/llms.txt")}) — index of this site, written for agents.`,
+    `- [${abs("/llms-full.txt")}](${abs("/llms-full.txt")}) — every documentation page as one file.`,
+    `- [${abs("/catalog.json")}](${abs("/catalog.json")}) — all ${CATALOG.total} chart types with props and data shapes.`,
+    `- [${abs("/api/charts.json")}](${abs("/api/charts.json")}) — the same catalog as an index, one chart per fetch.`,
+    `- [${abs("/openapi.json")}](${abs("/openapi.json")}) — OpenAPI 3.1 description of every endpoint here.`,
+    `- [${abs("/agent-setup.md")}](${abs("/agent-setup.md")}) — paste-and-run setup prompt for a coding agent.`,
+    "",
+    "Any page on this site answers `Accept: text/markdown` with its Markdown twin, and every twin is also fetchable by adding `.md` to the URL.",
+  ].join("\n");
+}
+
+/** `/` — what the library is, how to install it, where everything else lives. */
+export function homeMarkdown(): string {
+  return `# ${SITE.name} (${SITE.url})
+
+> ${SITE.description}
+
+microcharts renders charts small enough to sit inside a sentence, a table cell, a KPI card, or a streamed model reply. Each chart type is one import from its own subpath, so a page pays for the marks it uses and nothing else.
+
+## Install
+
+\`\`\`bash
+npm i ${SITE.pkg}
+\`\`\`
+
+## Render one
+
+\`\`\`tsx
+import { Sparkline } from "${SITE.pkg}/sparkline";
+import "${SITE.pkg}/styles.css";
+
+export function Revenue() {
+  return <Sparkline data={[128, 131, 129, 138, 141, 139, 148, 152]} title="Revenue" />;
+}
+\`\`\`
+
+Pass \`data\` and you get something correct. After that, \`domain\`, \`color\`, \`title\`, \`format\` and \`label\` mean the same thing on every chart.
+
+## What ships
+
+- **${CATALOG.total} chart types**, one grammar between them. Sparklines, bars, bullets, heat strips, box plots, donuts, hypnograms, and the rest of the catalog.
+- **Zero runtime dependencies.** React is the only peer. Scales, paths, easing, colour, statistics and summaries are all in-house.
+- **${SIZE_MARKETING}**, gzipped, per chart. The median static chart is ${SIZE.median} kB.
+- **Accessible by default.** Every chart is \`role="img"\` with a natural-language summary generated from the data. Direction and state are never colour alone.
+- **Server-component safe.** Default exports are hook-free pure SVG with zero client JavaScript. Interactivity is a separate \`/interactive\` import.
+
+## Read next
+
+- [Quickstart](${abs("/docs/quickstart")}) — install, wire the stylesheet, render the first chart.
+- [All charts](${abs("/docs/charts")}) — every type, filed by the question it answers.
+- [Chart index](${abs("/charts")}) — the catalog at a glance.
+- [When to use it](${abs("/docs/when-to-use")}) — and when a full chart library is the right call.
+- [AI-native](${abs("/docs/ai")}) — emitting charts from a model, and the MCP server.
+- [Examples](${abs("/examples")}) — seven deployed apps that install the package from npm.
+
+${machineSurfaces()}
+`;
+}
+
+/** `/charts` — the catalog, by collection. */
+export function chartsMarkdown(): string {
+  const shelves = COLLECTIONS.map((collection) => {
+    const rows = STABLE_CHARTS.filter((c) => c.collection === collection.key)
+      .map((c) => `- [${c.name}](${abs(`/docs/charts/${c.slug}.md`)}) — ${c.tagline}`)
+      .join("\n");
+    return `### ${collection.label}\n\n${collection.blurb}\n\n${rows}`;
+  }).join("\n\n");
+
+  return `# Chart index (${abs("/charts")})
+
+All ${CATALOG.total} chart types in \`${SITE.pkg}\`, filed by collection. Each link goes to that chart's documentation as Markdown; drop the \`.md\` for the page.
+
+Import a chart from its own subpath — \`${SITE.pkg}/sparkline\` — and add \`/interactive\` only when you need hover, keyboard, touch or selection.
+
+## Collections
+
+${shelves}
+
+${machineSurfaces()}
+`;
+}
+
+/** `/examples` — the deployed apps. */
+export function examplesMarkdown(): string {
+  const apps = SHOWCASE.map(
+    (app) =>
+      `### ${app.name}\n\n${app.blurb}\n\n${app.story}\n\n- Live: [${app.host}](${app.url})\n- Charts used: ${app.charts.length}\n- Detail page: [${abs(`/examples/${app.slug}`)}](${abs(`/examples/${app.slug}`)})`,
+  ).join("\n\n");
+
+  return `# Examples (${abs("/examples")})
+
+${SHOWCASE.length} independent apps, each deployed and each installing \`${SITE.pkg}\` from npm the way you would. Between them they render every chart type in the catalog. The source for all of them sits in the repository beside the running site.
+
+${apps}
+
+${machineSurfaces()}
+`;
+}
+
+/** `/brand` — the assets and how they may be used. */
+export function brandMarkdown(): string {
+  return `# Brand (${abs("/brand")})
+
+Logos, wordmarks and colour for writing about microcharts. The full set, including PNG exports, is on the [brand page](${abs("/brand")}) and in [microcharts-brand-kit.zip](${abs("/brand/microcharts-brand-kit.zip")}).
+
+## Assets
+
+- [Mark](${abs("/brand/mark.svg")}) — the glyph on its own. Adaptive, light, dark and monochrome cuts sit beside it.
+- [Wordmark](${abs("/brand/wordmark.svg")}) — the name set as a drawn path, so it needs no font.
+- [Lockup](${abs("/brand/lockup.svg")}) — mark and wordmark together, in the fixed relationship.
+
+## Using them
+
+- Keep the mark's proportions and its clear space. Do not recolour it outside the supplied cuts.
+- The name is lowercase, always: microcharts.
+- The package is \`${SITE.pkg}\`, and the site is ${SITE.url}.
+- Everything here is MIT licensed with the rest of the project. Attribution is welcome, not required.
+
+${machineSurfaces()}
+`;
+}
+
+/** `/404.md` — the recovery note, as a static file for hosts with no Worker. */
+export function notFoundMarkdown(): string {
+  return problemMarkdown(notFound({ path: null, origin: SITE.url }));
+}

--- a/apps/docs/src/lib/site.ts
+++ b/apps/docs/src/lib/site.ts
@@ -11,6 +11,10 @@ export const SITE = {
   pkg: "@microcharts/react",
   repo: "https://github.com/ganapativs/microcharts",
   npm: "https://www.npmjs.com/package/@microcharts/react",
+  /** The MCP server package — the other half of what this project publishes. */
+  npmMcp: "https://www.npmjs.com/package/@microcharts/mcp",
+  /** Published project contact, the same address SECURITY.md and package.json carry. */
+  email: "vsg.inbox@gmail.com",
   /** Third-party read on the published package — dependency count and the size
    *  of the root entry, measured by someone other than us. */
   bundlephobia: "https://bundlephobia.com/package/@microcharts/react",

--- a/apps/docs/src/lib/trust-pages.test.ts
+++ b/apps/docs/src/lib/trust-pages.test.ts
@@ -1,0 +1,105 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  CONTACT_PAGE,
+  GA_PROPERTY,
+  PRIVACY_PAGE,
+  STORAGE_KEYS,
+  THIRD_PARTIES,
+  trustPageMarkdown,
+  type TrustPage,
+} from "./trust-pages.ts";
+import { SITE } from "./site.ts";
+
+const read = (rel: string) => readFileSync(fileURLToPath(new URL(rel, import.meta.url)), "utf8");
+
+describe.each([
+  ["contact", CONTACT_PAGE, "/contact"],
+  ["privacy", PRIVACY_PAGE, "/privacy"],
+])("%s page", (_name, page: TrustPage, path) => {
+  const md = trustPageMarkdown(page, `${SITE.url}${path}`);
+
+  it("carries enough substance to answer the question it names", () => {
+    expect(md.length).toBeGreaterThan(500);
+  });
+
+  it("opens with an H1 and keeps one heading per section", () => {
+    expect(md.startsWith(`# ${page.title} (`)).toBe(true);
+    expect((md.match(/^## /gm) ?? []).length).toBe(page.sections.length);
+  });
+
+  it("gives every section a unique anchor", () => {
+    const ids = page.sections.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const id of ids) expect(id).toMatch(/^[a-z][a-z-]*$/);
+  });
+
+  it("closes every inline construct it opens", () => {
+    for (const block of page.sections.flatMap((s) => s.blocks)) {
+      const text = "p" in block ? block.p : block.list.join(" ");
+      expect((text.match(/`/g) ?? []).length % 2, text).toBe(0);
+      expect((text.match(/\[/g) ?? []).length).toBe((text.match(/\]\(/g) ?? []).length);
+    }
+  });
+
+  it("links only to real destinations", () => {
+    for (const [, href] of md.matchAll(/\]\((.*?)\)/g)) {
+      expect(href.startsWith("https://") || href.startsWith("/"), href).toBe(true);
+    }
+  });
+});
+
+describe("contact routes", () => {
+  it("names the issue tracker and the private security channel", () => {
+    const md = trustPageMarkdown(CONTACT_PAGE, `${SITE.url}/contact`);
+    expect(md).toContain(`${SITE.repo}/issues`);
+    expect(md).toContain(`${SITE.repo}/security/advisories/new`);
+    expect(md).toContain(SITE.email);
+  });
+
+  it("uses the address SECURITY.md publishes", () => {
+    expect(read("../../../../SECURITY.md")).toContain(SITE.email);
+  });
+});
+
+/**
+ * The privacy page is only worth publishing if it is true. Each claim is
+ * checked against the component that would make it false, so adding a tracker
+ * or a storage key without updating the page fails here.
+ */
+describe("privacy claims match the code", () => {
+  const analytics = read("../components/analytics.tsx");
+  const githubStars = read("../components/github-stars.tsx");
+  const md = trustPageMarkdown(PRIVACY_PAGE, `${SITE.url}/privacy`);
+
+  it("names the analytics property the site actually loads", () => {
+    expect(analytics).toContain(GA_PROPERTY);
+    expect(md).toContain(GA_PROPERTY);
+  });
+
+  it("names every third-party host a page can call", () => {
+    for (const { host } of THIRD_PARTIES) expect(md).toContain(host);
+    expect(analytics).toContain("googletagmanager.com");
+    expect(githubStars).toContain("api.github.com");
+  });
+
+  it("declares no host the code does not call", () => {
+    const source = [analytics, githubStars, read("../components/ui/stackblitz-sandbox.tsx")].join(
+      "\n",
+    );
+    for (const { host } of THIRD_PARTIES) {
+      const root = host.split(".").slice(-2).join(".");
+      expect(source, host).toContain(root);
+    }
+  });
+
+  it("lists every localStorage key the site writes", () => {
+    for (const key of STORAGE_KEYS) expect(md, key).toContain(key);
+    expect(githubStars).toContain("mc-gh-stars");
+  });
+
+  it("states that the package itself collects nothing", () => {
+    expect(md).toContain("zero runtime dependencies");
+  });
+});

--- a/apps/docs/src/lib/trust-pages.ts
+++ b/apps/docs/src/lib/trust-pages.ts
@@ -1,0 +1,224 @@
+/**
+ * `/contact` and `/privacy`, written once.
+ *
+ * Both pages render from these structures, and both Markdown twins
+ * (`/contact.md`, `/privacy.md`) serialize from them — so the page a reader
+ * sees and the file an agent fetches cannot drift. The prose accepts a small
+ * Markdown subset, `[label](href)` and `` `code` ``, rendered by
+ * `components/prose-doc.tsx` and passed through verbatim into Markdown.
+ *
+ * Every claim on the privacy page is checked against the code in
+ * `trust-pages.test.ts`: the analytics property, the third-party hosts, and the
+ * `localStorage` keys are read out of the components that set them, so a new
+ * tracker cannot ship while the page still says there isn't one.
+ */
+import { CATALOG } from "./docs-facts";
+import { SITE } from "./site";
+
+export type Block = { p: string } | { list: string[] };
+
+export type Section = {
+  heading: string;
+  /** Anchor id — stable, referenced from other pages. */
+  id: string;
+  blocks: Block[];
+};
+
+export type TrustPage = {
+  title: string;
+  /** Meta description: one plain, page-specific sentence. */
+  description: string;
+  /** The lede, above the first heading. */
+  intro: string;
+  sections: Section[];
+};
+
+/** The Google Analytics 4 property this site loads. Mirrors `components/analytics.tsx`. */
+export const GA_PROPERTY = "G-LN11CCKKTW";
+
+/** Hosts a page here can call at runtime, and why. */
+export const THIRD_PARTIES = [
+  {
+    host: "www.googletagmanager.com",
+    what: `Google Analytics 4 (property ${GA_PROPERTY}), loaded on every page.`,
+  },
+  {
+    host: "api.github.com",
+    what: "One unauthenticated call for the repository's star count, cached in your browser for six hours.",
+  },
+  {
+    host: "stackblitz.com",
+    what: "Only when you open an example in StackBlitz, which loads that editor in a frame.",
+  },
+] as const;
+
+/** Keys this site writes to `localStorage`, all first-party, all preferences. */
+export const STORAGE_KEYS = ["mc-accent", "mc-preset", "mc-gh-stars", "theme"] as const;
+
+export const CONTACT_PAGE: TrustPage = {
+  title: "Contact",
+  description:
+    "How to report a bug, propose a chart type, or report a security issue in microcharts.",
+  intro:
+    "microcharts is an open-source project maintained in the open. Everything below reaches the maintainer; the issue tracker reaches them fastest.",
+  sections: [
+    {
+      heading: "Report a bug",
+      id: "bugs",
+      blocks: [
+        {
+          p: `Open an issue at [${SITE.repo}/issues](${SITE.repo}/issues). Include the chart, the props you passed, the React version, and whether it rendered on the server, the client, or both.`,
+        },
+        {
+          p: "A minimal reproduction closes a bug faster than a description of one. The examples in the repository are a working starting point.",
+        },
+      ],
+    },
+    {
+      heading: "Propose a chart type or a prop",
+      id: "proposals",
+      blocks: [
+        {
+          p: `Open an issue first, before writing code. The catalog is deliberately bounded, so a new type has to clear the admission bar: a data story the existing ${CATALOG.total} types cannot already tell, one honest encoding channel, and readability at 200×60 px without training.`,
+        },
+        {
+          p: `The same applies to new props. \`CONTRIBUTING.md\` in the repository carries the full policy, and [/docs/design-notes](${SITE.url}/docs/design-notes) explains what has already been ruled out and why.`,
+        },
+      ],
+    },
+    {
+      heading: "Report a security issue",
+      id: "security",
+      blocks: [
+        {
+          p: `Do not open a public issue. Report privately through [GitHub's private vulnerability reporting](${SITE.repo}/security/advisories/new), or email **vsg.inbox@gmail.com**.`,
+        },
+        {
+          p: "You get an acknowledgement within a few days. Once a fix ships, the advisory is disclosed with credit to the reporter unless you prefer to stay anonymous.",
+        },
+      ],
+    },
+    {
+      heading: "Follow releases",
+      id: "releases",
+      blocks: [
+        {
+          list: [
+            `[${SITE.url}/rss.xml](${SITE.url}/rss.xml) — every release as an Atom feed.`,
+            `[${SITE.npm}](${SITE.npm}) — the published package.`,
+            `[${SITE.repo}/releases](${SITE.repo}/releases) — release notes and changelogs.`,
+          ],
+        },
+      ],
+    },
+    {
+      heading: "Who maintains this",
+      id: "maintainer",
+      blocks: [
+        {
+          p: `${SITE.author} ([${SITE.authorUrl}](${SITE.authorUrl})), on [GitHub](${SITE.authorGithub}) and [X](${SITE.authorX}). microcharts is MIT licensed.`,
+        },
+      ],
+    },
+    {
+      heading: "For agents",
+      id: "agents",
+      blocks: [
+        {
+          p: `This page has a Markdown twin at [${SITE.url}/contact.md](${SITE.url}/contact.md), and the same contact details appear in the \`info.contact\` object of [${SITE.url}/openapi.json](${SITE.url}/openapi.json).`,
+        },
+      ],
+    },
+  ],
+};
+
+export const PRIVACY_PAGE: TrustPage = {
+  title: "Privacy",
+  description:
+    "What microcharts.dev collects, what it stores in your browser, and who else sees a request.",
+  intro:
+    "microcharts.dev is a static documentation site. It has no accounts, no sign-in, no forms, and no payments, so there is nothing here to hand over. What follows is everything the site does that touches you.",
+  sections: [
+    {
+      heading: "What is collected",
+      id: "collected",
+      blocks: [
+        {
+          p: `This site loads Google Analytics 4 (property \`${GA_PROPERTY}\`) on every page. It records page views, plus four interactions: clicking a call to action, following a link off this site, copying a code block, and opening search. Those events carry the page path and the link involved, and nothing you type.`,
+        },
+        {
+          p: "Google Analytics sets its own cookies and processes the request under Google's terms. Block it with any content blocker, or with your browser's Do Not Track setting, and the site works exactly the same — nothing here depends on analytics.",
+        },
+        {
+          p: "The npm package itself collects nothing. It ships zero runtime dependencies and makes no network requests, on the server or in the browser.",
+        },
+      ],
+    },
+    {
+      heading: "What is stored in your browser",
+      id: "storage",
+      blocks: [
+        {
+          p: "Four `localStorage` keys, all first-party, all preferences. None of them is sent anywhere.",
+        },
+        {
+          list: [
+            "`mc-accent` and `mc-preset` — the accent colour and chart preset you picked, so the page paints them before the first frame on your next visit.",
+            "`theme` — light, dark, or system.",
+            "`mc-gh-stars` — the repository's star count, cached for six hours so the navigation makes one API call per session rather than one per page.",
+          ],
+        },
+      ],
+    },
+    {
+      heading: "Who else sees a request",
+      id: "third-parties",
+      blocks: [
+        { p: "Three hosts, in the situations named:" },
+        {
+          list: THIRD_PARTIES.map((t) => `\`${t.host}\` — ${t.what}`),
+        },
+        {
+          p: "Fonts are not one of them. Every typeface is served from this domain: the two Google-hosted families are downloaded at build time and self-hosted, so reading a page sends no request to Google's font servers.",
+        },
+        {
+          p: "The site is served from Cloudflare's edge network, which processes the request in order to answer it.",
+        },
+      ],
+    },
+    {
+      heading: "Agents and crawlers",
+      id: "agents",
+      blocks: [
+        {
+          p: `Automated clients are welcome, and \`/robots.txt\` says so by name. Nothing on this site is rate-limited, gated, or fingerprinted, and no request is logged in a way that identifies a caller. Reading this site with \`Accept: text/markdown\` or fetching [${SITE.url}/llms.txt](${SITE.url}/llms.txt) is the intended use, not an edge case.`,
+        },
+      ],
+    },
+    {
+      heading: "Changes and questions",
+      id: "changes",
+      blocks: [
+        {
+          p: `This page changes when the site does, and its history is public in the repository. Ask about anything here at [${SITE.repo}/issues](${SITE.repo}/issues), or email **vsg.inbox@gmail.com**.`,
+        },
+      ],
+    },
+  ],
+};
+
+/** Serialize a trust page to the Markdown its twin serves. */
+export function trustPageMarkdown(page: TrustPage, url: string): string {
+  const lines = [`# ${page.title} (${url})`, "", page.intro, ""];
+  for (const section of page.sections) {
+    lines.push(`## ${section.heading}`, "");
+    for (const block of section.blocks) {
+      if ("p" in block) lines.push(block.p, "");
+      else {
+        for (const item of block.list) lines.push(`- ${item}`);
+        lines.push("");
+      }
+    }
+  }
+  return `${lines.join("\n").trimEnd()}\n`;
+}

--- a/apps/docs/worker.test.ts
+++ b/apps/docs/worker.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from "vitest";
+import worker from "./worker.ts";
+
+/**
+ * The Worker, exercised against a stand-in for Cloudflare's asset store.
+ *
+ * `fakeAssets` reproduces the two behaviours `wrangler.jsonc` configures and
+ * the Worker leans on: `html_handling: "auto-trailing-slash"` (a clean route
+ * resolves to `<route>.html`) and `not_found_handling: "404-page"` (a miss is
+ * the 404 page with a 404 status). Everything else — negotiation, error
+ * format, redirects, headers — is the Worker's own code running for real.
+ */
+const FILES: Record<string, string> = {
+  "/index.html": "<html><h1>microcharts</h1></html>",
+  "/index.md": "# microcharts (https://microcharts.dev)\n\nWord-sized charts.\n",
+  "/charts.html": "<html><h1>Chart index</h1></html>",
+  "/charts.md": "# Chart index\n",
+  "/charts/core.html": "<html><h1>Core</h1></html>",
+  "/docs/ai.html": "<html><h1>AI-native</h1></html>",
+  "/docs/ai.md": "# AI-native (https://microcharts.dev/docs/ai)\n",
+  "/404.html": "<html><h1>This page doesn't exist</h1></html>",
+  "/404.md": "# 404 — no page at this URL\n",
+  "/catalog.json": '{"package":"@microcharts/react"}',
+  "/api/search": '{"index":[]}',
+  "/openapi.json": '{"openapi":"3.1.1"}',
+  "/brand/mark.svg": "<svg/>",
+  "/sitemap.xml": [
+    "<urlset>",
+    "<url><loc>https://microcharts.dev/docs</loc></url>",
+    "<url><loc>https://microcharts.dev/docs/charts/sparkline</loc></url>",
+    "<url><loc>https://microcharts.dev/docs/quickstart</loc></url>",
+    "<url><loc>https://microcharts.dev/charts</loc></url>",
+    "</urlset>",
+  ].join(""),
+};
+
+const env = {
+  ASSETS: {
+    async fetch(request: Request): Promise<Response> {
+      const path = new URL(request.url).pathname;
+      const clean = path.length > 1 && path.endsWith("/") ? path.slice(0, -1) : path;
+
+      const hit = FILES[clean] ?? FILES[clean === "/" ? "/index.html" : `${clean}.html`];
+      if (hit != null) {
+        const type = clean.endsWith(".json")
+          ? "application/json"
+          : clean.endsWith(".md")
+            ? "text/markdown"
+            : clean.endsWith(".xml")
+              ? "application/xml"
+              : clean.endsWith(".svg")
+                ? "image/svg+xml"
+                : "text/html";
+        return new Response(hit, { status: 200, headers: { "Content-Type": type } });
+      }
+      return new Response(FILES["/404.html"], {
+        status: 404,
+        headers: { "Content-Type": "text/html" },
+      });
+    },
+  },
+};
+
+const BROWSER = "text/html,application/xhtml+xml,image/avif,image/webp,*/*;q=0.8";
+
+function get(path: string, accept?: string | null, method = "GET"): Promise<Response> {
+  const headers = accept == null ? undefined : { Accept: accept };
+  return worker.fetch(new Request(`https://microcharts.dev${path}`, { method, headers }), env);
+}
+
+describe("markdown negotiation", () => {
+  it("serves the home page's twin on `Accept: text/markdown`", async () => {
+    const res = await get("/", "text/markdown");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("text/markdown; charset=utf-8");
+    expect(await res.text()).toContain("# microcharts");
+  });
+
+  it("varies on Accept and Accept-Encoding, in both representations", async () => {
+    for (const accept of ["text/markdown", BROWSER]) {
+      const vary = (await get("/", accept)).headers.get("Vary") ?? "";
+      expect(vary.toLowerCase()).toContain("accept");
+      expect(vary.toLowerCase()).toContain("accept-encoding");
+    }
+  });
+
+  it("negotiates every page route, not just /docs", async () => {
+    expect(await (await get("/charts", "text/markdown")).text()).toContain("# Chart index");
+    expect(await (await get("/docs/ai", "text/markdown")).text()).toContain("# AI-native");
+  });
+
+  it("names the twin it served in Content-Location", async () => {
+    expect((await get("/", "text/markdown")).headers.get("Content-Location")).toBe("/index.md");
+  });
+
+  it("keeps browsers and wildcard clients on HTML", async () => {
+    for (const accept of [BROWSER, "*/*", null]) {
+      const res = await get("/", accept);
+      expect(res.status).toBe(200);
+      expect(await res.text()).toContain("<h1>microcharts</h1>");
+    }
+  });
+
+  it("respects q=0 on markdown", async () => {
+    const res = await get("/", "text/markdown;q=0, text/html");
+    expect(await res.text()).toContain("<h1>microcharts</h1>");
+  });
+
+  it("406s a markdown-only client on a page with no twin", async () => {
+    const res = await get("/charts/core", "text/markdown");
+    expect(res.status).toBe(406);
+    expect(res.headers.get("Content-Type")).toBe("text/markdown; charset=utf-8");
+    expect(res.headers.get("Vary")?.toLowerCase()).toContain("accept");
+  });
+
+  it("406s a client that accepts neither representation", async () => {
+    const res = await get("/", "application/json");
+    expect(res.status).toBe(406);
+    expect(res.headers.get("Content-Type")).toBe("application/problem+json; charset=utf-8");
+    expect((await res.json()).code).toBe("not_acceptable");
+  });
+
+  it("advertises the OpenAPI description on page responses", async () => {
+    const link = (await get("/", BROWSER)).headers.get("Link") ?? "";
+    expect(link).toContain('rel="service-desc"');
+    expect(link).toContain("/openapi.json");
+  });
+});
+
+describe("404s", () => {
+  it("keeps the designed page for browsers, and points them at the twin", async () => {
+    const res = await get("/nope", BROWSER);
+    expect(res.status).toBe(404);
+    expect(await res.text()).toContain("This page doesn't exist");
+    expect(res.headers.get("Link")).toContain("/404.md");
+  });
+
+  it("answers a scripted client with a short markdown recovery note", async () => {
+    const res = await get("/nope", "*/*");
+    expect(res.status).toBe(404);
+    expect(res.headers.get("Content-Type")).toBe("text/markdown; charset=utf-8");
+
+    const body = await res.text();
+    expect(body.startsWith("# 404 — ")).toBe(true);
+    expect(body).toContain("/nope");
+    expect(body).toContain("https://microcharts.dev/llms.txt");
+    expect(body).toContain("https://microcharts.dev/sitemap.xml");
+    expect(body).toContain("https://microcharts.dev/docs");
+    expect(body.length).toBeLessThan(2000);
+  });
+
+  it("suggests the closest real URLs, read from the sitemap", async () => {
+    const body = await (await get("/docs/charts/sparklines", "*/*")).text();
+    expect(body).toContain("## Closest matches");
+    expect(body).toContain("https://microcharts.dev/docs/charts/sparkline");
+  });
+
+  it("answers the JSON surface with problem details", async () => {
+    const res = await get("/api/charts/nope.json", "*/*");
+    expect(res.status).toBe(404);
+    expect(res.headers.get("Content-Type")).toBe("application/problem+json; charset=utf-8");
+
+    const body = await res.json();
+    expect(body.status).toBe(404);
+    expect(body.code).toBe("not_found");
+    expect(body.error.message).toBeTruthy();
+    expect(body.hints.length).toBeGreaterThan(0);
+    expect(body.links.some((l: { href: string }) => l.href.endsWith("/openapi.json"))).toBe(true);
+  });
+
+  it("answers an explicit JSON ask in JSON, on any path", async () => {
+    const res = await get("/nope", "application/json");
+    expect(res.headers.get("Content-Type")).toBe("application/problem+json; charset=utf-8");
+    expect((await res.json()).status).toBe(404);
+  });
+
+  it("never caches an error", async () => {
+    expect((await get("/nope", "*/*")).headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("leaves a missing binary asset to the asset store", async () => {
+    const res = await get("/brand/missing.woff2", "*/*");
+    expect(res.status).toBe(404);
+    expect(res.headers.get("Content-Type")).toContain("text/html");
+  });
+});
+
+describe("methods", () => {
+  it("405s a write with problem details and an Allow header", async () => {
+    const res = await get("/api/search", "*/*", "POST");
+    expect(res.status).toBe(405);
+    expect(res.headers.get("Allow")).toBe("GET, HEAD, OPTIONS");
+    expect(res.headers.get("Content-Type")).toBe("application/problem+json; charset=utf-8");
+
+    const body = await res.json();
+    expect(body.code).toBe("method_not_allowed");
+    expect(body.detail).toContain("POST");
+  });
+
+  it("answers OPTIONS with what it allows", async () => {
+    const res = await get("/", "*/*", "OPTIONS");
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Allow")).toBe("GET, HEAD, OPTIONS");
+  });
+
+  it("HEAD carries the headers and no body", async () => {
+    const res = await get("/", "text/markdown", "HEAD");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("text/markdown; charset=utf-8");
+    expect(await res.text()).toBe("");
+  });
+});
+
+describe("redirects and content types", () => {
+  it("redirects /gallery with a real 301", async () => {
+    const res = await get("/gallery", BROWSER);
+    expect(res.status).toBe(301);
+    expect(res.headers.get("Location")).toBe("https://microcharts.dev/charts");
+  });
+
+  it("names the type of the extensionless API files", async () => {
+    const res = await get("/api/search", "*/*");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("application/json; charset=utf-8");
+  });
+
+  it("passes a real asset through untouched", async () => {
+    const res = await get("/brand/mark.svg", BROWSER);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("image/svg+xml");
+  });
+});

--- a/apps/docs/worker.ts
+++ b/apps/docs/worker.ts
@@ -1,73 +1,227 @@
 /**
- * Cloudflare Worker fronting the static-exported docs (`./out`), adding
- * `Accept: text/markdown` content negotiation per https://acceptmarkdown.com.
+ * Cloudflare Worker fronting the static-exported docs (`./out`).
  *
- * It runs *only* on `/docs/*` (see `run_worker_first` in `wrangler.jsonc`); every
- * other path is served straight from the edge with no Worker cost. On a doc
- * route it inspects `Accept` and, when the client prefers Markdown, streams the
- * pre-generated `.md` mirror inline from the asset store. Browsers and
- * no-preference clients fall through to the HTML page unchanged, save for an
- * added `Vary: Accept` so shared caches key on the header.
+ * The site is static HTML on a CDN; this Worker adds the four behaviours a
+ * static host cannot express, all of them for the benefit of a caller that is
+ * not a browser:
  *
- * The static `.md` mirrors (`/docs/<slug>.md`) remain the host-agnostic
- * fallback: this Worker is a Cloudflare-only enhancement, not a dependency.
+ * 1. **Markdown negotiation** (https://acceptmarkdown.com) on every page route,
+ *    not just `/docs/*` — `Accept: text/markdown` streams the pre-generated
+ *    `.md` mirror from the same URL, and every negotiated response carries
+ *    `Vary: Accept, Accept-Encoding` so a shared cache keys on the header.
+ * 2. **Errors a caller can act on** — a 404 answers in the caller's own format:
+ *    RFC 9457 problem details on the JSON surface, a short Markdown note with
+ *    real links (and closest-match URLs read from `sitemap.xml`) for any other
+ *    scripted client, the designed HTML page for browsers.
+ * 3. **A real 301 for `/gallery`**, whose static page can only meta-refresh —
+ *    a stub no non-JS client follows.
+ * 4. **Honest content types on `/api/*`**, whose files are extensionless in the
+ *    export and would otherwise be sniffed.
+ *
+ * Browsers are unaffected: same HTML, same status, two extra response headers.
+ * Everything here is additive — the `.md` mirrors, `/404.md` and the static
+ * `/gallery` page all keep working on a host with no Worker at all.
  */
-import { markdownAssetFor, negotiate } from "./src/lib/content-negotiation.ts";
+import {
+  acceptsHtml,
+  errorFormat,
+  isApiPath,
+  markdownAssetFor,
+  negotiate,
+  rewritableError,
+} from "./src/lib/content-negotiation.ts";
+import {
+  methodNotAllowed,
+  notAcceptable,
+  notFound,
+  problemJson,
+  problemMarkdown,
+  suggestRoutes,
+  type Problem,
+} from "./src/lib/agent-errors.ts";
 
 interface Env {
   ASSETS: { fetch: (request: Request) => Promise<Response> };
 }
 
+const READ_METHODS = new Set(["GET", "HEAD"]);
+const ALLOW = ["GET", "HEAD", "OPTIONS"];
+
 /** Append a token to an existing `Vary` header without duplicating it. */
-function addVary(headers: Headers, token: string): void {
-  const existing = headers.get("Vary");
-  if (!existing) {
-    headers.set("Vary", token);
-    return;
+function addVary(headers: Headers, ...tokens: string[]): void {
+  for (const token of tokens) {
+    const existing = headers.get("Vary");
+    if (!existing) {
+      headers.set("Vary", token);
+      continue;
+    }
+    const has = existing.split(",").some((t) => t.trim().toLowerCase() === token.toLowerCase());
+    if (!has) headers.set("Vary", `${existing}, ${token}`);
   }
-  const has = existing.split(",").some((t) => t.trim().toLowerCase() === token.toLowerCase());
-  if (!has) headers.set("Vary", `${existing}, ${token}`);
+}
+
+/** Advertise the OpenAPI description, per the RFC 8631 `service-desc` relation. */
+function addServiceDesc(headers: Headers, origin: string): void {
+  const link = `<${origin}/openapi.json>; rel="service-desc"; type="application/json"`;
+  const existing = headers.get("Link");
+  headers.set("Link", existing ? `${existing}, ${link}` : link);
+}
+
+/** Advertise the Markdown twin of a page route. */
+function addMarkdownAlternate(headers: Headers, origin: string, mdPath: string): void {
+  const link = `<${origin}${mdPath}>; rel="alternate"; type="text/markdown"`;
+  const existing = headers.get("Link");
+  headers.set("Link", existing ? `${existing}, ${link}` : link);
+}
+
+/** Body only on GET; a HEAD response carries the headers and nothing else. */
+function bodyFor(method: string, body: BodyInit | null): BodyInit | null {
+  return method === "HEAD" ? null : body;
+}
+
+/** Render a problem in the format the caller asked for. */
+function problemResponse(
+  problem: Problem,
+  format: "json" | "markdown",
+  method: string,
+  origin: string,
+): Response {
+  const headers = new Headers();
+  addVary(headers, "Accept", "Accept-Encoding");
+  addServiceDesc(headers, origin);
+  headers.set("Cache-Control", "no-store");
+  if (problem.allow) headers.set("Allow", problem.allow.join(", "));
+
+  const [type, body] =
+    format === "json"
+      ? (["application/problem+json; charset=utf-8", problemJson(problem, origin)] as const)
+      : (["text/markdown; charset=utf-8", problemMarkdown(problem)] as const);
+  headers.set("Content-Type", type);
+
+  return new Response(bodyFor(method, body), { status: problem.status, headers });
+}
+
+/**
+ * Every `<loc>` in the deployed sitemap, as site-relative paths, memoised for
+ * the life of the isolate. Read only when a 404 needs closest-match
+ * suggestions, so the common path never pays for it; a failure here costs the
+ * suggestions and nothing else.
+ */
+let routeCache: Promise<string[]> | null = null;
+function knownRoutes(env: Env, origin: string): Promise<string[]> {
+  routeCache ??= env.ASSETS.fetch(new Request(`${origin}/sitemap.xml`))
+    .then(async (res) => {
+      if (!res.ok) return [];
+      const xml = await res.text();
+      return [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => {
+        try {
+          return new URL(m[1]).pathname;
+        } catch {
+          return m[1];
+        }
+      });
+    })
+    .catch(() => []);
+  return routeCache;
 }
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
-    const isRead = request.method === "GET" || request.method === "HEAD";
     const url = new URL(request.url);
-    const mdPath = isRead ? markdownAssetFor(url.pathname) : null;
+    const { origin, pathname } = url;
+    const method = request.method;
+    const accept = request.headers.get("Accept");
 
-    // Not a negotiable doc route → hand straight to the asset store.
-    if (mdPath == null) return env.ASSETS.fetch(request);
-
-    // Probe whether a mirror actually exists for this route.
-    const mirrorURL = new URL(url);
-    mirrorURL.pathname = mdPath;
-    const mirror = await env.ASSETS.fetch(new Request(mirrorURL, { method: "GET" }));
-    const hasMarkdown = mirror.ok;
-
-    const decision = negotiate(request.headers.get("Accept"), hasMarkdown);
-
-    if (decision === "markdown") {
-      const headers = new Headers(mirror.headers);
-      headers.set("Content-Type", "text/markdown; charset=utf-8");
-      addVary(headers, "Accept");
-      const body = request.method === "HEAD" ? null : mirror.body;
-      return new Response(body, { status: 200, headers });
+    // OPTIONS is a capability question, and the answer is the same everywhere:
+    // this site is readable and nothing else.
+    if (method === "OPTIONS") {
+      return new Response(null, { status: 204, headers: { Allow: ALLOW.join(", ") } });
     }
 
-    if (decision === "not-acceptable") {
-      return new Response("Not Acceptable\n", {
-        status: 406,
-        headers: { "Content-Type": "text/plain; charset=utf-8", Vary: "Accept" },
+    // A write to a read-only site. Answer in JSON rather than letting the asset
+    // store decide, so a caller that POSTs an endpoint learns why it failed.
+    if (!READ_METHODS.has(method)) {
+      const problem = methodNotAllowed({ path: pathname, origin, method, allow: ALLOW });
+      // A write is never a browser navigation, so HTML is not on the menu here.
+      const format = errorFormat(accept, pathname) === "markdown" ? "markdown" : "json";
+      return problemResponse(problem, format, method, origin);
+    }
+
+    // `/gallery` is a legacy URL whose static page can only meta-refresh to
+    // `/charts`. At the edge it can be the real redirect it always meant.
+    if (pathname === "/gallery" || pathname === "/gallery/") {
+      return new Response(null, {
+        status: 301,
+        headers: { Location: `${origin}/charts`, "Cache-Control": "public, max-age=3600" },
       });
     }
 
-    // HTML: serve the page, advertising that this URL also negotiates Markdown.
-    const page = await env.ASSETS.fetch(request);
-    const headers = new Headers(page.headers);
-    addVary(headers, "Accept");
-    return new Response(request.method === "HEAD" ? null : page.body, {
-      status: page.status,
-      statusText: page.statusText,
+    const mdPath = markdownAssetFor(pathname);
+
+    // Markdown was asked for by name: probe the mirror, and serve it if it exists.
+    if (mdPath != null && negotiate(accept, true) === "markdown") {
+      const mirrorURL = new URL(url);
+      mirrorURL.pathname = mdPath;
+      const mirror = await env.ASSETS.fetch(new Request(mirrorURL, { method: "GET" }));
+
+      if (mirror.ok) {
+        const headers = new Headers(mirror.headers);
+        headers.set("Content-Type", "text/markdown; charset=utf-8");
+        headers.set("Content-Location", mdPath);
+        addVary(headers, "Accept", "Accept-Encoding");
+        addServiceDesc(headers, origin);
+        return new Response(bodyFor(method, mirror.body), { status: 200, headers });
+      }
+      // No mirror: fall through to HTML, or to the 406 below if this client
+      // cannot read HTML either.
+    }
+
+    const response = await env.ASSETS.fetch(request);
+
+    if (response.status === 404 && rewritableError(pathname)) {
+      const format = errorFormat(accept, pathname);
+      if (format === "html") {
+        // Browsers keep the designed page; the headers still point a parser at
+        // the Markdown twin of this error.
+        const headers = new Headers(response.headers);
+        addVary(headers, "Accept", "Accept-Encoding");
+        addMarkdownAlternate(headers, origin, "/404.md");
+        addServiceDesc(headers, origin);
+        return new Response(bodyFor(method, response.body), { status: 404, headers });
+      }
+
+      const suggestions = suggestRoutes(pathname, await knownRoutes(env, origin)).map(
+        (path) => `${origin}${path}`,
+      );
+      const problem = notFound({ path: pathname, origin, suggestions });
+      return problemResponse(problem, format, method, origin);
+    }
+
+    // The page exists and Markdown is off the table, so HTML is what is left.
+    // A client that cannot read it gets 406 — but only here, after the 404
+    // check, because "no such page" is the more useful answer when both apply.
+    if (mdPath != null && response.status === 200 && !acceptsHtml(accept)) {
+      const problem = notAcceptable({ path: pathname, origin, accept: accept ?? "" });
+      const format = errorFormat(accept, pathname) === "json" ? "json" : "markdown";
+      return problemResponse(problem, format, method, origin);
+    }
+
+    const headers = new Headers(response.headers);
+
+    // The export writes route handlers with no extension, so `/api/search` and
+    // friends arrive without a usable type. Name it.
+    if (isApiPath(pathname) && response.ok && !pathname.includes(".")) {
+      headers.set("Content-Type", "application/json; charset=utf-8");
+    }
+
+    if (mdPath != null) {
+      addVary(headers, "Accept", "Accept-Encoding");
+      addServiceDesc(headers, origin);
+    }
+
+    return new Response(bodyFor(method, response.body), {
+      status: response.status,
+      statusText: response.statusText,
       headers,
     });
   },

--- a/apps/docs/wrangler.jsonc
+++ b/apps/docs/wrangler.jsonc
@@ -1,9 +1,9 @@
 {
   // Cloudflare Workers Static Assets deploy for the static-exported docs site.
-  // Cloudflare serves ./out directly from the edge; a thin Worker
-  // (`worker.ts`) runs *only* on `/docs/*` to add `Accept: text/markdown`
-  // content negotiation (https://acceptmarkdown.com). Every other path is
-  // served straight from the edge with no Worker invocation.
+  // Cloudflare serves ./out directly from the edge; the Worker (`worker.ts`)
+  // adds the behaviours a static host cannot express — `Accept: text/markdown`
+  // negotiation (https://acceptmarkdown.com), errors an agent can act on, and a
+  // real 301 for `/gallery`.
   //   pnpm --filter @microcharts/docs cf:deploy
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "microcharts",
@@ -13,10 +13,13 @@
     "directory": "./out",
     // Bind the asset store so the Worker can read mirrors / fall through to pages.
     "binding": "ASSETS",
-    // Run the Worker ahead of asset serving on doc routes only (the bare
-    // `/docs` root plus every nested route).
-    "run_worker_first": ["/docs", "/docs/*"],
-    // Static export emits per-route index.html + a top-level 404.html.
+    // Run the Worker ahead of asset serving on everything a caller can navigate
+    // to or get a 404 from. The two exclusions are the trees where neither
+    // applies and the request volume is highest: content-hashed build output,
+    // and the generated Open Graph images.
+    "run_worker_first": ["/*", "!/_next/*", "!/og/*"],
+    // Static export emits `<route>.html` per route (trailingSlash: false) plus a
+    // top-level 404.html.
     "html_handling": "auto-trailing-slash",
     "not_found_handling": "404-page",
   },


### PR DESCRIPTION
## What & why

An agent reading microcharts.dev could see the pages but not operate the site: a wrong URL returned a designed HTML page with no machine-readable way out, `Accept: text/markdown` only worked under `/docs/*`, and nothing described the endpoints that were already there. This closes the five essential gaps the is-agentic/Ora audit found (score 63/100), plus the recommended ones that could be fixed honestly.

Browsers see no change: same HTML, same design, same status codes, two extra response headers.

Closes # <!-- none — requested directly by the maintainer as an audit follow-up -->

- [x] The linked issue was agreed before I wrote this — or this is one of the two documented exceptions

## Type

- [ ] Fix — behaviour was wrong
- [x] Feature — new capability or prop
- [ ] New chart type
- [x] Docs / examples
- [ ] Refactor / perf / internal
- [ ] Build, CI, or tooling
- [ ] Breaking change

## Surfaces touched

- [ ] `src/` — the library (`@microcharts/react`)
- [ ] `packages/mcp` — MCP server / AI-SDK tools
- [x] `apps/docs` — docs site
- [ ] `examples/`
- [ ] `scripts/`, `tests/`, `bench/`, CI

## What changed

**Errors answer in the caller's format.** `worker.ts` renders a 404 as RFC 9457 problem details on `/api/*` and `.json` paths, as a short Markdown note with recovery links everywhere else, and as the designed page for browsers. The Markdown note carries closest-match URLs read from `sitemap.xml`. A 405 carries `Allow`; a 406 arrives only when a request accepts neither representation, and never preempts a 404. `/404.md` is the static twin for hosts with no Worker.

**Markdown negotiation covers every page route**, not just `/docs/*`. `/`, `/charts`, `/examples`, `/brand`, `/contact` and `/privacy` get twins built from the same registries the pages render from, and every negotiated response carries `Vary: Accept, Accept-Encoding`. All four acceptmarkdown.com probes pass, including `q=0` falling back to HTML and an unsatisfiable `Accept` returning 406.

**`/openapi.json`** describes all 15 endpoints with a unique operation id, a description, typed parameters and a response schema on each. It is built from the chart registry, so it cannot document a chart the site does not serve, and the `Problem` schema it publishes is validated against the bodies the Worker actually renders.

**`/api/charts.json`** and **`/api/charts/{slug}.json`** slice the existing catalog: wiring one chart costs ~8 kB instead of the full catalog's 290 kB. Same shapes, one generator, no second data model.

**`/contact` and `/privacy`** are real pages, single-sourced with their Markdown twins. Every privacy claim — the analytics property, the three third-party hosts, the four `localStorage` keys — is tested against the code that would falsify it.

**`/gallery`** gets a real 301 instead of the meta-refresh stub no non-JS client follows.

Also: `Link: rel="service-desc"` (RFC 8631) on page and error responses, `contactPoint` on the Organization JSON-LD, the MCP registry `server.json` served at the well-known path, and honest content types on the extensionless `/api/*` files.

## Gates

- [x] `pnpm typecheck` · `pnpm lint` · `pnpm format:check` · `pnpm knip`
- [x] `pnpm build` succeeds
- [x] `pnpm gen:check` — all 12 generated artifacts match their sources
- [x] `pnpm vitest run --project core --project dom` — 5053 passed
- [x] `pnpm --filter @microcharts/docs test` — 3086 passed (61 files)
- [x] `pnpm vitest run --project browser` — green in CI on both React 18 and 19 (could not run in the authoring sandbox: it ships Chromium 1194, Playwright 1.62.1 wants 1234, and the download CDN is blocked; the diff contains no `src/` changes, so this project exercises nothing that moved)
- [x] `pnpm size` — `size-diff` reports every measured subpath byte-identical to `main`; no library code changed
- [x] Tests added for every behaviour changed
- [x] Zero new dependencies, runtime or dev
- [x] Conventional Commit subject ≤ 50 chars
- [x] Docs-only release — no changeset needed (`apps/docs` is private, `packages/mcp` untouched)

All 10 checks on this head are green, including the Cloudflare Workers Build, which exercises the new `wrangler.jsonc`.

## New tests

| File | Covers |
| --- | --- |
| `worker.test.ts` | The real handler against a stand-in asset store: negotiation, all four acceptmarkdown probes, 404/405/406 bodies, the 301, content types, HEAD, OPTIONS |
| `src/lib/agent-errors.test.ts` | Problem builders, RFC 9457 shape, Markdown rendering, suggestion scoring |
| `src/lib/openapi.test.ts` | Unique operation ids, a description and response schema on every operation, `$ref` resolution, and the published `Problem` schema validated (Ajv) against real error bodies |
| `src/lib/trust-pages.test.ts` | Privacy claims checked against `analytics.tsx`, `github-stars.tsx` and `SECURITY.md` |
| `src/lib/page-mirrors.test.ts` | Every mirror has one H1, absolute links, balanced fences, and the chart count the rest of the site states |
| `src/lib/agent-surface.test.ts` | Build-gated: every path the OpenAPI document advertises resolves in `out/`, and every URL `llms.txt` points at exists |
| `src/lib/content-negotiation.test.ts` | Extended for site-wide mirrors, error-format selection, and the 406 rule |

One note for reviewers: `agent-surface.test.ts` is gated on a real export, the same way `metadata.test.ts` already is. The `docs` CI job runs `pnpm build` (the library) but not `next build`, so those 21 assertions **skip in CI** and run only for someone who has built the site locally. Adding `pnpm --filter @microcharts/docs build` to that job would make them real; that is a CI-runtime call, so it is left out of this PR.

## Evidence

Verified against a real export behind `wrangler dev`:

```
$ curl -s -o /dev/null -w "%{http_code}" /some-path-that-does-not-exist
404

$ curl -sI -H 'Accept: text/markdown' /
HTTP/1.1 200 OK
Content-Type: text/markdown; charset=utf-8
Content-Location: /index.md
Vary: Accept, Accept-Encoding

$ curl -s -o /dev/null -w "%{http_code} %{content_type}" -H 'Accept: application/pdf' /
406 text/markdown; charset=utf-8

$ curl -s -X POST -o /dev/null -w "%{http_code} %{content_type}" /api/search
405 application/problem+json; charset=utf-8   # Allow: GET, HEAD, OPTIONS

$ curl -s -o /dev/null -w "%{http_code} %{redirect_url}" /gallery
301 /charts
```

A typo suggests the page (`/docs/charts/sparklines` → `/docs/charts/sparkline`); a nonsense path suggests nothing rather than three confident guesses. `/_next/static/*` still bypasses the Worker entirely and keeps its immutable cache header.

## Known limitation

**Content without JavaScript** stays partial, and the remaining fix is a product decision. The home page's raw HTML already has a valid outline — one `h1`, five `h2`, ten `h3` — and 16 kB of text. What the audit is reading is content efficiency: 673 kB of HTML for that 16 kB, of which 354 kB is the RSC hydration payload and 184 kB is the 171 live charts the page is *for*. There is no honest heading to add — the heading-less stretch is a specimen sheet and a code-fence sequence, and its visible text is captions and one kicker label, not section titles. Rather than invent headings to move a metric, this PR gives `/` a real Markdown twin, advertises it with `rel="alternate"`, and serves it on `Accept: text/markdown`. Getting the ratio itself above 5% would mean redesigning the specimen sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
