### PR TITLE
fix(deps): move the Playwright override to pnpm 11's settings home

### DIFF
--- a/package.json
+++ b/package.json
@@ -1233,10 +1233,5 @@
   "engines": {
     "node": ">=20"
   },
-  "packageManager": "pnpm@11.25.0+sha512.5cde925b4f075f725eb71fbae18a42ffe784524789f19b61c731cb8721ec28aaee160e01a8d5af4fedb2a42cdbf300efe23db356b0d4a17b4d63e11f8ab7c956",
-  "pnpm": {
-    "overrides": {
-      "playwright": "1.63.0"
-    }
-  }
+  "packageManager": "pnpm@11.25.0+sha512.5cde925b4f075f725eb71fbae18a42ffe784524789f19b61c731cb8721ec28aaee160e01a8d5af4fedb2a42cdbf300efe23db356b0d4a17b4d63e11f8ab7c956"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  playwright: 1.63.0
+
 importers:
 
   .:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,3 +37,15 @@ allowBuilds:
 peerDependencyRules:
   allowedVersions:
     "tsdown>typescript": "7"
+
+# One Playwright runtime, and only one. This repo pins `playwright` and
+# `@playwright/test` together with the CI container image (see ci.yml), but
+# `@vitest/browser-playwright` declares its peer as `playwright: "*"`, which
+# happily resolves a SECOND copy. Two runtimes in the tree and Playwright
+# collects nothing at all — "did not expect test() to be called here", 0 of 104
+# specs, on a message that names neither version.
+#
+# This lived in `package.json#pnpm.overrides` until pnpm 11.25, which stopped
+# reading that field (silently — an ignored override does not fail an install).
+overrides:
+  playwright: "1.63.0"


### PR DESCRIPTION
Caught while clearing the Renovate queue — a silent interaction between two PRs that both landed today.

#160 pinned a single Playwright runtime with `package.json#pnpm.overrides`, because `@vitest/browser-playwright` declares its peer as `playwright: "*"` and will otherwise resolve a second copy (two runtimes and Playwright collects **0 of 104** specs, on an error that names neither version).

#149 then bumped pnpm to 11.25, which **stopped reading `package.json#pnpm`**:

```
[WARN] The "pnpm" field in package.json is no longer read by pnpm.
The following keys were ignored: "pnpm.overrides".
```

An ignored override does not fail an install, so the pin has been inert since that bump. Nothing is broken right now — the lockfile still holds exactly one runtime because it was resolved while the override was honoured, and CI installs `--frozen-lockfile` — but the guard is gone, so the next resolution could quietly bring the duplicate back and take every browser leg with it.

Moves it to `pnpm-workspace.yaml`, which this repo already uses for pnpm 11 settings (`minimumReleaseAge`, `allowBuilds`, `peerDependencyRules`) and whose own comment says "pnpm 11 reads project settings from here". The dead `pnpm` field is removed from `package.json`.

`pnpm install` is now warning-free, `pnpm why playwright` reports one version, `playwright test --list` finds 104 tests, and the browser (1025) and node (5075) suites pass.